### PR TITLE
Improve battery level

### DIFF
--- a/drivers/tildagon_power/bq25895/bq25895.c
+++ b/drivers/tildagon_power/bq25895/bq25895.c
@@ -41,13 +41,15 @@ static void write_scaled( bq_state_t* state, scaled_register_t scaledregister, f
  * @brief initialise the bq25895
  * @details reset then setup 500mA Iin limit, boost disabled, charging enabled,
  * ADC at 1Hz, disable unused features and disable watchdog to reduce interruptions
+ * charge current limit to be 0.85C for the 1800mAh and 0.77C for 2000mAh batteries
+ * termination and precharge current to 64mA. min Vbat 3.5V
  * @param state pmic object
  */
 void bq_init( bq_state_t* state )
 {
     write_bits( state, register_reset, 1 );
-    uint8_t write_buffer[3] = { 0x02, 0x60, 0x1A };
-    mp_machine_i2c_buf_t buffer = { .len = 3, .buf = write_buffer };
+    uint8_t write_buffer[5] = { 0x02, 0x60, 0x1A, 0x18, 0x00 };
+    mp_machine_i2c_buf_t buffer = { .len = 5, .buf = write_buffer };
     tildagon_mux_i2c_transaction( state->mux_port, ADDRESS, 1, &buffer, WRITE );
     write_buffer[0] = 0x07;
     write_buffer[1] = 0x8C;

--- a/drivers/tildagon_power/mp_power.c
+++ b/drivers/tildagon_power/mp_power.c
@@ -56,7 +56,32 @@ static MP_DEFINE_CONST_FUN_OBJ_0( Icharge_obj, power_Icharge);
 static mp_obj_t power_BatteryLevel( void ) 
 {
     bq_update_state( &pmic );
-    return mp_obj_new_float( ( ( pmic.vbat-VBATMIN ) / ( VBATMAX- VBATMIN ) ) * 100.0F );
+    float level = 0.0F;
+    if( ( ( pmic.status & BQ_CHARGE_STAT_MASK ) == BQ_NOTCHARGING )
+     || ( ( pmic.status & BQ_CHARGE_STAT_MASK ) == BQ_TERMINATED ) )
+    {
+        level = ( ( pmic.vbat-VBATMIN ) / ( VBATMAX- VBATMIN ) ) * 100.0F;
+    }
+    else
+    {
+        if ( pmic.vbat >= VBATMAX-0.1 )
+        {
+            level =  85.0F + ( 15.0F - ( ( pmic.ichrg / ( IBAT_MAX - IBAT_TERM ) ) * 15.0F ) );
+        }
+        else
+        {
+            level = ( ( pmic.vbat-VBATMIN ) / ( 4.2F - VBATMIN ) ) * 85.0F;
+        }
+    }    
+    if ( level > 100.0F )
+    {
+        level = 100.0F;
+    }
+    else if ( level < 0.0F )
+    {
+        level = 0.0F;
+    }
+    return mp_obj_new_float(level);
 }
 
 static MP_DEFINE_CONST_FUN_OBJ_0( BatteryLevel_obj, power_BatteryLevel);

--- a/drivers/tildagon_power/mp_power.c
+++ b/drivers/tildagon_power/mp_power.c
@@ -14,7 +14,6 @@
 #define VBAT_DIS_MIN 3.5F
 #define VBAT_CHG_MAX 4.2F
 #define VBAT_CHG_MIN 3.6F
-#define IBAT_MAX 1.536F
 #define IBAT_TERM 0.064F
 #define VBAT_CI_PERCENT 85.0F
 #define VBAT_CV_PERCENT ( 100.0F - VBAT_CI_PERCENT ) 
@@ -85,7 +84,16 @@ static mp_obj_t power_BatteryLevel( void )
         }
         else
         {
-            level =  VBAT_CI_PERCENT + ( VBAT_CV_PERCENT - ( ( pmic.ichrg / ( IBAT_MAX - IBAT_TERM ) ) * VBAT_CV_PERCENT ) );
+            float max_current = 1.536F;
+            if ( usb_in.fusb.input_current_limit == 1500U )
+            {
+                max_current = 1.3F;
+            }
+            else if ( usb_in.fusb.input_current_limit == 500 )
+            {
+                max_current = 0.4F;
+            }
+            level =  VBAT_CI_PERCENT + ( VBAT_CV_PERCENT - ( ( pmic.ichrg / ( max_current - IBAT_TERM ) ) * VBAT_CV_PERCENT ) );
         }
     }    
     if ( level > 100.0F )

--- a/drivers/tildagon_power/tildagon_power.h
+++ b/drivers/tildagon_power/tildagon_power.h
@@ -9,16 +9,6 @@
 #include "fusb302b/fusb302b_pd.h"
 #include "fusb302b/fusb302b.h"
 
-/* 
-    minimum input voltage for step down at max (4A) load. 
-    minimum input voltage = ( Rl(DCR) + Rdson ) * max current + output voltage
-    (0.078ohms * 4.0A) + 3.3V = 3.6V 
-    most users won't use 4A so badge will run lower than this so use 3.5V as minimum.
-*/
-#define VBATMAX 4.14F
-#define VBATMIN 3.5F
-#define IBAT_MAX 1.536F
-#define IBAT_TERM 0.064F
 typedef struct
 {
     fusb_state_t fusb;

--- a/drivers/tildagon_power/tildagon_power.h
+++ b/drivers/tildagon_power/tildagon_power.h
@@ -9,10 +9,16 @@
 #include "fusb302b/fusb302b_pd.h"
 #include "fusb302b/fusb302b.h"
 
-
-#define VBATMAX 4.104F
-#define VBATMIN 3.500F
-
+/* 
+    minimum input voltage for step down at max (4A) load. 
+    minimum input voltage = ( Rl(DCR) + Rdson ) * max current + output voltage
+    (0.078ohms * 4.0A) + 3.3V = 3.6V 
+    most users won't use 4A so badge will run lower than this so use 3.5V as minimum.
+*/
+#define VBATMAX 4.14F
+#define VBATMIN 3.5F
+#define IBAT_MAX 1.536F
+#define IBAT_TERM 0.064F
 typedef struct
 {
     fusb_state_t fusb;


### PR DESCRIPTION
# Description
fixes issue #83 
rework the battery level algorithm to be use different values for discharge and charge states and in the charge state use charge current profiles based on input current limits to calculate SOC. Reduce the charge termination current to 64mA to allow battery to charge to 4.2V.