### PR TITLE
Add ujson fake

### DIFF
--- a/sim/fakes/ujson.py
+++ b/sim/fakes/ujson.py
@@ -1,0 +1,1 @@
+from json import *


### PR DESCRIPTION
This adds in a very simple mock for `ujson` which I think is a built-in MicroPython library for which mocks are missing.
