### PR TITLE
Launcher: fix /apps not being included in module path.

### DIFF
--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -66,7 +66,7 @@ class Launcher(App):
                 if not path_isfile(f"{app_dir}/{name}/__init__.py"):
                     continue
                 app = {
-                    "path": name,
+                    "path": "apps."+name,
                     "callable": "main",
                     "name": name,
                     "icon": None,


### PR DESCRIPTION
Launcher raises exception when trying to launch apps in `/apps`. It can find and display them just fine though.