### PR TITLE
Improvements to background functionality reliability

### DIFF
--- a/modules/app_components/background.py
+++ b/modules/app_components/background.py
@@ -49,7 +49,16 @@ class _Background:
     def draw(self, ctx):
         if self.runner:
             ctx.save()
-            self.runner.draw(ctx)
+            try:
+                self.runner.draw(ctx)
+            except Exception as e:
+                print(f"Error creating background: {e}")
+                eventbus.emit(
+                    ShowNotificationEvent(
+                        message=f"Background {self.selection[0]} has crashed"
+                    )
+                )
+                self.runner = None
             ctx.restore()
         else:
             clear_background(ctx)

--- a/modules/firmware_apps/settings_app.py
+++ b/modules/firmware_apps/settings_app.py
@@ -8,6 +8,7 @@ from system.eventbus import eventbus
 from system.patterndisplay.events import PatternReload
 from app_components.background import Background as bg
 from system.launcher.app import load_info
+from system.scheduler.events import RequestForegroundPushEvent
 
 BG_DIR = "/backgrounds"
 
@@ -56,6 +57,12 @@ class SettingsApp(app.App):
         self.layout = layout.LinearLayout(items=[layout.DefinitionDisplay("", "")])
         self.overlays = []
         self.dialog = None
+        self.load_background_options()
+        self.ctx = None
+        eventbus.on_async(ButtonDownEvent, self._button_handler, self)
+        eventbus.on(RequestForegroundPushEvent, self.load_background_options, self)
+
+    def load_background_options(self, event=None):
         self.backgrounds = [("None", None), ("hexagons", None), ("emf logo", None)]
         try:
             contents = os.listdir(BG_DIR)
@@ -72,9 +79,6 @@ class SettingsApp(app.App):
             if "name" in metadata:
                 name = metadata["name"]
             self.backgrounds.append((name, path))
-        self.ctx = None
-        eventbus.on_async(ButtonDownEvent, self._button_handler, self)
-        # eventbus.on(RequestForegroundPushEvent, self.make_layout_children, self)
 
     async def string_editor(self, label, id, render_update):
         self.dialog = TextDialog(label, self)


### PR DESCRIPTION
# Description

This makes two improvements to the background functionality:

1. The settings app re-scans for backgrounds when it's foregrounded. Without this, if a user has already opened the settings app since boot, new backgrounds won't be added after installation until rebooping
2. Add crash handling code around the background draw method, so crashes here are contained to the background runner, rather than bringing down the launcher