### PR TITLE
Improved keyboard

### DIFF
--- a/modules/app_components/dialog.py
+++ b/modules/app_components/dialog.py
@@ -4,7 +4,7 @@ import display
 from events.input import BUTTON_TYPES, ButtonDownEvent
 from system.eventbus import eventbus
 
-from .tokens import label_font_size, set_color, small_font_size
+from .tokens import label_font_size, set_color, small_font_size, button_labels
 
 SPECIAL_KEY_META = "..."
 SPECIAL_KEY_DONE = "Done"
@@ -66,6 +66,7 @@ class YesNoDialog:
         display.hexagon(ctx, 0, 0, 120)
 
         self.draw_message(ctx)
+        button_labels(ctx, confirm_label="Yes", cancel_label="No")
         ctx.restore()
 
     def _handle_buttondown(self, event: ButtonDownEvent):
@@ -157,25 +158,6 @@ class TextDialog:
         ctx.move_to(0, -15).text(self.message)
         ctx.move_to(0, 15).text(self.text if not self.masked else ("*" * len(self.text)))
 
-    def draw_legend(self, ctx):
-        if len(self._keys) != 6:
-            return
-
-        set_color(ctx, "label")
-
-        ctx.font_size = small_font_size
-        ctx.text_align = ctx.CENTER
-        ctx.text_baseline = ctx.MIDDLE
-        ctx.move_to(0, -100).text(''.join(self._keys[0]))
-        ctx.move_to(0, 100).text(''.join(self._keys[3]))
-
-        ctx.text_align = ctx.RIGHT
-        ctx.move_to(75, -75).text(''.join(self._keys[1]))
-        ctx.move_to(75, 75).text(''.join(self._keys[2]))
-
-        ctx.text_align = ctx.LEFT
-        ctx.move_to(-75, -75).text(''.join(self._keys[5]))
-        ctx.move_to(-75, 75).text(''.join(self._keys[4]))
 
     def draw(self, ctx):
         ctx.save()
@@ -183,7 +165,15 @@ class TextDialog:
         display.hexagon(ctx, 0, 0, 120)
 
         self.draw_message(ctx)
-        self.draw_legend(ctx)
+        if len(self._keys) == 6:
+            button_labels(ctx,
+                          up_label=''.join(self._keys[0]),
+                          down_label=''.join(self._keys[3]),
+                          left_label=''.join(self._keys[4]),
+                          right_label=''.join(self._keys[1]),
+                          confirm_label=''.join(self._keys[2]),
+                          cancel_label=''.join(self._keys[5]))
+
         ctx.restore()
 
     def _handle_buttondown(self, event: ButtonDownEvent):

--- a/modules/app_components/dialog.py
+++ b/modules/app_components/dialog.py
@@ -4,7 +4,7 @@ import display
 from events.input import BUTTON_TYPES, ButtonDownEvent
 from system.eventbus import eventbus
 
-from .tokens import label_font_size, set_color, small_font_size, button_labels
+from .tokens import button_labels, label_font_size, set_color
 
 SPECIAL_KEY_META = "..."
 SPECIAL_KEY_DONE = "Done"
@@ -100,7 +100,6 @@ class TextDialog:
         eventbus.on(ButtonDownEvent, self._handle_buttondown, self.app)
         self._update_keys()
 
-
     def _update_keys(self):
         if self._layer == -1:
             self._keys = [
@@ -156,8 +155,9 @@ class TextDialog:
         set_color(ctx, "label")
 
         ctx.move_to(0, -15).text(self.message)
-        ctx.move_to(0, 15).text(self.text if not self.masked else ("*" * len(self.text)))
-
+        ctx.move_to(0, 15).text(
+            self.text if not self.masked else ("*" * len(self.text))
+        )
 
     def draw(self, ctx):
         ctx.save()
@@ -166,13 +166,15 @@ class TextDialog:
 
         self.draw_message(ctx)
         if len(self._keys) == 6:
-            button_labels(ctx,
-                          up_label=''.join(self._keys[0]),
-                          down_label=''.join(self._keys[3]),
-                          left_label=''.join(self._keys[4]),
-                          right_label=''.join(self._keys[1]),
-                          confirm_label=''.join(self._keys[2]),
-                          cancel_label=''.join(self._keys[5]))
+            button_labels(
+                ctx,
+                up_label="".join(self._keys[0]),
+                down_label="".join(self._keys[3]),
+                left_label="".join(self._keys[4]),
+                right_label="".join(self._keys[1]),
+                confirm_label="".join(self._keys[2]),
+                cancel_label="".join(self._keys[5]),
+            )
 
         ctx.restore()
 

--- a/modules/app_components/tokens.py
+++ b/modules/app_components/tokens.py
@@ -8,12 +8,14 @@ ppi = display_x / display_height_inches
 
 # Font size
 one_pt = ppi / 72
+seven_pt = 7 * one_pt
 ten_pt = 10 * one_pt
 twelve_pt = 12 * one_pt
 fourteen_pt = 14 * one_pt
 sixteen_pt = 16 * one_pt
 eighteen_pt = 18 * one_pt
 twentyfour_pt = 24 * one_pt
+small_font_size = seven_pt
 label_font_size = ten_pt
 heading_font_size = eighteen_pt
 

--- a/modules/app_components/tokens.py
+++ b/modules/app_components/tokens.py
@@ -54,3 +54,27 @@ def clear_background(ctx):
 
 def set_color(ctx, color):
     ctx.rgb(*ui_colors.get(color, colors.get(color, color)))
+
+
+def button_labels(ctx, up_label=None, down_label=None, left_label=None, right_label=None, cancel_label=None, confirm_label=None):
+    set_color(ctx, "label")
+
+    ctx.font_size = small_font_size
+    ctx.text_align = ctx.CENTER
+    ctx.text_baseline = ctx.MIDDLE
+    if up_label is not None:
+        ctx.move_to(0, -100).text(up_label)
+    if down_label is not None:
+        ctx.move_to(0, 100).text(down_label)
+
+    ctx.text_align = ctx.RIGHT
+    if right_label is not None:
+        ctx.move_to(75, -75).text(right_label)
+    if confirm_label is not None:
+        ctx.move_to(75, 75).text(confirm_label)
+
+    ctx.text_align = ctx.LEFT
+    if cancel_label is not None:
+        ctx.move_to(-75, -75).text(cancel_label)
+    if left_label is not None:
+        ctx.move_to(-75, 75).text(left_label)

--- a/modules/app_components/tokens.py
+++ b/modules/app_components/tokens.py
@@ -56,7 +56,15 @@ def set_color(ctx, color):
     ctx.rgb(*ui_colors.get(color, colors.get(color, color)))
 
 
-def button_labels(ctx, up_label=None, down_label=None, left_label=None, right_label=None, cancel_label=None, confirm_label=None):
+def button_labels(
+    ctx,
+    up_label=None,
+    down_label=None,
+    left_label=None,
+    right_label=None,
+    cancel_label=None,
+    confirm_label=None,
+):
     set_color(ctx, "label")
 
     ctx.font_size = small_font_size


### PR DESCRIPTION
When I got home and had to type in my WiFi credentials using the old keyboard, it took me so long I decided to crack out my laptop and run code to do it instead. This PR is a bit of an attempt to improve the speed of typing text in on the keyboard.

Each button on the badge corresponds to a group of letters, so the up button does letters **a** to **f**, once you press that, the buttons are reassigned letters through that range, so the up button now becomes **a**. The numbers are part of the uppercase letters (accessed with shift or caps) to keep the keyboard simpler. There's a 'meta' menu with backspace, shift, caps lock, symbols and cancel.

![Screen recording of the improved keyboard](https://github.com/emfcamp/badge-2024-software/assets/10981005/919da9d7-a647-4d20-b1f5-9a085a112373)

The keyboard is compatible with how the old one is used, so no other code needs to be changed.

As I wrote a function to label the buttons, I added yes/no labels to the `YesNoDialog` in the same way.