### PR TITLE
Add documentation instructions to badge flasher page

### DIFF
--- a/flasher/index.html
+++ b/flasher/index.html
@@ -10,7 +10,11 @@
   <body>
     <div class="content">
       <h1>Provision a Tildagon</h1>
-      
+      <li>1. Hold <b>boop</b> while plugging USB into <b>USB in</b>.</li>
+      <li>2. Keep holding <b>boop</b> until you click <b>Connect</b> and click on the badge COM port.</li>
+      <li>3. Let go of the <b>boop</b></li>
+      <li>4. Select <b>Install Tildagon</b>, and wait.</li>
+      <br>
       <esp-web-install-button
         manifest="manifest.json"></esp-web-install-button>
       


### PR DESCRIPTION
<li>1. Hold <b>boop</b> while plugging USB into <b>USB in</b>.</li>
<li>2. Keep holding <b>boop</b> until you click <b>Connect</b> and click on the badge COM port.</li>
<li>3. Let go of the <b>boop</b></li>
<li>4. Select <b>Install Tildagon</b>, and wait.</li>