### PR TITLE
Improve bootloader activation instructions

### DIFF
--- a/flasher/index.html
+++ b/flasher/index.html
@@ -10,8 +10,9 @@
   <body>
     <div class="content">
       <h1>Provision a Tildagon</h1>
+      <li>1. Power off the badge from the menu, if it's already powered on.</li>
       <li>1. Hold <b>boop</b> while plugging USB into <b>USB in</b>.</li>
-      <li>2. Keep holding <b>boop</b> until you click <b>Connect</b> and click on the badge COM port.</li>
+      <li>2. Keep holding <b>boop</b> until you click <b>Connect</b> and click on the badge COM port. The device name should appears as <code>USB JTAG/serial debug unit</code></li>
       <li>3. Let go of the <b>boop</b></li>
       <li>4. Select <b>Install Tildagon</b>, and wait.</li>
       <br>

--- a/flasher/index.html
+++ b/flasher/index.html
@@ -11,10 +11,10 @@
     <div class="content">
       <h1>Provision a Tildagon</h1>
       <li>1. Power off the badge from the menu, if it's already powered on.</li>
-      <li>1. Hold <b>boop</b> while plugging USB into <b>USB in</b>.</li>
-      <li>2. Keep holding <b>boop</b> until you click <b>Connect</b> and click on the badge COM port. The device name should appears as <code>USB JTAG/serial debug unit</code></li>
-      <li>3. Let go of the <b>boop</b></li>
-      <li>4. Select <b>Install Tildagon</b>, and wait.</li>
+      <li>2. Hold <b>boop</b> while plugging USB into <b>USB in</b>.</li>
+      <li>3. Keep holding <b>boop</b> until you click <b>Connect</b> and click on the badge COM port. The device name should appears as <code>USB JTAG/serial debug unit</code></li>
+      <li>4. Let go of the <b>boop</b></li>
+      <li>5. Select <b>Install Tildagon</b>, and wait.</li>
       <br>
       <esp-web-install-button
         manifest="manifest.json"></esp-web-install-button>


### PR DESCRIPTION
Bootloader doesn't work if the device is already powered on when plugging in USB
