### PR TITLE
Use pattern brightness on OTA progress display

### DIFF
--- a/modules/system/ota/ota.py
+++ b/modules/system/ota/ota.py
@@ -259,6 +259,7 @@ class OtaUpdate(App):
         global last_update
         current_time = utime.ticks_ms()
 
+        brightness = settings.get("pattern_brightness", 0.1)
         if utime.ticks_diff(current_time, last_update) >= 1000:
             last_update = current_time
 
@@ -273,6 +274,11 @@ class OtaUpdate(App):
                     )  # Gradient color
                 else:
                     tildagonos.leds[i] = (255, 0, 0)  # Set to red
+
+                if brightness < 1.0:
+                    tildagonos.leds[i] = tuple(
+                        int(j * brightness) for j in tildagonos.leds[i]
+                    )
             tildagonos.leds.write()
 
         return True


### PR DESCRIPTION
# Description

Pull the current configured pattern brightness and apply it to the OTA progress indicator, to avoid the lights looking surprisingly bright during updates.
