### PR TITLE
add augmented pdos to SupplyCapabilities

### DIFF
--- a/drivers/tildagon_power/fusb302b/fusb302b_pd.h
+++ b/drivers/tildagon_power/fusb302b/fusb302b_pd.h
@@ -75,12 +75,20 @@ typedef union
     pd_sop_prime_header_t sop_prime;
 } pd_header_union_t;
 
-/* power data objects */
+/* 
+    power data objects 
+
+    Universal Serial Bus Power Delivery Specification
+    
+    Revision: 3.2
+    Version: 1.0
+    Release date: 2023-10
+*/
 
 typedef struct
 {
-    uint32_t max_current   : 10; /* Maximum Current in 10mA units */
-    uint32_t voltage       : 10; /* Voltage in 50mV units */
+    uint32_t max_current   : 10; /* Maximum Current in 10mA increments */
+    uint32_t voltage       : 10; /* Voltage in 50mV increments */
     uint32_t peak_current  : 2;  /* Peak Current capability */
     uint32_t reserved      : 3;  /* Reserved – Shall be set to zero. */
     uint32_t dual_role     : 1;  /* Dual-Role Data */
@@ -93,19 +101,55 @@ typedef struct
 
 typedef struct 
 {
-    uint32_t max_power    : 10; /* Maximum Allowable Power in 250mW units */
-    uint32_t min_volt     : 10; /* Maximum Voltage in 50mV units */
-    uint32_t max_volt     : 10; /* Minimum Voltage in 50mV units */
+    uint32_t max_power    : 10; /* Maximum Allowable Power in 250mW increments */
+    uint32_t min_volt     : 10; /* Maximum Voltage in 50mV increments */
+    uint32_t max_volt     : 10; /* Minimum Voltage in 50mV increments */
     uint32_t pdo_type     : 2;  /* Battery == 1 */
 } pd_battery_pdo_t;
 
 typedef struct 
 {
-    uint32_t max_current : 10; /* Maximum Current in 10mA units */
-    uint32_t min_voltage : 10; /* Minimum Voltage in 50mV units */
-    uint32_t max_voltage : 10; /* Maximum Voltage in 50mV units */
-    uint32_t pdo_type     : 2; /* Variable Supply (non-Battery) == 2 */
+    uint32_t max_current : 10; /* Maximum Current in 10mA increments */
+    uint32_t min_voltage : 10; /* Minimum Voltage in 50mV increments */
+    uint32_t max_voltage : 10; /* Maximum Voltage in 50mV increments */
+    uint32_t pdo_type    :  2; /* Variable Supply (non-Battery) == 2 */
 } pd_variable_pdo_t;
+
+typedef struct
+{
+    uint32_t max_current   : 6; /* Maximum Current in 50mA increments */
+    uint32_t               : 1;
+    uint32_t min_voltage   : 8; /* Minimum Voltage in 100mV increments */
+    uint32_t               : 1;
+    uint32_t max_voltage   : 8; /* Maximum Voltage in 100mV increments */
+    uint32_t               : 2;
+    uint32_t power_limited : 1;
+    uint32_t aug_type      : 2; /* 00b SPR Programmable Power Supply */
+    uint32_t pdo_type      : 2; /* Augmented pdo == 3 */
+} pd_pps_pdo_t;
+
+typedef struct
+{
+    uint32_t pdp          : 8; /* PDP in 1W increments */
+    uint32_t min_voltage  : 8; /* Minimum Voltage in 100mV increments */ 
+    uint32_t              : 1;
+    uint32_t max_voltage  : 8; /* Maximum Voltage in 100mV increments */ 
+    uint32_t peak_current : 2; /* Peak Current (see Table 6.15 “EPR AVS Power Source Peak Current Capability”) */
+    uint32_t aug_type     : 2; /* 01b EPR Adjustable Voltage Supply */
+    uint32_t pdo_type     : 2; /* Augmented pdo == 3 */
+} pd_epr_pdo_t;
+
+typedef struct
+{
+    uint32_t max_current15_20v : 10; /* For 15V – 20V range: Maximum Current in 10mA units equal to the Maximum Current field of the 20V
+                                        Fixed Source PDO, set to 0 if the Maximum voltage in the SPR AVS range is 15V. */
+    uint32_t max_current9_15v  : 10; /* For 9V – 15V range: Maximum Current in 10mA units equal to the Maximum Current field of the 15V
+                                        Fixed Source PDO */
+    uint32_t                   : 6;
+    uint32_t peak_current      : 2;  /* Peak Current (see Table 6.10 “Fixed Power Source Peak Current Capability”) */
+    uint32_t aug_type          : 2; /* 10b SPR Adjustable Voltage Supply */
+    uint32_t pdo_type          : 2; /* Augmented pdo == 3 */
+} pd_avr_pdo_t;
 
 typedef union
 {    
@@ -114,6 +158,9 @@ typedef union
     pd_fixed_pdo_t fixed;
     pd_battery_pdo_t battery;
     pd_variable_pdo_t variable;
+    pd_pps_pdo_t spr_pps; /* standard power range programmable power supply */
+    pd_epr_pdo_t epr_avs; /* extended power range adjustable voltage supply */
+    pd_avr_pdo_t spr_avs; /* standard power range adjustable voltage supply */
 } pd_source_pdo_union_t;
 
 typedef struct 
@@ -139,6 +186,11 @@ typedef union
 #define PD_FIXED_SUPPLY 0U
 #define PD_BATTERY 1U
 #define PD_VARIABLE_SUPPLY 2U
+#define PD_AUGMENTED 3U
+#define PD_STANDARD_POWER_PROG_PSU 0U
+#define PD_EXTENDED_POWER_VOLTAGE_SUPPLY 1U
+#define PD_STANDARD_POWER_VOLTAGE_SUPPLY 2U
+
 #define PD_MAX_TX_MSG_SIZE 50 
 #define PD_VENDOR_ID 0xCDCD
 

--- a/drivers/tildagon_power/mp_power.c
+++ b/drivers/tildagon_power/mp_power.c
@@ -170,9 +170,9 @@ static mp_obj_t power_SupplyCapabilities( void )
                 {
                     mp_obj_t tuple[4];
                     tuple[0] = mp_obj_new_str( "battery", 7 );
-                    tuple[1] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.min_volt * 50 ) / 1000.0F );
-                    tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.max_volt * 50 ) / 1000.0F );
-                    tuple[3] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.max_power * 250 ) / 1000.0F );
+                    tuple[1] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.max_power * 250 ) / 1000.0F );
+                    tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.min_volt * 50 ) / 1000.0F );
+                    tuple[3] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.max_volt * 50 ) / 1000.0F );
                     mp_obj_t capability = mp_obj_new_tuple(3, tuple);
                     mp_obj_list_append(capabilities, capability);
                     break;
@@ -182,8 +182,8 @@ static mp_obj_t power_SupplyCapabilities( void )
                     mp_obj_t tuple[4];
                     tuple[0] = mp_obj_new_str( "variable", 8 );
                     tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].variable.max_current * 10 );
-                    tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].variable.max_voltage * 50 ) / 1000.0F );
-                    tuple[3] = mp_obj_new_float( ( usb_in.pd.pdos[i].variable.min_voltage * 50 ) / 1000.0F );
+                    tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].variable.min_voltage * 50 ) / 1000.0F );
+                    tuple[3] = mp_obj_new_float( ( usb_in.pd.pdos[i].variable.max_voltage * 50 ) / 1000.0F );
                     mp_obj_t capability = mp_obj_new_tuple(3, tuple);
                     mp_obj_list_append(capabilities, capability);
                     break;

--- a/drivers/tildagon_power/mp_power.c
+++ b/drivers/tildagon_power/mp_power.c
@@ -168,20 +168,22 @@ static mp_obj_t power_SupplyCapabilities( void )
                 }
                 case PD_BATTERY:
                 {
-                    mp_obj_t tuple[3];
+                    mp_obj_t tuple[4];
                     tuple[0] = mp_obj_new_str( "battery", 7 );
                     tuple[1] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.min_volt * 50 ) / 1000.0F );
                     tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.max_volt * 50 ) / 1000.0F );
+                    tuple[3] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.max_power * 250 ) / 1000.0F );
                     mp_obj_t capability = mp_obj_new_tuple(3, tuple);
                     mp_obj_list_append(capabilities, capability);
                     break;
                 }
                 case PD_VARIABLE_SUPPLY:
                 {
-                    mp_obj_t tuple[3];
+                    mp_obj_t tuple[4];
                     tuple[0] = mp_obj_new_str( "variable", 8 );
                     tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].variable.max_current * 10 );
                     tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].variable.max_voltage * 50 ) / 1000.0F );
+                    tuple[3] = mp_obj_new_float( ( usb_in.pd.pdos[i].variable.min_voltage * 50 ) / 1000.0F );
                     mp_obj_t capability = mp_obj_new_tuple(3, tuple);
                     mp_obj_list_append(capabilities, capability);
                     break;

--- a/drivers/tildagon_power/mp_power.c
+++ b/drivers/tildagon_power/mp_power.c
@@ -153,11 +153,12 @@ static mp_obj_t power_SupplyCapabilities( void )
     {
         for ( uint8_t i = 0; i < usb_in.pd.number_of_pdos; i++ )
         {
-            mp_obj_t tuple[3];
+            
             switch ( usb_in.pd.pdos[i].fixed.pdo_type )
             {
-                case 0: /* fixed supply */
+                case PD_FIXED_SUPPLY:
                 {
+                    mp_obj_t tuple[3];
                     tuple[0] = mp_obj_new_str( "fixed", 5 );
                     tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].fixed.max_current * 10 );
                     tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].fixed.voltage * 50 ) / 1000.0F );
@@ -165,8 +166,9 @@ static mp_obj_t power_SupplyCapabilities( void )
                     mp_obj_list_append(capabilities, capability);
                     break;
                 }
-                case 1: /* battery */
+                case PD_BATTERY:
                 {
+                    mp_obj_t tuple[3];
                     tuple[0] = mp_obj_new_str( "battery", 7 );
                     tuple[1] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.min_volt * 50 ) / 1000.0F );
                     tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].battery.max_volt * 50 ) / 1000.0F );
@@ -174,14 +176,60 @@ static mp_obj_t power_SupplyCapabilities( void )
                     mp_obj_list_append(capabilities, capability);
                     break;
                 }
-                case 2: /* non battery variable supply */
+                case PD_VARIABLE_SUPPLY:
                 {
+                    mp_obj_t tuple[3];
                     tuple[0] = mp_obj_new_str( "variable", 8 );
                     tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].variable.max_current * 10 );
                     tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].variable.max_voltage * 50 ) / 1000.0F );
                     mp_obj_t capability = mp_obj_new_tuple(3, tuple);
                     mp_obj_list_append(capabilities, capability);
                     break;
+                }
+                case PD_AUGMENTED:
+                {
+                    switch( usb_in.pd.pdos[i].spr_pps.aug_type )
+                    {
+                        case PD_STANDARD_POWER_PROG_PSU:
+                        {
+                            mp_obj_t tuple[5];
+                            tuple[0] = mp_obj_new_str( "Prog PSU", 8 );
+                            tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].spr_pps.max_current * 50 );
+                            tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].spr_pps.min_voltage * 100 ) / 1000.0F );
+                            tuple[3] = mp_obj_new_float( ( usb_in.pd.pdos[i].spr_pps.max_voltage * 100 ) / 1000.0F );
+                            tuple[4] = mp_obj_new_bool( usb_in.pd.pdos[i].spr_pps.power_limited );
+                            mp_obj_t capability = mp_obj_new_tuple(5, tuple);
+                            mp_obj_list_append(capabilities, capability);
+                            break;
+                        }
+                        case PD_EXTENDED_POWER_VOLTAGE_SUPPLY:
+                        {
+                            mp_obj_t tuple[5];
+                            tuple[0] = mp_obj_new_str( "EPR Adj V", 9 );
+                            tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].epr_avs.pdp );
+                            tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].epr_avs.min_voltage * 100 ) / 1000.0F );
+                            tuple[3] = mp_obj_new_float( ( usb_in.pd.pdos[i].epr_avs.max_voltage * 100 ) / 1000.0F );
+                            tuple[4] = mp_obj_new_int( usb_in.pd.pdos[i].epr_avs.peak_current );
+                            mp_obj_t capability = mp_obj_new_tuple(5, tuple);
+                            mp_obj_list_append(capabilities, capability);
+                            break;
+                        }
+                        case PD_STANDARD_POWER_VOLTAGE_SUPPLY:
+                        {
+                            mp_obj_t tuple[4];
+                            tuple[0] = mp_obj_new_str( "SPR Adj V", 9 );
+                            tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].spr_avs.max_current15_20v * 10 );
+                            tuple[2] = mp_obj_new_int( usb_in.pd.pdos[i].spr_avs.max_current9_15v *10 );
+                            tuple[3] = mp_obj_new_int( usb_in.pd.pdos[i].spr_avs.peak_current );
+                            mp_obj_t capability = mp_obj_new_tuple(5, tuple);
+                            mp_obj_list_append(capabilities, capability);
+                            break;
+                        }
+                        default:
+                        {
+                            break;
+                        }
+                    }
                 }
                 default:
                 {
@@ -209,7 +257,7 @@ static mp_obj_t power_SupplyCapabilities( void )
             mp_obj_t tuple[3];
             tuple[0] = mp_obj_new_str( "disconnected", 12 );
             tuple[1] = mp_obj_new_int( 0 );
-            tuple[2] = mp_obj_new_int( 0 );
+            tuple[2] = mp_obj_new_float( 0.0F );
             mp_obj_t capability = mp_obj_new_tuple(3, tuple);
             mp_obj_list_append(capabilities, capability);
         }

--- a/drivers/tildagon_power/mp_power.c
+++ b/drivers/tildagon_power/mp_power.c
@@ -208,10 +208,10 @@ static mp_obj_t power_SupplyCapabilities( void )
                         {
                             mp_obj_t tuple[5];
                             tuple[0] = mp_obj_new_str( "EPR Adj V", 9 );
-                            tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].epr_avs.pdp );
+                            tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].epr_avs.peak_current );
                             tuple[2] = mp_obj_new_float( ( usb_in.pd.pdos[i].epr_avs.min_voltage * 100 ) / 1000.0F );
                             tuple[3] = mp_obj_new_float( ( usb_in.pd.pdos[i].epr_avs.max_voltage * 100 ) / 1000.0F );
-                            tuple[4] = mp_obj_new_int( usb_in.pd.pdos[i].epr_avs.peak_current );
+                            tuple[4] = mp_obj_new_int( usb_in.pd.pdos[i].epr_avs.pdp );
                             mp_obj_t capability = mp_obj_new_tuple(5, tuple);
                             mp_obj_list_append(capabilities, capability);
                             break;
@@ -220,9 +220,9 @@ static mp_obj_t power_SupplyCapabilities( void )
                         {
                             mp_obj_t tuple[4];
                             tuple[0] = mp_obj_new_str( "SPR Adj V", 9 );
-                            tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].spr_avs.max_current15_20v * 10 );
-                            tuple[2] = mp_obj_new_int( usb_in.pd.pdos[i].spr_avs.max_current9_15v *10 );
-                            tuple[3] = mp_obj_new_int( usb_in.pd.pdos[i].spr_avs.peak_current );
+                            tuple[1] = mp_obj_new_int( usb_in.pd.pdos[i].spr_avs.peak_current );
+                            tuple[2] = mp_obj_new_int( usb_in.pd.pdos[i].spr_avs.max_current15_20v * 10 );
+                            tuple[3] = mp_obj_new_int( usb_in.pd.pdos[i].spr_avs.max_current9_15v *10 );
                             mp_obj_t capability = mp_obj_new_tuple(5, tuple);
                             mp_obj_list_append(capabilities, capability);
                             break;


### PR DESCRIPTION
# Description

decode the 3 augmented pdos and add to power.SupplyCapabilities(). These are: 
standard power range programmable power supply
extended power range adjustable voltage supply
standard power range adjustable voltage supply

I'll need to update the Docs to go with this as the content in the tuples depends on what pdo it is.