### PR TITLE
turn off LEDs and hexpansions on power off

### DIFF
--- a/modules/firmware_apps/poweroff.py
+++ b/modules/firmware_apps/poweroff.py
@@ -32,6 +32,21 @@ class PowerOff(app.App):
         if not self.off:
             clear_background(ctx)
         if self.off:
+            from egpio import ePin
+
+            HEXPANSION_POWER = {
+                (2, 12),
+                (2, 13),
+                (1, 8),
+                (1, 9),
+                (1, 10),
+                (1, 11),
+            }
+            for epin in HEXPANSION_POWER:
+                pin = ePin(epin, ePin.OUT)
+                pin.on()
+            pin = ePin((2, 2), ePin.OUT)
+            pin.off()
             ctx.rgb(0, 0, 0).rectangle(-120, -120, 240, 240).fill()
             ctx.font_size = 22
             ctx.text_align = ctx.CENTER


### PR DESCRIPTION
# Description

Turn off LEDs and Hexpansions when the badge is plugged in and powered off. requested in issue #109 but this doesn't allow charging, but does make the badge feel like it's been shutdown. An App might be better solution to the issue.