### PR TITLE
Call cleanup before handlers for menu

### DIFF
--- a/modules/app_components/menu.py
+++ b/modules/app_components/menu.py
@@ -62,9 +62,11 @@ class Menu:
                     self.menu_items[self.position % len(self.menu_items)]
                 )
         if BUTTON_TYPES["CANCEL"] in event.button:
+            self._cleanup()
             if self.back_handler is not None:
                 self.back_handler()
         if BUTTON_TYPES["CONFIRM"] in event.button:
+            self._cleanup()
             if self.select_handler is not None:
                 self.select_handler(
                     self.menu_items[self.position % len(self.menu_items)],


### PR DESCRIPTION
With the way menu's work I don't think we should require users to call the `_cleanup method`. The underscore is supposed to mean it's internal anyway