### PR TITLE
I2C MUX: Initial C implementation/api

### DIFF
--- a/drivers/micropython.cmake
+++ b/drivers/micropython.cmake
@@ -2,3 +2,12 @@
 
 # Add the HID interface
 include(${CMAKE_CURRENT_LIST_DIR}/tildagon_usb/tildagon_usb.cmake)
+
+# Add TCA9548A I2C MUX
+add_library(tildagon INTERFACE)
+target_sources(tildagon INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/tildagon.c
+  ${CMAKE_CURRENT_LIST_DIR}/tca9548a.c
+)
+
+target_link_libraries(usermod INTERFACE tildagon)

--- a/drivers/tca9548a.c
+++ b/drivers/tca9548a.c
@@ -1,0 +1,29 @@
+
+#include "driver/i2c.h"
+#include "hal/i2c_ll.h"
+#include "tca9548a.h"
+
+
+void tca9548a_cmd_set_downstream(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port, i2c_cmd_handle_t cmd) {
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, self->addr << 1, true);
+    i2c_master_write_byte(cmd, (1<<port), true);
+}
+
+i2c_cmd_handle_t tca9548a_cmd_link_create(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port) {
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    tca9548a_cmd_set_downstream(self, port, cmd);
+    return cmd;
+}
+
+esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, i2c_cmd_handle_t cmd, TickType_t ticks_to_wait) {
+    TimeOut_t timeout;
+    vTaskSetTimeOutState(&timeout);
+    if (pdTRUE != xSemaphoreTake(self->mtx, ticks_to_wait) 
+        || pdFALSE != xTaskCheckForTimeOut(&timeout, &ticks_to_wait)) {
+      return ESP_ERR_TIMEOUT;
+    }
+    esp_err_t ret = i2c_master_cmd_begin(self->port, cmd, ticks_to_wait);
+    xSemaphoreGive(self->mtx);
+    return ret;
+}

--- a/drivers/tca9548a.h
+++ b/drivers/tca9548a.h
@@ -1,0 +1,43 @@
+#ifndef _TCA9548A_H
+#define _TCA9548A_H
+
+#include "driver/i2c.h"
+#include "hal/i2c_ll.h"
+
+#include "freertos/semphr.h"
+
+typedef struct _tca9548a_i2c_mux {
+  i2c_port_t port : 8;
+  uint16_t addr;
+  SemaphoreHandle_t mtx;
+} tca9548a_i2c_mux_t;
+
+typedef unsigned char tca9548a_i2c_port_t;
+
+
+/**
+ * tca9548a_cmd_link_create
+ * 
+ * Similar to i2c_cmd_link_create - creates an i2c_cmd_handle_t
+ * and additionally adds a command to set the downstream port.
+ * This function is thread-safe and can be called from any thread.
+ * Be aware that a longer timeout may be needed if the bus is busy!
+ *
+ * @param self - mux object to create the link for
+ * @param port - downstream port number to use
+*/
+i2c_cmd_handle_t tca9548a_cmd_link_create(const tca9548a_i2c_mux_t *self, tca9548a_i2c_port_t port);
+
+/**
+ * tca9548a_master_cmd_begin
+ *
+ * similar to i2c_master_cmd_begin - begins a sequence of I2C transactions
+ * on the bus upstream of the i2c mux.
+ * 
+ * @param self - mux object to begin the i2c transactions for
+ * @param cmd - command link to send
+ * @param ticks_to_wait - maximum timeout
+*/
+esp_err_t tca9548a_master_cmd_begin(const tca9548a_i2c_mux_t *self, i2c_cmd_handle_t cmd, TickType_t ticks_to_wait);
+
+#endif // _TCA9548A_H

--- a/drivers/tildagon.c
+++ b/drivers/tildagon.c
@@ -1,0 +1,15 @@
+#include "tildagon.h"
+
+static tca9548a_i2c_mux_t tildagon_i2c_mux;
+
+const tca9548a_i2c_mux_t *tildagon_get_i2c_mux() {
+  if(tildagon_i2c_mux.addr == 0) {
+    tildagon_i2c_mux.mtx = xSemaphoreCreateBinary();
+    if (tildagon_i2c_mux.mtx == NULL) {
+      return NULL;
+    }
+    xSemaphoreGive(&tildagon_i2c_mux.mtx);
+    tildagon_i2c_mux.addr = 0x77;
+  }
+  return &tildagon_i2c_mux;
+}

--- a/drivers/tildagon.h
+++ b/drivers/tildagon.h
@@ -1,0 +1,9 @@
+#ifndef _TILDAGON_H
+#define _TILDAGON_H
+
+#include "tca9548a.h"
+
+const tca9548a_i2c_mux_t *tildagon_get_i2c_mux();
+
+
+#endif // _TILDAGON_H


### PR DESCRIPTION
Added a simple C interface for the TCA9548A I2C MUX. Currently based on
the ESP-IDF i2c command link api. Creating a new link for a MUX port will
set the mux downstream port appropriately.
TODO: Add the micropython implementation