### PR TITLE
Add step counter to IMU API

### DIFF
--- a/components/flow3r_bsp/flow3r_bsp_imu.h
+++ b/components/flow3r_bsp/flow3r_bsp_imu.h
@@ -60,3 +60,10 @@ esp_err_t flow3r_bsp_imu_read_gyro(flow3r_bsp_imu_t *imu, int *x, int *y,
 // Return values in deg/s.
 esp_err_t flow3r_bsp_imu_read_gyro_dps(flow3r_bsp_imu_t *imu, float *x,
                                        float *y, float *z);
+
+// Get step count.
+//
+// Returns ESP_ERR_NOT_FOUND if there is no new reading available.
+// Returns ESP_FAIL if the sensor could not be read (e.g. I2C unavailable).
+// Retrurns the number of steps counted.
+esp_err_t flow3r_bsp_imu_read_steps(flow3r_bsp_imu_t *imu, uint32_t *steps);

--- a/components/st3m/st3m_imu.h
+++ b/components/st3m/st3m_imu.h
@@ -10,3 +10,4 @@ void st3m_imu_init(void);
 void st3m_imu_read_acc_mps(float *x, float *y, float *z);
 void st3m_imu_read_gyro_dps(float *x, float *y, float *z);
 void st3m_imu_read_pressure(float *pressure, float *temperature);
+void st3m_imu_read_steps(uint32_t *steps);

--- a/drivers/tildagon_helpers/mp_imu.c
+++ b/drivers/tildagon_helpers/mp_imu.c
@@ -29,9 +29,20 @@ static mp_obj_t mp_imu_gyro_read(void) {
 
 static MP_DEFINE_CONST_FUN_OBJ_0(mp_imu_gyro_read_obj, mp_imu_gyro_read);
 
+static mp_obj_t mp_imu_step_counter_read(void) {
+    static uint32_t steps;
+
+    st3m_imu_read_steps(&steps);
+
+    return mp_obj_new_int_from_uint(steps);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_0(mp_imu_step_counter_read_obj, mp_imu_step_counter_read);
+
 static const mp_rom_map_elem_t globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_acc_read), MP_ROM_PTR(&mp_imu_acc_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_gyro_read), MP_ROM_PTR(&mp_imu_gyro_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_step_counter_read), MP_ROM_PTR(&mp_imu_step_counter_read_obj) },
 };
 
 static MP_DEFINE_CONST_DICT(globals, globals_table);


### PR DESCRIPTION
Enables the step counter in the BMI270, exposing a `step_counter_read` method as part of the IMU API.

Example usage:
```python
import app
import imu

from events.input import Buttons, BUTTON_TYPES


class ExampleApp(app.App):
    def __init__(self):
        self.button_states = Buttons(self)
        self.acc_read = None
        self.steps_read = None

    def update(self, delta):
        if self.button_states.get(BUTTON_TYPES["CANCEL"]):
            self.button_states.clear()
            self.minimise()
        else:
            self.steps_read = imu.step_counter_read()

    def draw(self, ctx):
        ctx.save()
        ctx.rgb(0.2,0,0).rectangle(-120,-120,240,240).fill()
        if self.steps_read:
            ctx.rgb(1,0,0).move_to(-80,-40).text("steps:\n{}\n".format(self.steps_read))
        else:
            ctx.rgb(1,0,0).move_to(-80,0).text("no readings yet")
        ctx.restore()

__app_export__ = ExampleApp
```