### PR TITLE
Increase VBATMIN to 3 volts

### DIFF
--- a/drivers/tildagon_power/tildagon_power.h
+++ b/drivers/tildagon_power/tildagon_power.h
@@ -11,7 +11,7 @@
 
 
 #define VBATMAX 4.104F
-#define VBATMIN 2.500F
+#define VBATMIN 3.000F
 
 typedef struct
 {

--- a/drivers/tildagon_power/tildagon_power.h
+++ b/drivers/tildagon_power/tildagon_power.h
@@ -11,7 +11,7 @@
 
 
 #define VBATMAX 4.104F
-#define VBATMIN 3.000F
+#define VBATMIN 3.500F
 
 typedef struct
 {


### PR DESCRIPTION
Increases the minimum battery voltage to the 3 volt minimum specified in its datasheet, as discussed in issue #175 