### PR TITLE
Improve async compatibility of app store

### DIFF
--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -396,7 +396,8 @@ class AppStoreApp(app.App):
                 )
             except Exception:
                 self.update_state("no_index")
-            self.update_state("index_received")
+            else:
+                self.update_state("index_received")
 
             if self.to_install_app:
                 # We wait one cycle after background_update is called to ensure the

--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -92,39 +92,6 @@ class AppStoreApp(app.App):
             return
         self.update_state("refreshing_index")
 
-<<<<<<< HEAD
-    def background_update(self, delta):
-        if self.state == "refreshing_index":
-            try:
-                self.response = get(APP_STORE_LISTING_URL)
-            except Exception:
-                self.update_state("no_index")
-                return
-            self.update_state("index_received")
-        if self.to_install_app:
-            # We wait one cycle after background_update is called to ensure the
-            # installation screen is drawn
-            if self.wait_one_cycle:
-                self.install_app(self.to_install_app)
-                self.to_install_app = None
-                self.wait_one_cycle = False
-            self.wait_one_cycle = True
-
-||||||| parent of 8df3d90 (Improve async compatibility of app store)
-    def background_update(self, delta):
-        if self.state == "refreshing_index":
-            try:
-                self.response = get(APP_STORE_LISTING_URL)
-            except Exception:
-                self.update_state("no_index")
-                return
-            self.update_state("index_received")
-        if self.to_install_app:
-            self.install_app(self.to_install_app)
-            self.to_install_app = None
-
-=======
->>>>>>> 8df3d90 (Improve async compatibility of app store)
     def handle_index(self):
         if not self.response:
             print(self.response)
@@ -398,17 +365,13 @@ class AppStoreApp(app.App):
                 self.update_state("no_index")
             else:
                 self.update_state("index_received")
-
-            if self.to_install_app:
-                # We wait one cycle after background_update is called to ensure the
-                # installation screen is drawn
-                if self.wait_one_cycle:
-                    await async_helpers.unblock(
-                        self.install_app, render_update, self.to_install_app
-                    )
-                    self.to_install_app = None
-                    self.wait_one_cycle = False
-                self.wait_one_cycle = True
+        elif self.state == "installing_app":
+            # We wait one cycle after background_update is called to ensure the
+            # installation screen is drawn
+            await async_helpers.unblock(
+                self.install_app, render_update, self.to_install_app
+            )
+            self.to_install_app = None
         if self.menu:
             self.menu.update(delta)
         if self.available_categories_menu:

--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -89,6 +89,7 @@ def list_user_apps():
 
 class Launcher(App):
     def __init__(self):
+        self.menu = None
         self.update_menu()
         self._apps = {}
         eventbus.on_async(RequestStopAppEvent, self._handle_stop_app, self)
@@ -139,6 +140,8 @@ class Launcher(App):
 
     def update_menu(self):
         self.menu_items = self.list_core_apps() + list_user_apps()
+        if self.menu:
+            self.menu._cleanup()
         self.menu = Menu(
             self,
             [app["name"] for app in self.menu_items],


### PR DESCRIPTION
This moves some code from the background task to the main task, and refactors it to allow use of async methods. This looks like these tasks were in background from the idea that the background task runs 'in the background', rather than runs 'when the app is in the background'.

There are two calls that use requests.get, which block the update task. By refactoring slightly to use async, we can use async_helpers.unblock to move them to a thread.
