### PR TITLE
display: move framebuffer to SRAM to avoid cache line contention

### DIFF
--- a/drivers/gc9a01/display.c
+++ b/drivers/gc9a01/display.c
@@ -30,7 +30,7 @@ static MP_DEFINE_CONST_FUN_OBJ_0(get_fps_obj, get_fps);
 #define TILDAGON_DISPLAY_WIDTH  240
 #define TILDAGON_DISPLAY_HEIGHT 240
 
-EXT_RAM_BSS_ATTR
+//EXT_RAM_BSS_ATTR
 static uint8_t tildagon_fb[TILDAGON_DISPLAY_WIDTH * TILDAGON_DISPLAY_HEIGHT * 2];
 static Ctx *tildagon_ctx = NULL;
 


### PR DESCRIPTION
# Description

As suggested by pippin, this moves the ctx framebuffer to SRAM to avoid contention on the cache lines, which improves performance of v1.7.0 while the render task is in MP