### PR TITLE
Include aioespnow in manifest.py

### DIFF
--- a/tildagon/manifest.py
+++ b/tildagon/manifest.py
@@ -57,5 +57,6 @@ require("mip")
 
 require("aioble")
 require("aiorepl")
+require("aioespnow")
 require("gzip")
 require("tarfile")


### PR DESCRIPTION
While writing some PoCs around inter-Tildagon communication (tildacomms?) (using [`espnow`](https://docs.micropython.org/en/latest/library/espnow.html)) with the aim to update the docs with help on it (applications include multiplayer games, messaging other Tildagons, you name it), a blocker that keeps coming up is `espnow`'s blocking nature. It is not `asyncio`-compatible. Luckily they've made `aioespnow`, an `asyncio`-compatible implementation.

> From the linked docs above: _ESP-NOW a connection-less protocol for wireless communication between <20 peers without the need for an AP. aioespnow is an asyncio-compatible implementation of espnow._
> 
> aioespnow has many applications for inter-badge communication, where the classic espnow module falls short with its blocking nature.

This PR is to add `aioespnow` to the `manifest.py` of the Tildagon.