### PR TITLE
Update GH Action runner to resolve deprecations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           cd ../../..
           echo "{\"build\":\"$(git describe --tags --always)\", \"name\":\"$(git describe --tags --always)\"}" > micropython/ports/esp32/build-tildagon/tildagon.txt
       - name: Archive firmware
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: firmware
           path: |


### PR DESCRIPTION
Fixes #128 
Tested in a fork, but YMMV (see https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md for potential pitfalls I may have missed here, but I think this is as straightforward as it seems)