### PR TITLE
Change default pin value for simulator

### DIFF
--- a/sim/fakes/machine.py
+++ b/sim/fakes/machine.py
@@ -10,7 +10,7 @@ class Pin:
         pass
 
     def value(self):
-        return 0
+        return 1
 
     def on(self):
         pass


### PR DESCRIPTION
Attempting to fix #116 . I don't know if this has any other consequences tbh but the hexpansion code relies on Pin 0 returning true. See https://github.com/emfcamp/badge-2024-software/blob/main/modules/frontboards/twentyfour.py#L39