### PR TITLE
Better text wrapping

### DIFF
--- a/modules/app_components/utils.py
+++ b/modules/app_components/utils.py
@@ -34,5 +34,4 @@ def wrap_text(ctx, text, font_size=None, width=None):
     for line in lines:
         lines = fill_line(ctx, line, font_size, width)
         wrapped_lines.extend(lines)
-    print(wrapped_lines)
     return wrapped_lines

--- a/modules/app_components/utils.py
+++ b/modules/app_components/utils.py
@@ -1,16 +1,29 @@
 def fill_line(ctx, text, font_size, width_for_line):
     ctx.save()
     ctx.font_size = font_size
-    extra_text = ""
-    text_that_fits = text
-    text_width = ctx.text_width(text_that_fits)
-    while text_width > width_for_line:
-        character = text_that_fits[-1]
-        text_that_fits = text_that_fits[:-1]
-        extra_text = character + extra_text
-        text_width = ctx.text_width(text_that_fits)
+    lines = []
+    line = ""
+    words = text.split(' ')
+    for word in words:
+        remaining_word = word
+        while ctx.text_width(remaining_word) > width_for_line:
+            word = word[:-1]
+            check_word = (line + ' ' + word + '-').strip()
+            if ctx.text_width(check_word) <= width_for_line:
+                lines.append(check_word)
+                line = ""
+                word = remaining_word[len(word) :]
+                remaining_word = word
+
+        new_line = line + ' ' + word
+        if ctx.text_width(new_line) > width_for_line:
+            lines.append(line.strip())
+            line = word
+        else:
+            line = new_line.strip()
+    lines.append(line)
     ctx.restore()
-    return text_that_fits, extra_text
+    return lines
 
 
 def wrap_text(ctx, text, font_size=None, width=None):

--- a/modules/app_components/utils.py
+++ b/modules/app_components/utils.py
@@ -16,12 +16,10 @@ def fill_line(ctx, text, font_size, width_for_line):
 def wrap_text(ctx, text, font_size=None, width=None):
     if width is None:
         width = 240
-    remaining_text = text
-    lines = []
-    while remaining_text:
-        line, remaining_text = fill_line(ctx, remaining_text, font_size, width)
-        if "\n" in line:
-            lines += line.split("\n")
-        else:
-            lines.append(line)
-    return lines
+    lines = text.split("\n")
+    wrapped_lines = []
+    for line in lines:
+        lines = fill_line(ctx, line, font_size, width)
+        wrapped_lines.extend(lines)
+    print(wrapped_lines)
+    return wrapped_lines


### PR DESCRIPTION
# Description

Text was being wrapped in the middle of words.

Updated version only splits on spaces and if there is a word longer than will fit on one line then the word is hyphenated.

I would love to get the wrapping to work within a circular boundary but that will have to wait for another day!

## Normal Text - Before
![Normal Text - Before](https://github.com/emfcamp/badge-2024-software/assets/4094413/fc9cc13d-8bfe-4e25-9d58-240b232a3803)

## Normal Text - After
![Normal Text - After](https://github.com/emfcamp/badge-2024-software/assets/4094413/0a483a32-e330-4bac-9be1-f1188495a04f)

## Long Word - Before
![Long Word - Before](https://github.com/emfcamp/badge-2024-software/assets/4094413/b9b82b57-7d28-4197-a1b7-d64c605053db)

## Long Word - After
![Long Word - After](https://github.com/emfcamp/badge-2024-software/assets/4094413/2554ab9d-8c22-405d-9990-625411f9c571)

## Settings - Before
![Settings - Before](https://github.com/emfcamp/badge-2024-software/assets/4094413/cc6ab8a5-403e-4209-be35-9e8018c5f738)

## Settings - After
![Settings - After](https://github.com/emfcamp/badge-2024-software/assets/4094413/c536b785-f609-4a7b-b403-c8e8678f1f19)

