### PR TITLE
Update README.md docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Before you build the first time, apply any patches to vendored content:
 
 Then to build the images run:
 
-    docker run -it --env "TARGET=esp32s3" -v "$(pwd)"/:/firmware matthewwilkes/esp_idf:5.2.1
+    docker run -it --rm --env "TARGET=esp32s3" -v "$(pwd)"/:/firmware matthewwilkes/esp_idf:5.2.1
 
 Alternatively, to flash a badge:
     put the badge into bootloader by disconnecting the usb in, press and hold bat and boop buttons for 20 seconds  then reconnect the usb in and run:
 
-    docker run -it --device /dev/ttyACM0:/dev/ttyUSB0 --env "TARGET=esp32s3" -v "$(pwd)"/:/firmware matthewwilkes/esp_idf:5.2.1 deploy
+    docker run -it --rm --device /dev/ttyACM0:/dev/ttyUSB0 --env "TARGET=esp32s3" -v "$(pwd)"/:/firmware matthewwilkes/esp_idf:5.2.1 deploy
 
 where /dev/ttyACM0 is the device's endpoint. This value is correct on Linux.
 


### PR DESCRIPTION
Add `--rm` to the docker commandline to not leave old unused containers around. All the state is in the mapped folders, so they only waste disk space (and caused some weird btrfs issues on my system)