### PR TITLE
Add support for a beta channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,13 +89,13 @@ jobs:
           files: |
             micropython/ports/esp32/build-tildagon/micropython.bin
             micropython/ports/esp32/build-tildagon/tildagon.txt
-      - name: Create latest release for tags
+      - name: Create preview release for rc tags
         uses: "marvinpinto/action-automatic-releases@latest"
         if: ${{startsWith(github.event.ref, 'refs/tags/v')} && contains(github.event.ref, 'rc')}
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "preview"
-          title: "Latest release build"
+          title: "Latest preview build"
           files: |
             micropython/ports/esp32/build-tildagon/micropython.bin
             micropython/ports/esp32/build-tildagon/tildagon.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
             micropython/ports/esp32/build-tildagon/tildagon.txt
       - name: Create latest release for tags
         uses: "marvinpinto/action-automatic-releases@latest"
-        if: github.event_name == 'push'
+        if: ${{startsWith(github.event.ref, 'refs/tags/v')} && !contains(github.event.ref, 'rc')}
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
@@ -83,9 +83,19 @@ jobs:
             micropython/ports/esp32/build-tildagon/tildagon.txt
       - name: Create specific release for tags
         uses: "marvinpinto/action-automatic-releases@latest"
-        if: github.event_name == 'push'
+        if: ${{startsWith(github.event.ref, 'refs/tags/v')}}
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          files: |
+            micropython/ports/esp32/build-tildagon/micropython.bin
+            micropython/ports/esp32/build-tildagon/tildagon.txt
+      - name: Create latest release for tags
+        uses: "marvinpinto/action-automatic-releases@latest"
+        if: ${{startsWith(github.event.ref, 'refs/tags/v')} && contains(github.event.ref, 'rc')}
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "preview"
+          title: "Latest release build"
           files: |
             micropython/ports/esp32/build-tildagon/micropython.bin
             micropython/ports/esp32/build-tildagon/tildagon.txt
@@ -101,7 +111,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action
         with:
           path: ./flasher
-        if: startsWith(github.event.ref, 'refs/tags/v')
+        if: ${{startsWith(github.event.ref, 'refs/tags/v')} && !contains(github.event.ref, 'rc')}
   deploy:
     if: startsWith(github.event.ref, 'refs/tags/v')
     needs: Build-Firmware

--- a/modules/firmware_apps/settings_app.py
+++ b/modules/firmware_apps/settings_app.py
@@ -173,6 +173,7 @@ class SettingsApp(app.App):
             ("pattern", "LED Pattern", string_formatter, None),
             ("pattern_brightness", "Pattern brightness", pct_formatter, None),
             ("pattern_mirror_hexpansions", "Mirror pattern", string_formatter, None),
+            ("update_channel", "Update channel", string_formatter, None),
             ("wifi_tx_power", "WiFi TX power", string_formatter, None),
             (
                 "wifi_connection_timeout",


### PR DESCRIPTION
# Description
This improves the OTA app to parse version numbers better, with the following rules:

- Major, Minor and Patch versions are parsed as numbers rather than strings, so v1.10.0 > v1.9.0
- Development versions where there's a 'number of commits ahead' item are counted as ahead of the version they're on
- If there's an rc after the patch number, it's treated as ahead of the previous version, so v1.9.0 < v1.10.0rc1 < v1.10.0rc1-1-aaaaaa < v1.10.0 < v1.10.0-1-aaaaaa

If there is an rc in the tag name, it won't overwrite the `latest` release, it will overwrite the `preview` release.

The setting `update_channel` will work as normal if unset or set to `latest`. Set it to `preview` to get release candidates.
