### PR TITLE
try/except block fix for crash

### DIFF
--- a/modules/system/hexpansion/app.py
+++ b/modules/system/hexpansion/app.py
@@ -107,7 +107,11 @@ class HexpansionManagerApp(app.App):
             self._cleanup_import_path(old_cwd, old_sys_path)
             return
 
-        App = package.__app_export__ if hasattr(package, "__app_export__") else None
+        try:
+            App = package.__app_export__ if hasattr(package, "__app_export__") else None
+        except ValueError as e:
+            print(e)
+            App = None
 
         if App is None:
             print("No exported app found")


### PR DESCRIPTION
# Description

Add a try/except block around call to hasattr() as it can fail with ValueError exception if the hexpansion EEPROM has corruption.

Fix for Issue #164 