### PR TITLE
Skyler ic2 expansions

### DIFF
--- a/modules/aw9523b.py
+++ b/modules/aw9523b.py
@@ -1,0 +1,201 @@
+from machine import Pin
+
+class AW9523BPin:
+    """
+    AW9523B Pin Class
+    Should be mostly compatible with micropython's
+    machine.Pin class. 
+    Can be given to apps as a transparent interface
+    for a GPIO pin
+    """
+    def __init__(self, chip, id, *args, **kwargs):
+        self.chip = chip
+        self.pin = id
+        self.port = id[0]
+        self.pin = id[1]
+        self.init(*args, **kwargs)
+
+    def init(self, mode=-1, pull=-1, value=None, drive=0):
+        self.mode(mode)
+        self.pull(pull)
+        self.drive(drive)
+        self.value(value)
+
+    def value(self, *value):
+        if len(value) == 0:
+            return self.chip.pin_read(self.pin)
+        value = value[0]
+        self.chip.pin_write(self.pin, value)
+
+    def __call__(self, *args):
+        return self.value(*args)
+    
+    def on(self):
+        self.value(True)
+
+    def off(self):
+        self.value(False)
+
+    def irq(self, handler=None, trigger=Pin.IRQ_FALLING|Pin.IRQ_RISING):
+        if trigger is None or handler is None:
+            self.chip.set_irq_handler(self.pin, None, None)
+            self.chip.pin_set_irq_enabled(self.pin, False)
+            return
+        
+        def handler_wrapper(pinobj):
+            pinstate = pinobj.value()
+            if pinstate and (trigger&Pin.IRQ_RISING) or \
+                not pinstate and (trigger&Pin.IRQ_FALLING):
+                handler(pinobj)
+        self.chip.set_irq_handler(self.pin, handler_wrapper, self)
+        self.chip.pin_set_irq_enabled(self.pin, True)
+
+    def low(self):
+        self.value(False)
+
+    def high(self):
+        self.value(True)
+
+    def mode(self, *mode):
+        """
+        We use ALT mode to represent LED driving ability
+        of the AW9523B. This supports 255 levels of drive
+        strength
+        """
+        if len(mode) == 0:
+            mode = self.chip.pin_get_mode(self.pin)
+            if mode == 0:
+                return Pin.ALT
+            return Pin.IN if self.chip.pin_get_direction(self.pin) else Pin.OUT
+        mode = mode[0]
+        if mode == Pin.ALT:
+            self.chip.pin_set_mode(self.pin, 0)
+            return
+        if mode == Pin.IN or mode == Pin.OUT:
+            self.chip.pin_set_mode(self.pin, 1)
+        if mode == Pin.IN:
+            self.chip.pin_set_direction(self.pin, True)
+        elif mode == Pin.OUT:
+            self.chip.pin_set_direction(self.pin, False)
+            
+
+
+    def pull(self, *pull):
+        #does nothing currently
+        pass
+
+    def drive(self, *drive):
+        """
+        set the LED drive strength
+        Does nothing in regular Pin.OUT mode
+        """
+        if len(drive) == 0:
+            return self.chip.pin_get_drive(self.pin)
+        drive = drive[0]
+        self.chip.pin_set_drive(self.pin, drive)
+
+
+class AW9523B:
+    def __init__(self, bus, addr):
+        self.bus = bus
+        self.addr = addr
+
+        self.port_get_input_value = AW9523B.port_getter(0x00)
+        self.port_get_output_value = AW9523B.port_getter(0x02)
+        self.port_set_output_value = AW9523B.port_setter(0x02)
+        self.port_get_direction = AW9523B.port_getter(0x04)
+        self.port_set_direction = AW9523B.port_setter(0x04)
+        self.port_get_irq_enabled = AW9523B.port_getter(0x06)
+        self.port_set_irq_enabled = AW9523B.port_setter(0x06)
+        self.port_get_mode = AW9523B.port_getter(0x12)
+        self.port_set_mode = AW9523B.port_setter(0x12)
+
+        # self.pin_read = AW9523B.pin_getter(0x00)
+        self.pin_write = AW9523B.pin_setter(0x02)
+        self.pin_set_direction = AW9523B.pin_setter(0x04)
+        self.pin_get_irq_enabled = AW9523B.pin_getter(0x06)
+        self.pin_set_irq_enabled = AW9523B.pin_setter(0x06)
+        self.pin_get_mode = AW9523B.pin_getter(0x12)
+        self.pin_set_mode = AW9523B.pin_setter(0x12)
+
+        self.port_values = [0,0]
+        self.irq_handlers = [[None for _ in range(8)] for _ in range(2)]
+
+    def init(self):
+        #reset
+        self.bus.writeto_mem(self.addr, 0x7f, bytes([0x00]))
+        #disable interrupts
+        self.bus.writeto_mem(self.addr, 0x06, bytes([0xff, 0xff]))
+        #everything input
+        self.bus.writeto_mem(self.addr, 0x04, bytes([0xff, 0xff]))
+        #push-pull
+        self.bus.writeto_mem(self.addr, 0x11, bytes([0x10]))
+
+
+    def port_getter(cls, base):
+        def getter(self, port):
+            return int(self.bus.readfrom_mem(self.addr, base+port, 1)[0])
+        return getter
+
+    def port_setter(cls, base):
+        def setter(self, port, value):
+            return self.bus.writeto_mem(self.addr, base+port, bytes([value]))
+        return setter
+    
+    def pin_getter(cls, base):
+        port_getter = cls.port_getter(base)
+        def getter(self, pin):
+            return True if (port_getter(self, pin[0]) & (1<<pin[1])) else False
+        return getter
+    
+    def pin_setter(cls, base):
+        port_getter = cls.port_getter(base)
+        port_setter = cls.port_setter(base)
+        def setter(self, pin, value):
+            portvalue = port_getter(self, pin[0])
+            if value:
+                portvalue |= (1<<pin[1])
+            else:
+                portvalue &= 0xff^(1<<pin[1])
+            port_setter(self, pin[0], portvalue)
+        return setter
+            
+    def pin_read(self, pin):
+        value = self.port_get_input_value(pin[0])
+        self.port_values[pin[0]] = value
+    
+    def pinidx(_, pin):
+        if pin[0] == 0:
+            return 4+pin[1]
+        if pin[1] < 4:
+            return pin[1]
+        return 8+pin[1]
+        
+    def pin_set_drive(self, pin, drive):
+        self.bus.writeto_mem(self.addr, 0x20+AW9523B.pinidx(pin), bytes([drive]))
+
+    def pin_get_drive(self, pin):
+        return int(self.bus.readto_mem(self.addr, 0x20+AW9523B.pinidx(pin), 1)[0])
+
+    def check_irqs(self):
+        irqs_enabled = list(map(int,self.bus.readfrom_mem(self.addr, 0x06, 2)))
+        pin_values = list(map(int, self.bus.readfrom_mem(self.addr, 0x00, 2)))
+        pins_changed = list(map(lambda a,b,c: (a^b)&c, zip(pin_values, self.port_values, irqs_enabled)))
+        self.port_values = pin_values
+        if sum(pins_changed) == 0:
+            # quick out if nothing triggered
+            return
+        for port in range(2):
+            for pin in range(8):
+                if pins_changed[port]&(1<<pin) == 0:
+                    continue
+                handler = self.irq_handlers[port][pin]
+                if handler is None:
+                    continue
+                handler[0](handler[1])
+
+    def set_irq_handler(self, pin, handler, obj):
+        if handler:
+            self.irq_handlers[pin[0]][pin[1]] = (handler, obj)
+        else:
+            self.irq_handlers[pin[0]][pin[1]] = None

--- a/modules/tca9548a.py
+++ b/modules/tca9548a.py
@@ -1,0 +1,46 @@
+class TCA9548ABus:
+    def __init__(self, chip, bus_no):
+        self.chip = chip
+        self.bus_no = bus_no
+
+    def __getattr__(self, key):
+        chip = getattr(self, "chip")
+        bus_no = getattr(self, "bus_no")
+        try:
+            v = getattr(self, key)
+            return v
+        except:
+            v = getattr(chip.bus, key)
+            if callable(v):
+                def wrapper(*args, **kwargs):
+                    chip.select_downstream(bus_no)  
+                    return v(*args, **kwargs)
+                v = wrapper
+            setattr(self, key, v)
+            return v
+        
+class TCA9548A:
+
+    def __init__(self, bus, addr):
+        self.bus = bus
+        self.addr = addr
+        self.cur_i2c_bus = None
+        self.downstreams = [TCA9548ABus(self, i) for i in range(8)]
+        self.save = []
+
+    def select_downstream(self, bus) -> None:
+        if bus is not None and bus >= 0 and bus <=7 and self.cur_i2c_bus != bus:
+            self.system_i2c.writeto(self.addr,bytes([(0x1<<bus)]))
+            self.cur_i2c_bus=bus
+        elif self.cur_i2c_bus != None:
+            self.system_i2c.writeto(self.addr,bytes([0]))
+            self.cur_i2c_bus=bus
+
+    def save_downstream(self):
+        self.save.append(self.cur_i2c_bus)
+
+    def restore_downstream(self):
+        self.select_downstream(self.save.pop())
+
+    def get_downstream_bus(self, bus):
+        return self.downstreams[bus]

--- a/modules/tildagonos.py
+++ b/modules/tildagonos.py
@@ -1,6 +1,8 @@
 from machine import Pin, I2C, SPI
 import neopixel, time
 import gc9a01py as gc9a01
+from tca9548a import TCA9548A
+from aw9523b import AW9523B, AW9523BPin
 
 BUS_SYSTEM=7
 BUS_TOP=0
@@ -32,12 +34,20 @@ class tildagonos:
         self.pin_reset_i2c=Pin(9,Pin.OUT)
         self.pin_reset_i2c.on()
         self.system_i2c=I2C(0, scl=Pin(46), sda=Pin(45), freq=400000)
-        self.cur_i2c_bus=None
+        self.i2c_expansion=TCA9548A(self.system_i2c, 0x77)
         self.init_gpio()
         self.leds=neopixel.NeoPixel(Pin(21),19)
         self.gpiodata={}
         self.spi=None
         self.tft=None
+        self.pin_system_irq=Pin(10,Pin.IN)
+        self.pin_system_irq.irq(self.system_irq_handler, Pin.IRQ_RISING)
+
+        self.egpio_a = AW9523B(self.i2c_expansion.get_downstream_bus(BUS_SYSTEM), 0x58)
+        self.egpio_b = AW9523B(self.i2c_expansion.get_downstream_bus(BUS_SYSTEM), 0x59)
+        self.egpio_c = AW9523B(self.i2c_expansion.get_downstream_bus(BUS_SYSTEM), 0x5a)
+
+        self.LED_POWER = AW9523BPin(self.egpio_a, (0, 2), mode=Pin.ALT)
         
     def init_display(self):
         self.spi=SPI(1,40000000, sck=Pin(8), mosi=Pin(7))
@@ -45,52 +55,35 @@ class tildagonos:
         self.tft.fill(gc9a01.MAGENTA)
         
     def init_gpio(self):
-        prev_bus=self.cur_i2c_bus
-        self.sel_i2c_bus(BUS_SYSTEM)
-        #egpio reset
-        self.system_i2c.writeto_mem(0x58, 0x7f, bytes([0x00]))
-        self.system_i2c.writeto_mem(0x59, 0x7f, bytes([0x00]))
-        self.system_i2c.writeto_mem(0x5a, 0x7f, bytes([0x00]))
-        #chip A - disable interrupts 
-        self.system_i2c.writeto_mem(0x58, 0x06, bytes([0xff,0xff]))
-        #chip A - set everything to input
-        self.system_i2c.writeto_mem(0x58, 0x04, bytes([0xff,0xff]))
-        #chip A - switch mode to push-pull
-        self.system_i2c.writeto_mem(0x58, 0x11, bytes([0x10]))
-        
-        #chip B - disable interrupts
-        self.system_i2c.writeto_mem(0x59, 0x06, bytes([0xff,0xff]))
-        #chip B - set everything to input
-        self.system_i2c.writeto_mem(0x59, 0x04, bytes([0xff,0xff]))
-        #chip B - switch mode to push-pull
-        self.system_i2c.writeto_mem(0x59, 0x11, bytes([0x10]))
-        #chip C - disable interrupts
-        self.system_i2c.writeto_mem(0x5a, 0x06, bytes([0xff,0xff]))
+        self.i2c_expansion.save_downstream()
+        sys_i2c = self.i2c_expansion.get_downstream_bus(BUS_SYSTEM)
+        self.egpio_a.init()
+        self.egpio_b.init()
+        self.egpio_c.init()
+        #I'd like this to not be direct access but it works as is.
         #chip C - set P0 bits 0,1,3,6,7 and P1 bits 0,1,2,3,4,5,6,7 to input
-        self.system_i2c.writeto_mem(0x5a, 0x04, bytes([0xcb,0xff]))
+        sys_i2c.writeto_mem(0x5a, 0x04, bytes([0xcb,0xff]))
         #chip C - set P0_4(PMID_SW) to 0, set P0_5(USBSEL) to 0, set P0_2(led_power_en) to 0
-        self.system_i2c.writeto_mem(0x5a, 0x02, bytes([0x00]))
-        #chip C - switch mode to push-pull
-        self.system_i2c.writeto_mem(0x5a, 0x11, bytes([0x10]))
-        self.sel_i2c_bus(prev_bus)
+        sys_i2c.writeto_mem(0x5a, 0x02, bytes([0x00]))
+        self.i2c_expansion.restore_downstream()
         
     def set_egpio_pin(self, pin, state):
-        prev_bus=self.cur_i2c_bus
-        self.sel_i2c_bus(BUS_SYSTEM)
-        portstates=list(map(int,self.system_i2c.readfrom_mem(pin[0],0x02,2)))
-        if state:
-            self.system_i2c.writeto_mem(0x5a, 0x02+pin[1], bytes([portstates[pin[1]]|pin[2]]))
-        else:
-            self.system_i2c.writeto_mem(0x5a, 0x02+pin[1], bytes([portstates[pin[1]]&(pin[2]^0xff)]))
-        self.sel_i2c_bus(prev_bus)
+        self.i2c_expansion.save_downstream()
+        egpios = [self.egpio_a, self.egpio_b, self.egpio_c]
+        egpio = egpios[pin[0]-0x59]
+        pinidx = 0
+        v = pin[2]
+        while (v := v//2):
+            pinidx += 1
+        egpio.pin_write((pin[1], pinidx), state)
+        self.i2c_expansion.restore_downstream()
         
     def read_egpios(self):
-        prev_bus=self.cur_i2c_bus
-        self.sel_i2c_bus(BUS_SYSTEM)
-        for i in [0x58, 0x59, 0x5a]:
-            portstates=list(map(int,self.system_i2c.readfrom_mem(i,0x00,2)))
-            self.gpiodata[i]=tuple(portstates)
-        self.sel_i2c_bus(prev_bus)
+        self.i2c_expansion.save_downstream()
+        for eg in [self.egpio_a, self.egpio_b, self.egpio_c]:
+            portstates=list(map(int,eg.bus.readfrom_mem(eg.addr,0x00,2)))
+            self.gpiodata[eg.addr]=tuple(portstates)
+        self.i2c_expansion.restore_downstream()
         
     def check_egpio_state(self, pin, readgpios=True):
         if not pin[0] in self.gpiodata or readgpios:
@@ -98,7 +91,9 @@ class tildagonos:
         return bool(pin[2]&self.gpiodata[pin[0]][pin[1]])
     
     def set_led_power(self, state):
-        self.set_egpio_pin(EPIN_LED_POWER, state)
+        self.i2c_expansion.save_downstream()
+        self.LED_POWER.value(state)
+        self.i2c_expansion.restore_downstream()
         
     def indicate_hexpansion_insertion(self):
         self.set_led_power(True)
@@ -119,6 +114,10 @@ class tildagonos:
             time.sleep(0.1)
             
     def sel_i2c_bus(self, bus=None):
+        """
+        TO BE DEPRACATED
+        use the TCA9548 bus wrappper instead!
+        """
         if bus is not None and bus >= 0 and bus <=7:
             self.system_i2c.writeto(0x77,bytes([(0x1<<bus)]))
             self.cur_i2c_bus=bus

--- a/modules/tildagonos.py
+++ b/modules/tildagonos.py
@@ -29,7 +29,7 @@ led_colours=[
 ]
 
 class tildagonos:
-    
+    instance = None
     def __init__(self):
         self.pin_reset_i2c=Pin(9,Pin.OUT)
         self.pin_reset_i2c.on()
@@ -48,6 +48,8 @@ class tildagonos:
         self.egpio_c = AW9523B(self.i2c_expansion.get_downstream_bus(BUS_SYSTEM), 0x5a)
 
         self.LED_POWER = AW9523BPin(self.egpio_a, (0, 2), mode=Pin.ALT)
+
+        tildagonos.instance = self
         
     def init_display(self):
         self.spi=SPI(1,40000000, sck=Pin(8), mosi=Pin(7))
@@ -124,3 +126,10 @@ class tildagonos:
         else:
             self.system_i2c.writeto(0x77,bytes([0]))
             self.cur_i2c_bus=None
+
+    @staticmethod()
+    def system_irq_handler(pin):
+        # Add some interrupt handling code here?
+        # probably good to micropython.schedule deferred stuff
+        # that's not as urgent
+        pass


### PR DESCRIPTION
Rebased this onto the new toolchain branch. 

Adds new python drivers for the I2C MUX and GPIO expander with APIs as close to machine.I2C/machine.Pin as is reasonable.

Please note while I've tested this on the linux micropython port I'm not able to completely confirm the machine interfaces and drivers are completely functional as it's not been tested on hardware. Anyone who is able to test - would be very appreciated if you could give it a try!