### PR TITLE
Improved hexpansion helper scripts

### DIFF
--- a/modules/scripts/mount_hexpansions.py
+++ b/modules/scripts/mount_hexpansions.py
@@ -1,17 +1,25 @@
 from machine import I2C
-from system.hexpansion.util import read_hexpansion_header, get_hexpansion_block_devices
+from system.hexpansion.util import read_hexpansion_header, get_hexpansion_block_devices, detect_eeprom_addr
 import vfs
 
 for port in range(1, 7):
     print(f"Attempting to mount hexpansion in port: {port}")
     i2c = I2C(port)
+    addr = detect_eeprom_addr(i2c)
 
-    header = read_hexpansion_header(i2c)
+    if addr is None:
+        continue
+    else:
+        print("Found EEPROM at addr " + hex(addr))
+
+    header = read_hexpansion_header(i2c, addr)
     if header is None:
         continue
+    else:
+        print("Read header: " + str(header))
 
     try:
-        eep, partition = get_hexpansion_block_devices(i2c, header)
+        eep, partition = get_hexpansion_block_devices(i2c, header, addr)
     except Exception as e:
         print(f"Failed to get block devices for hexpansion {port}: {e}")
         continue

--- a/modules/scripts/prepare_eeprom.py
+++ b/modules/scripts/prepare_eeprom.py
@@ -29,6 +29,7 @@ header = HexpansionHeader(
     friendly_name="Flopagon",
 )
 
+
 # Determine amount of bytes in internal address
 addr_len = 2 if header.eeprom_total_size > 256 else 1
 print(f"Using {addr_len} bytes for eeprom internal address")

--- a/modules/system/hexpansion/util.py
+++ b/modules/system/hexpansion/util.py
@@ -60,6 +60,7 @@ def get_hexpansion_block_devices(i2c, header, addr=0x50):
         chip_size=header.eeprom_total_size,
         page_size=header.eeprom_page_size,
         addr=addr,
+        max_chips_count = 1
     )
     partition = EEPROMPartition(
         eep=eep,


### PR DESCRIPTION
Changes to hexpansion helper scripts to work with EEPROMs that have the address 0x57 as well as 0x50 (previously 0x50 was hard coded). This now works with the Zetta ZD24C64A-XGMT EEPROM.

Change to `get_hexpansion_block_devices` to only look for one EEPROM on the bus, which I think fixes issue #81 where the script would throw an error when another I2C device was on the bus with a non-sequential address to the EEPROM.