### PR TITLE
Allow app updating

### DIFF
--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -218,15 +218,18 @@ class AppStoreApp(app.App):
                     self.apps_with_updates.append(ia)
             else:
                 print("No app in app store matching: ", ia)
-
-        self.update_menu = Menu(
-            self,
-            menu_items=[app["name"] for app in self.apps_with_updates],
-            select_handler=on_select,
-            back_handler=on_cancel,
-            focused_item_font_size=fourteen_pt,
-            item_font_size=ten_pt,
-        )
+        if len(self.apps_with_updates):
+            self.update_menu = Menu(
+                self,
+                menu_items=[app["name"] for app in self.apps_with_updates],
+                select_handler=on_select,
+                back_handler=on_cancel,
+                focused_item_font_size=fourteen_pt,
+                item_font_size=ten_pt,
+            )
+        else:
+            self.update_state("main_menu")
+            eventbus.emit(ShowNotificationEvent("All apps up to date!"))
 
     def prepare_installed_menu(self):
         def on_cancel():

--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -54,6 +54,8 @@ class AppStoreApp(app.App):
         self.codeinstall = None
         self.response = None
         self.app_store_index = []
+        self.apps_with_updates = []
+        self.apps_available_dict = {}
         self.to_install_app = None
         self.tarball = None
 
@@ -175,11 +177,55 @@ class AppStoreApp(app.App):
             menu_items=[
                 CODE_INSTALL,
                 AVAILABLE,
-                # UPDATE,
+                UPDATE,
                 INSTALLED,
             ],
             select_handler=on_select,
             back_handler=on_cancel,
+        )
+
+    def prepare_update_menu(self):
+        def on_cancel():
+            self.cleanup_ui_widgets()
+            self.update_state("main_menu")
+
+        def on_select(_, i):
+            app_name = self.apps_with_updates[i]["folder"]
+            self.to_install_app = self.apps_available_dict[app_name]
+            self.update_state("installing_app")
+            self.cleanup_ui_widgets()
+
+        def compare_version(v1, v2):
+            # compare format v0.0.0
+            return v1.split(".") > v2.split(".")
+
+        installed_apps = list_user_apps()
+        self.apps_available_dict = {}
+        for a in self.app_store_index:
+            folder_name = a["id"]["owner"] + "_" + a["id"]["title"]
+            folder_name = folder_name.replace("-", "_")
+            self.apps_available_dict[folder_name] = a
+        self.apps_with_updates = []
+        for ia in installed_apps:
+            if ia["folder"] in self.apps_available_dict:
+                app_dict = self.apps_available_dict[ia["folder"]]
+                latest_version = app_dict["manifest"]["metadata"]["version"]
+                print("App: " + ia["name"])
+                print(f"Latest version: {latest_version}")
+                print("Installed version: " + ia["version"])
+
+                if compare_version(latest_version, ia["version"]):
+                    self.apps_with_updates.append(ia)
+            else:
+                print("No app in app store matching: ", ia)
+
+        self.update_menu = Menu(
+            self,
+            menu_items=[app["name"] for app in self.apps_with_updates],
+            select_handler=on_select,
+            back_handler=on_cancel,
+            focused_item_font_size=fourteen_pt,
+            item_font_size=ten_pt,
         )
 
     def prepare_installed_menu(self):
@@ -255,6 +301,8 @@ class AppStoreApp(app.App):
             self.prepare_available_menu()
         elif self.state == "installed_menu" and not self.installed_menu:
             self.prepare_installed_menu()
+        elif self.state == "update_menu" and not self.update_menu:
+            self.prepare_update_menu()
 
         if self.menu:
             self.menu.update(delta)
@@ -418,6 +466,7 @@ def install_app(app):
         internal_manifest = {
             "name": app["manifest"]["app"]["name"],
             "hidden": False,
+            "version": app["manifest"]["metadata"]["version"],
         }
         json_path = f"{APP_DIR}/{app_module_name}/metadata.json"
         print(f"Json path: {json_path}")

--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -75,9 +75,12 @@ def list_user_apps():
                 "path": f"apps.{name}.app",
                 "callable": "__app_export__",
                 "name": name,
+                "folder": name,
                 "hidden": False,
             }
             metadata = load_info(APP_DIR, name)
+            if "version" not in metadata:
+                app["version"] = "0.0.0"
             app.update(metadata)
             if not app["hidden"]:
                 apps.append(app)


### PR DESCRIPTION
Fixes #124.
Because we currently don't store the version (we do in the toml but adding regex checking into this feels error-prone), the first time a user runs upgrade they'll get all installed apps. The versions then get stored in the metadata.json and from there it will only list apps if there are apps to be updated.

This is easier to test if you rebase off of #167 