### PR TITLE
Fix hexpansions not being consistently detected on hotplug

### DIFF
--- a/modules/tildagonos.py
+++ b/modules/tildagonos.py
@@ -77,8 +77,10 @@ class _tildagonos:
 
     def read_egpios(self):
         for i in [0x58, 0x59, 0x5A]:
-            portstates = list(map(int, self.system_i2c.readfrom_mem(i, 0x00, 2)))
-            self.gpiodata[i] = tuple(portstates)
+            self.gpiodata[i] = (
+                self.system_i2c.readfrom_mem(i, 0, 1)[0],
+                self.system_i2c.readfrom_mem(i, 1, 1)[0],
+            )
 
     def check_egpio_state(self, pin, readgpios=True):
         if pin[0] not in self.gpiodata or readgpios:


### PR DESCRIPTION
For mysterious reasons the GPIO expanders seem to not always update the state of port 1 when doing a multi-byte read. If we instead do two single-byte reads, we appear to get the correct state 100% of the time.

The datasheet has some confusing lines about how you always need to send a write command before reading the port states - I believe `readfrom_mem` actually does this, but since it's not actually sending any data for the write, it's only technically writing to address 0, which only updates port 0 (hence why buttons work consistently - they're all port 0!)