### PR TITLE
Only draw the focused and always-on-top apps

### DIFF
--- a/modules/system/scheduler/__init__.py
+++ b/modules/system/scheduler/__init__.py
@@ -213,7 +213,7 @@ class _Scheduler:
 
             with PerfTimer("render"):
                 ctx = display.get_ctx()
-                for app in self.foreground_stack:
+                for app in self.foreground_stack[-1:] + self.on_top_stack:
                     with PerfTimer(f"rendering {app}"):
                         ctx.save()
                         try:
@@ -226,11 +226,6 @@ class _Scheduler:
                                     message=f"{app.__class__.__name__} has crashed"
                                 )
                             )
-                        ctx.restore()
-                for app in self.on_top_stack:
-                    with PerfTimer(f"rendering {app}"):
-                        ctx.save()
-                        app.draw(ctx)
                         ctx.restore()
                 display.end_frame(ctx)
             await asyncio.sleep(0)


### PR DESCRIPTION
Do not draw the whole foreground stack, only the last one and overlays. People aren't writing apps that draw partial screens, and this prevents us having to re-render the menu constantly.

Refs: #100