### PR TITLE
Fix typographical error in "Rebooping" message

### DIFF
--- a/modules/system/ota/ota.py
+++ b/modules/system/ota/ota.py
@@ -161,7 +161,7 @@ class OtaUpdate(App):
             # window.println("Press [A] to")
             # window.println("reboot and")
             # window.println("finish update.")
-            self.status.value = "Rebooting"
+            self.status.value = "Rebooping"
             await render_update()
             await asyncio.sleep(5)
             machine.reset()


### PR DESCRIPTION
Rebooting? Is that even a word?

Fixed the status message output to correctly say "Rebooping"