### PR TITLE
Add events for common keyboard buttons

### DIFF
--- a/modules/app_components/dialog.py
+++ b/modules/app_components/dialog.py
@@ -2,6 +2,7 @@ import asyncio
 
 import display
 from events.input import BUTTON_TYPES, ButtonDownEvent
+from events.keyboard import KEYBOARD_BUTTONS
 from system.eventbus import eventbus
 
 from .tokens import button_labels, label_font_size, set_color
@@ -182,6 +183,9 @@ class TextDialog:
 
     def _handle_buttondown(self, event: ButtonDownEvent):
         key = -1
+        final = None
+
+        kbd_button = event.button.find_parent_in_group('Keyboard')
 
         if BUTTON_TYPES["UP"] in event.button:
             key = 0
@@ -196,12 +200,39 @@ class TextDialog:
         elif BUTTON_TYPES["CONFIRM"] in event.button:
             key = 2
 
+        elif kbd_button is not None:
+            if KEYBOARD_BUTTONS["SHIFT"] in event.button:
+                key = -2
+                final = SPECIAL_KEY_SHIFT
+            elif KEYBOARD_BUTTONS["DELETE"] in event.button:
+                key = -2
+                final = SPECIAL_KEY_BACKSPACE
+            elif KEYBOARD_BUTTONS["SPACE"] in event.button:
+                key = -2
+                final = SPECIAL_KEY_SPACE
+            elif kbd_button.name in UPPERCASE_ALPHABET:
+                # This is a letter
+                if self._current_alphabet == UPPERCASE_ALPHABET:
+                    key = -2
+                    final = kbd_button.name
+                else:
+                    key = -2
+                    final = kbd_button.name.lower()
+            elif kbd_button.name in SYMBOL_ALPHABET:
+                key = -2
+                final = kbd_button.name
+
         if key == -1:
             return
 
-        selected = self._keys[key]
-        if len(selected) == 1:
-            selected = self._keys[key][0]
+        if key >= 0:
+            selected = self._keys[key]
+            if len(selected) == 1:
+                final = self._keys[key][0]
+
+        if final:
+            selected = final
+            final = None
 
             if selected == SPECIAL_KEY_SPACE:
                 selected = " "

--- a/modules/events/input.py
+++ b/modules/events/input.py
@@ -26,6 +26,8 @@ class Button:
         return self.name == other.name and self.group == other.group
 
     def __contains__(self, other):
+        if other == self:
+            return True
         parent = self.parent
         while parent is not None:
             if other == parent:
@@ -34,6 +36,16 @@ class Button:
                 parent = parent.parent
         return False
 
+    def find_parent_in_group(self, group):
+        if self.group == group:
+            return self
+        parent = self.parent
+        while parent is not None:
+            if parent.group == group:
+                return parent
+            else:
+                parent = parent.parent
+        return None
 
 BUTTON_TYPES = {
     "UNDEFINED": Button("UNDEFINED", "System"),

--- a/modules/events/keyboard.py
+++ b/modules/events/keyboard.py
@@ -1,0 +1,30 @@
+
+from .input import Button, BUTTON_TYPES
+
+letters = {
+    letter: Button(letter, "Keyboard") for letter in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+}
+
+numbers = {
+    number: Button(number, "Keyboard") for number in '0123456789'
+}
+
+symbols = {
+    symbol: Button(symbol, "Keyboard") for symbol in '''!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'''
+}
+
+modifiers = {
+    "SPACE": Button("SPACE", "Keyboard"),
+    "SHIFT": Button("SHIFT", "Keyboard"),
+    "CTRL": Button("CTRL", "Keyboard"),
+    "ALT": Button("ALT", "Keyboard"),
+    "ESCAPE": Button("ESCAPE", "Keyboard", BUTTON_TYPES["CANCEL"]),
+    "DELETE": Button("DELETE", "Keyboard"),
+    "ENTER": Button("ENTER", "Keyboard", BUTTON_TYPES["CONFIRM"]),
+    "UP": Button("UP", "Keyboard", BUTTON_TYPES["UP"]),
+    "DOWN": Button("DOWN", "Keyboard", BUTTON_TYPES["DOWN"]),
+    "LEFT": Button("LEFT", "Keyboard", BUTTON_TYPES["LEFT"]),
+    "RIGHT": Button("RIGHT", "Keyboard", BUTTON_TYPES["RIGHT"]),
+}
+
+KEYBOARD_BUTTONS = letters | numbers | symbols | modifiers


### PR DESCRIPTION
# Description
I expect that there will be a number of Hexpansions that handle some form of text input. This adds common keyboard buttons to the list of inputs known by the firmware, and updates the text entry dialogue to accept them.
