### PR TITLE
App launcher: clean up menu on reload

### DIFF
--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -159,6 +159,7 @@ class Launcher(App):
                 break
 
     def back_handler(self):
+        self.menu._cleanup()
         self.update_menu()
         return
         # if self.current_menu == "main":


### PR DESCRIPTION
Reloading the menu set a new menu, but the old one still exists and was also reacting to button presses, leading to chaos when multiple instances tried launching apps.