### PR TITLE
Add menu item change handler

### DIFF
--- a/modules/app_components/menu.py
+++ b/modules/app_components/menu.py
@@ -18,6 +18,7 @@ class Menu:
         menu_items: list[str] = [],
         position=0,
         select_handler: Union[Callable[[str], Any], None] = None,
+        change_handler: Union[Callable[[str], Any], None] = None,
         back_handler: Union[Callable, None] = None,
         speed_ms=300,
         item_font_size=label_font_size,
@@ -29,6 +30,7 @@ class Menu:
         self.menu_items = menu_items
         self.position = position
         self.select_handler = select_handler
+        self.change_handler = change_handler
         self.back_handler = back_handler
         self.speed_ms = speed_ms
         self.item_font_size = item_font_size
@@ -48,8 +50,16 @@ class Menu:
     def _handle_buttondown(self, event: ButtonDownEvent):
         if BUTTON_TYPES["UP"] in event.button:
             self.up_handler()
+            if self.change_handler is not None:
+                self.change_handler(
+                    self.menu_items[self.position % len(self.menu_items)]
+                )
         if BUTTON_TYPES["DOWN"] in event.button:
             self.down_handler()
+            if self.change_handler is not None:
+                self.change_handler(
+                    self.menu_items[self.position % len(self.menu_items)]
+                )
         if BUTTON_TYPES["CANCEL"] in event.button:
             if self.back_handler is not None:
                 self.back_handler()


### PR DESCRIPTION
Allows code to be executed when the menu item is being changed.

My use case is to preview LED effects without having to press the confirm button and show a nice preview of the colour palette on the menu.

![VirtualBoxVM_2024-05-22_06-06-50](https://github.com/emfcamp/badge-2024-software/assets/4094413/83895019-bd48-447e-898c-eedbfad3a58b)
