### PR TITLE
enable pd comms

### DIFF
--- a/drivers/tildagon_power/fusb302b/fusb302b_pd.c
+++ b/drivers/tildagon_power/fusb302b/fusb302b_pd.c
@@ -85,28 +85,6 @@ void fusbpd_decode( pd_state_t* state, fusb_state_t* fusb )
 }
 
 /**
- * @brief select the highest voltage pdo up to 14V
- * @param state the comms state onject
- * @return the index of the pdo object
- */
-uint8_t fusbpd_select_pdo( pd_state_t* state )
-{
-    uint8_t i = 0U;
-    for ( i = 0U ; i < state->last_rx_header.sop.number_objects; i++ )
-    {
-        const uint16_t voltage = state->pdos[i].fixed.voltage * 50;
-        if (
-            ( state->pdos[i].fixed.pdo_type == PD_FIXED_SUPPLY )
-            && ( voltage == 5000U )
-        )
-        {
-            break;
-        }
-    }
-    return i;
-}
-
-/**
  * @brief creat a request power message 
  * @param state the comms state onject
  * @param num the index of the pdo list sent from the source

--- a/drivers/tildagon_power/fusb302b/fusb302b_pd.c
+++ b/drivers/tildagon_power/fusb302b/fusb302b_pd.c
@@ -91,22 +91,19 @@ void fusbpd_decode( pd_state_t* state, fusb_state_t* fusb )
  */
 uint8_t fusbpd_select_pdo( pd_state_t* state )
 {
-    uint16_t highest_voltage = 5000U;
-    uint8_t index = 0U;
-    for ( uint8_t i = 0U; i < state->last_rx_header.sop.number_objects; i++ )
+    uint8_t i = 0U;
+    for ( i = 0U ; i < state->last_rx_header.sop.number_objects; i++ )
     {
         const uint16_t voltage = state->pdos[i].fixed.voltage * 50;
         if (
             ( state->pdos[i].fixed.pdo_type == PD_FIXED_SUPPLY )
-            && ( voltage > highest_voltage )
-            && ( voltage <= 5000U )
+            && ( voltage == 5000U )
         )
         {
-            highest_voltage = voltage;
-            index = i;
+            break;
         }
     }
-    return index;
+    return i;
 }
 
 /**

--- a/drivers/tildagon_power/fusb302b/fusb302b_pd.c
+++ b/drivers/tildagon_power/fusb302b/fusb302b_pd.c
@@ -99,7 +99,7 @@ uint8_t fusbpd_select_pdo( pd_state_t* state )
         if (
             ( state->pdos[i].fixed.pdo_type == PD_FIXED_SUPPLY )
             && ( voltage > highest_voltage )
-            && ( voltage < 14000 )
+            && ( voltage <= 5000U )
         )
         {
             highest_voltage = voltage;

--- a/drivers/tildagon_power/fusb302b/fusb302b_pd.h
+++ b/drivers/tildagon_power/fusb302b/fusb302b_pd.h
@@ -165,12 +165,6 @@ typedef struct
  */
 extern void fusbpd_decode( pd_state_t* state, fusb_state_t* fusb );
 /**
- * @brief select the highest voltage pdo up to 14V
- * @param state the comms state onject
- * @return the index of the pdo object
- */
-extern uint8_t fusbpd_select_pdo( pd_state_t* state );
-/**
  * @brief creat a request power message 
  * @param state the comms state onject
  * @param num the index of the pdo list sent from the source

--- a/drivers/tildagon_power/tildagon_power.c
+++ b/drivers/tildagon_power/tildagon_power.c
@@ -310,8 +310,7 @@ void device_unattached_handler( event_t event )
         determine_input_current_limit( &usb_in );
         if ( ( usb_in.fusb.input_current_limit >= 1500 ) && ( device_pd_state == NOT_STARTED ) )
         {
-            //todo enable device pd
-            //fusb_setup_pd( &usb_in.fusb );
+            fusb_setup_pd( &usb_in.fusb );
             device_pd_state = WAITING;
         }
         fusb_mask_interrupt_bclevel( &usb_in.fusb, 1 );
@@ -334,8 +333,7 @@ void device_attached_handler( event_t event )
         determine_input_current_limit( &usb_in );
         if ( ( usb_in.fusb.input_current_limit >= 1500 ) && ( device_pd_state == NOT_STARTED ) )
         {
-            //todo enable device pd
-            //fusb_setup_pd( &usb_in.fusb );
+            fusb_setup_pd( &usb_in.fusb );
             device_pd_state = WAITING;
         }
         fusb_mask_interrupt_bclevel( &usb_in.fusb, 1 );
@@ -365,7 +363,12 @@ void device_pd_machine ( event_t event )
                 if ( usb_in.pd.last_rx_data_msg_type == PD_DATA_SOURCE_CAPABILITIES )
                 {
                     uint8_t index = fusbpd_select_pdo( &usb_in.pd );
-                    fusbpd_request_power( &usb_in.pd, index, usb_in.pd.pdos[index].fixed.max_current * 10, usb_in.pd.pdos[index].fixed.max_current * 10 );
+                    uint32_t current = usb_in.pd.pdos[index].fixed.max_current * 10;
+                    if ( current > 3250 )
+                    {
+                        current = 3250;
+                    }
+                    fusbpd_request_power( &usb_in.pd, index, current, current );
                     fusb_send( &usb_in.fusb, usb_in.pd.tx_buffer, usb_in.pd.message_length );  
                     usb_in.pd.last_rx_data_msg_type = PD_DATA_DO_NOT_USE; 
                     device_pd_state = POWER_REQUESTED;

--- a/drivers/tildagon_power/tildagon_power.c
+++ b/drivers/tildagon_power/tildagon_power.c
@@ -362,20 +362,29 @@ void device_pd_machine ( event_t event )
                 fusbpd_decode( &usb_in.pd, &usb_in.fusb );
                 if ( usb_in.pd.last_rx_data_msg_type == PD_DATA_SOURCE_CAPABILITIES )
                 {
-                    uint8_t index = fusbpd_select_pdo( &usb_in.pd );
-                    uint32_t current = usb_in.pd.pdos[index].fixed.max_current * 10;
-                    if ( current > 3250 )
+                    /*
+                        We only need 5V so can use the first object, from the usb 3 standard:
+                        The vSafe5V Fixed Supply Object Shall always be the first object.
+                        A Source Shall Not offer multiple Power Data Objects of the same 
+                        type (fixed, variable, Battery) and the same Voltage but Shall 
+                        instead offer one Power Data Object with the highest available 
+                        current for that Source capability and Voltage. 
+                        
+                    */
+                    uint32_t current = usb_in.pd.pdos[0].fixed.max_current * 10;
+                    /* limit current to the maximum current of a non active cable */
+                    if ( current > 3000 )
                     {
-                        current = 3250;
+                        current = 3000;
                     }
-                    fusbpd_request_power( &usb_in.pd, index, current, current );
+                    fusbpd_request_power( &usb_in.pd, 0, current, current );
                     fusb_send( &usb_in.fusb, usb_in.pd.tx_buffer, usb_in.pd.message_length );  
                     usb_in.pd.last_rx_data_msg_type = PD_DATA_DO_NOT_USE; 
                     device_pd_state = POWER_REQUESTED;
                 }          
                 else if( usb_in.pd.last_rx_data_msg_type == PD_DATA_VENDOR_DEFINED )
                 {
-                    /* if vendor pdo received decide on badge to badge and callback? */    
+                    /* ToDo: if vendor pdo received decide on badge to badge and callback? */    
                 }
             }
             break;


### PR DESCRIPTION
enable pd comms to add pd supply capabilities to power.SupplyCapabilities(), restrict the maximum voltage requested to 5V due to hardware limits and cap current request to max input current.



