### PR TITLE
Improve settings app performance

### DIFF
--- a/modules/app_components/utils.py
+++ b/modules/app_components/utils.py
@@ -1,6 +1,8 @@
 from os import stat
+import micropython
 
 
+@micropython.native
 def fill_line(ctx, text, font_size, width_for_line):
     ctx.save()
     ctx.font_size = font_size
@@ -29,6 +31,7 @@ def fill_line(ctx, text, font_size, width_for_line):
     return lines
 
 
+@micropython.native
 def wrap_text(ctx, text, font_size=None, width=None):
     if width is None:
         width = 240

--- a/modules/firmware_apps/settings_app.py
+++ b/modules/firmware_apps/settings_app.py
@@ -111,7 +111,7 @@ class SettingsApp(app.App):
             self.layout.items = []
             for id, label, formatter, editor in self.settings_options():
                 value = settings.get(id)
-                print(editor)
+
                 if editor:
 
                     async def _button_event(event, label=label, id=id, editor=editor):
@@ -220,8 +220,8 @@ class SettingsApp(app.App):
                 await render_update()
                 current_time = time.ticks_ms()
                 self.update(current_time - previous_time)
-                if self.ctx:
-                    self.draw(self.ctx)
+                # if self.ctx:
+                #    self.draw(self.ctx)
                 if self.dialog:
                     result = await self.dialog.run(render_update)
                     if (

--- a/modules/system/scheduler/__init__.py
+++ b/modules/system/scheduler/__init__.py
@@ -227,7 +227,8 @@ class _Scheduler:
                                 )
                             )
                         ctx.restore()
-                display.end_frame(ctx)
+                with PerfTimer("End frame"):
+                    display.end_frame(ctx)
             await asyncio.sleep(0)
 
     async def _main(self):

--- a/sim/fakes/micropython.py
+++ b/sim/fakes/micropython.py
@@ -1,0 +1,2 @@
+def native(func):
+    return func


### PR DESCRIPTION

# Description

Improve reliability of the settings app by:

1. Remove extraneous draw call
2. Use micropython optimisation decorator on word wrap util function
3. Avoid calling draw() method for items that will be out of the clip region

