### PR TITLE
Fix TextDisplay, ButtonDisplay, DefinitionDisplay

### DIFF
--- a/modules/app_components/layout.py
+++ b/modules/app_components/layout.py
@@ -29,14 +29,16 @@ class TextDisplay(Layoutable):
 
     def draw(self, ctx, focused=False):
         ctx.save()
+        ctx.translate(-100,-40)
         if self.lines is None:
-            self.lines = utils.wrap_text(ctx, self.text)
-            self.height = len(self.lines) * ctx.font_size
+            self.lines = utils.wrap_text(ctx, self.text, self.font_size)
+            self.height = len(self.lines) * self.font_size
         ctx.text_align = ctx.LEFT
+        ctx.font_size = self.font_size
         if self.rgb:
             ctx.rgb(*self.rgb)
         for i, line in enumerate(self.lines):
-            ctx.move_to(0, i * ctx.font_size)
+            ctx.move_to(0, i * self.font_size)
             ctx.text(line)
         ctx.restore()
 
@@ -101,7 +103,7 @@ class DefinitionDisplay(Layoutable):
             ctx.rgb(*tokens.colors["yellow"])
 
         # Draw label
-        label_lines = utils.wrap_text(ctx, self.label)
+        label_lines = utils.wrap_text(ctx, self.label, tokens.label_font_size)
         for line in label_lines:
             ctx.move_to(0, self.height)
             ctx.text(line)
@@ -111,7 +113,7 @@ class DefinitionDisplay(Layoutable):
 
         # Draw value
         ctx.font_size = tokens.ten_pt
-        value_lines = utils.wrap_text(ctx, self.value, width=230)
+        value_lines = utils.wrap_text(ctx, self.value, 230, tokens.label_font_size)
         for line in value_lines:
             ctx.move_to(10, self.height)
             ctx.text(line)
@@ -202,5 +204,5 @@ def scroll():
         display.end_frame(ctx)
         time.sleep_ms(100)
         layout.y_offset -= 10
-        
+
 """

--- a/modules/app_components/layout.py
+++ b/modules/app_components/layout.py
@@ -86,22 +86,28 @@ class ButtonDisplay(Layoutable):
                 self.button_handler(event)
 
 class DefinitionDisplay(Layoutable):
-    def __init__(self, label, value, button_handler=None):
+    def __init__(self, label, value, height=None, button_handler=None):
         self.label = label
         self.value = value
-        self.height = 0
+        if not height:
+            self.height = 0
+        else:
+            self.height = height
         self.button_handler = button_handler
 
-    async def button_event(self, event):
+        eventbus.on(ButtonDownEvent, self._handle_buttondown, self.app)
+
+    def _cleanup(self):
+        eventbus.remove(ButtonDownEvent, self._handle_buttondown, self.app)
+
+    def _handle_buttondown(self, event):
         if self.button_handler:
-            return await self.button_handler(event)
+            return self.button_handler(event)
         return False
 
     def draw(self, ctx, focused=False):
-        print("draw")
         ctx.save()
         ctx.translate(-100,0)
-        self.height = 0
 
         # Draw heading
         ctx.font_size = tokens.one_pt * 8
@@ -111,12 +117,14 @@ class DefinitionDisplay(Layoutable):
         else:
             ctx.rgb(*tokens.colors["yellow"])
 
+        height = self.height
+
         # Draw label
         label_lines = utils.wrap_text(ctx, self.label, tokens.label_font_size)
         for line in label_lines:
-            ctx.move_to(0, self.height)
+            ctx.move_to(0, height)
             ctx.text(line)
-            self.height += ctx.font_size
+            height += ctx.font_size
 
         ctx.rgb(*tokens.ui_colors["label"])
 
@@ -124,9 +132,9 @@ class DefinitionDisplay(Layoutable):
         ctx.font_size = tokens.ten_pt
         value_lines = utils.wrap_text(ctx, self.value, tokens.label_font_size)
         for line in value_lines:
-            ctx.move_to(10, self.height)
+            ctx.move_to(10, height)
             ctx.text(line)
-            self.height += ctx.font_size
+            height += ctx.font_size
 
         ctx.restore()
 

--- a/modules/app_components/layout.py
+++ b/modules/app_components/layout.py
@@ -53,7 +53,7 @@ class ButtonDisplay(Layoutable):
         ctx.save()
 
         # Draw button
-        ctx.translate(30, 0)
+        ctx.translate(-90, 0)
         ctx.scale(0.75, 0.75)
         if focused:
             bg = tokens.ui_colors["active_button_background"]

--- a/modules/app_components/layout.py
+++ b/modules/app_components/layout.py
@@ -81,9 +81,8 @@ class ButtonDisplay(Layoutable):
 
     def _handle_buttondown(self, event: ButtonDownEvent):
         self._cleanup()
-        if BUTTON_TYPES["CONFIRM"] in event.button:
-            if self.button_handler:
-                self.button_handler(event)
+        if self.button_handler:
+            self.button_handler(event)
 
 class DefinitionDisplay(Layoutable):
     def __init__(self, label, value, height=None, button_handler=None):

--- a/modules/app_components/layout.py
+++ b/modules/app_components/layout.py
@@ -30,7 +30,7 @@ class TextDisplay(Layoutable):
 
     def draw(self, ctx, focused=False):
         ctx.save()
-        ctx.translate(-100,-40)
+        # ctx.translate(-100,-40)
         if self.lines is None:
             self.lines = utils.wrap_text(ctx, self.text, self.font_size)
             self.height = len(self.lines) * self.font_size
@@ -60,7 +60,8 @@ class ButtonDisplay(Layoutable):
         ctx.save()
 
         # Draw button
-        ctx.translate(-90, 0)
+        # ctx.translate(-90, 0)
+        # ctx.translate(30, 0)
         ctx.scale(0.75, 0.75)
         if focused:
             bg = tokens.ui_colors["active_button_background"]
@@ -85,9 +86,10 @@ class ButtonDisplay(Layoutable):
             self.button_handler(event)
 
 class DefinitionDisplay(Layoutable):
-    def __init__(self, label, value, height=None, button_handler=None):
+    def __init__(self, label, value, app, height=None, button_handler=None):
         self.label = label
         self.value = value
+        self.app = app
         if not height:
             self.height = 0
         else:
@@ -106,7 +108,7 @@ class DefinitionDisplay(Layoutable):
 
     def draw(self, ctx, focused=False):
         ctx.save()
-        ctx.translate(-100,0)
+        # ctx.translate(-100,0)
 
         # Draw heading
         ctx.font_size = tokens.one_pt * 8
@@ -200,7 +202,7 @@ import app_components.layout
 
 text = app_components.layout.TextDisplay("Lorem ipsum " + "abcde "*30)
 foo = app_components.layout.ButtonDisplay("foo")
-bar = app_components.layout.DefinitionDisplay("Wifi", "emfcamp")
+bar = app_components.layout.DefinitionDisplay("Wifi", "emfcamp", self)
 layout = app_components.layout.LinearLayout([text, foo, bar])
 
 ctx=display.get_ctx()

--- a/modules/app_components/utils.py
+++ b/modules/app_components/utils.py
@@ -1,4 +1,6 @@
-def fill_line(ctx, text, width_for_line):
+def fill_line(ctx, text, width_for_line, font_size):
+    ctx.save()
+    ctx.font_size = font_size
     extra_text = ""
     text_that_fits = text
     text_width = ctx.text_width(text_that_fits)
@@ -7,16 +9,17 @@ def fill_line(ctx, text, width_for_line):
         text_that_fits = text_that_fits[:-1]
         extra_text = character + extra_text
         text_width = ctx.text_width(text_that_fits)
+    ctx.restore()
     return text_that_fits, extra_text
 
 
-def wrap_text(ctx, text, width=None):
+def wrap_text(ctx, text, font_size, width=None):
     if width is None:
-        width = 240
+        width = 200
     remaining_text = text
     lines = []
     while remaining_text:
-        line, remaining_text = fill_line(ctx, remaining_text, width)
+        line, remaining_text = fill_line(ctx, remaining_text, width, font_size)
         if "\n" in line:
             lines += line.split("\n")
         else:

--- a/modules/firmware_apps/settings_app.py
+++ b/modules/firmware_apps/settings_app.py
@@ -38,7 +38,7 @@ BRIGHTNESSES = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
 
 class SettingsApp(app.App):
     def __init__(self):
-        self.layout = layout.LinearLayout(items=[layout.DefinitionDisplay("", "")])
+        self.layout = layout.LinearLayout(items=[layout.DefinitionDisplay("", "", self)])
         self.overlays = []
         self.dialog = None
         eventbus.on_async(ButtonDownEvent, self._button_handler, self)
@@ -86,10 +86,10 @@ class SettingsApp(app.App):
                         return False
 
                     entry = layout.DefinitionDisplay(
-                        label, formatter(value), button_handler=_button_event
+                        label, formatter(value), self, button_handler=_button_event
                     )
                 else:
-                    entry = layout.DefinitionDisplay(label, formatter(value))
+                    entry = layout.DefinitionDisplay(label, formatter(value), self)
                 self.layout.items.append(entry)
 
                 if id == "pattern":
@@ -111,7 +111,7 @@ class SettingsApp(app.App):
                         return False
 
                     entry = layout.ButtonDisplay(
-                        "Next pattern", button_handler=_button_event_pattern_toggle
+                        "Next pattern", self, button_handler=_button_event_pattern_toggle
                     )
                     self.layout.items.append(entry)
 
@@ -134,7 +134,7 @@ class SettingsApp(app.App):
                         return False
 
                     entry = layout.ButtonDisplay(
-                        "Toggle", button_handler=_button_event_pattern_toggle
+                        "Toggle", self, button_handler=_button_event_pattern_toggle
                     )
                     self.layout.items.append(entry)
 
@@ -150,7 +150,7 @@ class SettingsApp(app.App):
                     return True
                 return False
 
-            entry = layout.ButtonDisplay("Reset WiFi", button_handler=_button_event_w)
+            entry = layout.ButtonDisplay("Reset WiFi", self, button_handler=_button_event_w)
             self.layout.items.append(entry)
 
             while True:
@@ -197,9 +197,11 @@ class SettingsApp(app.App):
         return True
 
     def draw(self, ctx):
+        ctx.save()
         tokens.clear_background(ctx)
         self.layout.draw(ctx)
         self.draw_overlays(ctx)
+        ctx.restore()
 
 
 __app_export__ = SettingsApp

--- a/modules/system/ota/ota.py
+++ b/modules/system/ota/ota.py
@@ -18,9 +18,9 @@ class OtaUpdate(App):
     def __init__(self):
         self.status = None
         super().__init__()
-        self.status = layout.DefinitionDisplay("Status", "")
-        self.old_version = layout.DefinitionDisplay("Current", "-")
-        self.new_version = layout.DefinitionDisplay("New", "-")
+        self.status = layout.DefinitionDisplay("Status", "", self)
+        self.old_version = layout.DefinitionDisplay("Current", "-", self)
+        self.new_version = layout.DefinitionDisplay("New", "-", self)
         self.layout = layout.LinearLayout(
             [self.status, self.old_version, self.new_version]
         )
@@ -137,7 +137,7 @@ class OtaUpdate(App):
                     line.split("[")[0].strip() for line in release_notes.split("\n")
                 ]
                 release_notes = "\n".join(release_notes)
-                self.notes = layout.DefinitionDisplay("Release notes", release_notes)
+                self.notes = layout.DefinitionDisplay("Release notes", release_notes, self)
                 self.layout.items.append(self.notes)
             """
             try:


### PR DESCRIPTION
I'm now working through how the `SettingsApp`. I didn't previously get that these were supposed to be composed and used together in a `LinearLayout`.

- `TextDisplay`: The text display got drawn at 0,0 and the calculations for wrapping don't take the font size into account. I've changed that.
- `ButtonDisplay`: You can now pass in an event handler
- `DefinitionDisplay` You can now pass in height and the event handler