### PR TITLE
Improved use of semver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,17 +73,19 @@ jobs:
             micropython/ports/esp32/build-tildagon/tildagon.txt
       - name: Create latest release for tags
         uses: "marvinpinto/action-automatic-releases@latest"
-        if: ${{startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, 'rc') }}
+        if: ${{startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, '-') }}
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
           title: "Latest release build"
+          prerelease: false
           files: |
             micropython/ports/esp32/build-tildagon/micropython.bin
             micropython/ports/esp32/build-tildagon/tildagon.txt
       - name: Create specific release for tags
         uses: "marvinpinto/action-automatic-releases@latest"
         if: ${{startsWith(github.event.ref, 'refs/tags/v')}}
+        prerelease: ${{ contains(github.event.ref, '-') }}
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           files: |
@@ -91,10 +93,11 @@ jobs:
             micropython/ports/esp32/build-tildagon/tildagon.txt
       - name: Create preview release for rc tags
         uses: "marvinpinto/action-automatic-releases@latest"
-        if: ${{startsWith(github.event.ref, 'refs/tags/v') && contains(github.event.ref, 'rc') }}
+        if: ${{startsWith(github.event.ref, 'refs/tags/v') && contains(github.event.ref, '-') }}
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "preview"
+          prerelease: true
           title: "Latest preview build"
           files: |
             micropython/ports/esp32/build-tildagon/micropython.bin
@@ -111,7 +114,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action
         with:
           path: ./flasher
-        if: ${{startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, 'rc') }}
+        if: ${{startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, '-') }}
   deploy:
     if: startsWith(github.event.ref, 'refs/tags/v')
     needs: Build-Firmware

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,8 +85,8 @@ jobs:
       - name: Create specific release for tags
         uses: "marvinpinto/action-automatic-releases@latest"
         if: ${{startsWith(github.event.ref, 'refs/tags/v')}}
-        prerelease: ${{ contains(github.event.ref, '-') }}
         with:
+          prerelease: ${{ contains(github.event.ref, '-') }}
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           files: |
             micropython/ports/esp32/build-tildagon/micropython.bin

--- a/components/st3m/host-tools/version.py
+++ b/components/st3m/host-tools/version.py
@@ -16,10 +16,13 @@ import os
 def get_git_based_version():
     root = os.environ.get('GITHUB_WORKSPACE', '/firmware')
     os.chdir(root)
-    return subprocess.check_output(
+    version = subprocess.check_output(
         ["git", "describe", "--tags", "--always"]
     ).decode().strip()
-
+    if '-' in version:
+        version = version.replace("-", "+", 1)
+        version  = version.replace("-", ".")
+    return version
 
 fmt = None
 if len(sys.argv) > 1:

--- a/components/st3m/host-tools/version.py
+++ b/components/st3m/host-tools/version.py
@@ -11,6 +11,7 @@ and the release process.
 import subprocess
 import sys
 import os
+import re
 
 
 def get_git_based_version():
@@ -19,9 +20,14 @@ def get_git_based_version():
     version = subprocess.check_output(
         ["git", "describe", "--tags", "--always"]
     ).decode().strip()
-    if '-' in version:
-        version = version.replace("-", "+", 1)
-        version  = version.replace("-", ".")
+    commit_hash = subprocess.check_output(
+        ["git", "describe", "--always"]
+    ).decode().strip()
+    if version.endswith(commit_hash):
+        build_info = re.compile(f"\-(\d+)\-(.*?{re.escape(commit_hash)})").findall(version)
+        if build_info:
+            ahead, commit_hash = build_info[0]
+            version = version.replace(f"-{ahead}-{commit_hash}", f"+{ahead}.{commit_hash}", 1)
     return version
 
 fmt = None

--- a/tildagon/mpconfigboard.cmake
+++ b/tildagon/mpconfigboard.cmake
@@ -24,7 +24,7 @@ file(
         BASE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
 )
 execute_process(
-        COMMAND "${GIT_EXECUTABLE}" describe --tags --always
+        COMMAND "python" "components/st3m/host-tools/version.py"
         WORKING_DIRECTORY "${FIRMWARE_ROOT}"
         RESULT_VARIABLE res
         OUTPUT_VARIABLE TILDAGON_GIT_VERSION


### PR DESCRIPTION
# Description

This changes the use of git describe to generate (v-prefixed) semver versions, moving the build information to a + block. It also enhances the version parsing in ota to more closely match semver.

This should make the `v1.8.0-rc.1` tag format work.