### PR TITLE
web flasher: actively disable improv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,9 +116,9 @@ jobs:
           path: ./flasher
         if: ${{startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, '-') }}
   deploy:
-    if: startsWith(github.event.ref, 'refs/tags/v')
+    if: ${{startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, '-') }}
     needs: Build-Firmware
-        
+
     permissions:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source

--- a/flasher/manifest.json
+++ b/flasher/manifest.json
@@ -4,6 +4,7 @@
     "new_install_prompt_erase": false,
     "builds": [
       {
+        "improv": false,
         "chipFamily": "ESP32-S3",
         "parts": [
           { "path": "merged-firmware.bin", "offset": 0 }


### PR DESCRIPTION
We currently don't support IMPROV, but it keeps accidentally getting turned on when connecting to the badge over webserial.  This prevents the webserial terminal from being used, as it appends `IMPROV` to random characters

This MR should force it to be disabled.