### PR TITLE
Add 0xA0 to EEPROM address detection for M24C16-R

### DIFF
--- a/modules/system/hexpansion/util.py
+++ b/modules/system/hexpansion/util.py
@@ -10,6 +10,8 @@ def detect_eeprom_addr(i2c):
     devices = i2c.scan()
     if 0x57 in devices and 0x50 not in devices:
         return 0x57
+    if 0xA0 in devices and 0x50 not in devices:
+        return 0xA0
     if 0x50 in devices:
         return 0x50
     return None


### PR DESCRIPTION
The docs list M24C16-RMN6TP as a supported EEPROM for hexpansions, but the M24C16-R series uses addresses 0xA0 to 0xA8 for its page addressing. The code currently only supports 0x50 and 0x57 for addresses, as discussed in #75. This PR adds support for 0xA0 as a base address.

Note: **THIS HAS NOT BEEN TESTED.** I don't currently have time to spin up an environment for badge firmware development. I'm providing this in the hopes of speeding up an OTA rollout so we can get the nullsector hexpansions programmed and running, since we used those EEPROMs. Given that the addressing is wrong, it is unclear if the M24C16-R series has other behaviours that have not been tested with the badge. If you need me to provide one of our hexpansions for testing you can reach me via DECT on 6464 and I can deliver one.