### PR TITLE
prepare_eeprom.py: Add CAT24C512 header example

### DIFF
--- a/modules/scripts/prepare_eeprom.py
+++ b/modules/scripts/prepare_eeprom.py
@@ -41,6 +41,17 @@ header_zd24c64 = HexpansionHeader(
     friendly_name="ZD24C64A",
 )
 
+header_cat24c512 = HexpansionHeader(
+    manifest_version="2024",
+    fs_offset=128,
+    eeprom_page_size=128,
+    eeprom_total_size=1024 * (512 // 8),
+    vid=0xCA75,
+    pid=0x1337,
+    unique_id=0x0,
+    friendly_name="CAT24C512",
+)
+
 # pick which one to use here
 header = header_m24c16
 


### PR DESCRIPTION
This is a large (512kbit - 64kbyte) eeprom that seems to work fine

# Description

I built a hexpansion with this EEPROM (https://www.digikey.com/en/products/detail/onsemi/CAT24C512WI-GT3/2683757) - this PR adds an example of how to use it.

This could be useful for those who need more space - it's the largest the 16-bit addresses can deal with!