### PR TITLE
Add Emote events

### DIFF
--- a/modules/app_components/background.py
+++ b/modules/app_components/background.py
@@ -1,4 +1,5 @@
 import settings
+from events.emote import EmoteNegativeEvent
 from system.backgrounds.emflogo import EmfLogo
 from system.backgrounds.wigglinghexagons import WigglingHexagons
 from system.eventbus import eventbus
@@ -38,6 +39,7 @@ class _Background:
                             message=f"Background {self.selection[0]} has crashed"
                         )
                     )
+                    eventbus.emit(EmoteNegativeEvent())
                     self.runner = None
             else:
                 print("path not a file: " + path)
@@ -58,6 +60,7 @@ class _Background:
                         message=f"Background {self.selection[0]} has crashed"
                     )
                 )
+                eventbus.emit(EmoteNegativeEvent())
                 self.runner = None
             ctx.restore()
         else:

--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -17,6 +17,7 @@ import machine
 from app_components import Menu, fourteen_pt, sixteen_pt, ten_pt, seven_pt
 from app_components.tokens import set_color
 from events.input import ButtonDownEvent
+from events.emote import EmoteNegativeEvent, EmotePositiveEvent
 from frontboards.common import FRONTBOARD_BUTTON_TYPES
 from requests import get
 from system.eventbus import eventbus
@@ -161,11 +162,13 @@ class AppStoreApp(app.App):
             self.update_state("main_menu")
             eventbus.emit(InstallNotificationEvent())
             eventbus.emit(ShowNotificationEvent("Installed the app!"))
+            eventbus.emit(EmotePositiveEvent())
         except MemoryError:
             self.update_state("install_oom")
         except Exception as e:
             print(e)
             eventbus.emit(ShowNotificationEvent("Couldn't install app"))
+            eventbus.emit(EmoteNegativeEvent())
             self.update_state("main_menu")
 
     def update_state(self, state):

--- a/modules/firmware_apps/settings_app.py
+++ b/modules/firmware_apps/settings_app.py
@@ -224,6 +224,25 @@ class SettingsApp(app.App):
                     )
                     self.layout.items.append(entry)
 
+                if id == "backleds_emotes":
+
+                    async def _button_event_backleds_emotes_toggle(event):
+                        if BUTTON_TYPES["CONFIRM"] in event.button:
+                            backleds_emotes = settings.get("backleds_emotes", True)
+
+                            backleds_emotes = not backleds_emotes
+
+                            settings.set("backleds_emotes", backleds_emotes)
+                            await self.update_values()
+                            await render_update()
+                            return True
+                        return False
+
+                    entry = layout.ButtonDisplay(
+                        "Toggle", button_handler=_button_event_backleds_emotes_toggle
+                    )
+                    self.layout.items.append(entry)
+
                 if id == "update_channel":
 
                     async def _button_event_channel_toggle(event):
@@ -308,6 +327,7 @@ class SettingsApp(app.App):
             ("pattern", "LED Pattern", tuple_formatter, None),
             ("pattern_brightness", "Pattern brightness", pct_formatter, None),
             ("pattern_mirror_hexpansions", "Mirror pattern", on_off_formatter, None),
+            ("backleds_emotes", "Flash emotes on backleds", on_off_formatter, None),
             ("background", "Background", tuple_formatter, None),
             ("update_channel", "Update channel", string_formatter, None),
             ("wifi_tx_power", "WiFi TX power", string_formatter, None),

--- a/modules/main.py
+++ b/modules/main.py
@@ -5,6 +5,7 @@ import wifi
 from system.scheduler import scheduler
 from system.hexpansion.app import HexpansionManagerApp
 from system.patterndisplay.app import PatternDisplay
+from system.backleds.app import BackLEDManager
 from system.notification.app import NotificationService
 from system.launcher.app import Launcher
 from system.power.handler import PowerEventHandler
@@ -31,8 +32,11 @@ else:
 # Start expansion interface
 scheduler.start_app(HexpansionManagerApp())
 
-# Start led pattern displayer app
+# Start front led pattern displayer app
 scheduler.start_app(PatternDisplay())
+
+# Start back led manager
+scheduler.start_app(BackLEDManager())
 
 # Start root app
 scheduler.start_app(Launcher(), foreground=True)

--- a/modules/system/backleds/app.py
+++ b/modules/system/backleds/app.py
@@ -21,10 +21,14 @@ class BackLEDManager(App):
         tildagonos.set_led_power(True)
         eventbus.on_async(HexpansionInsertionEvent, self.handle_insertion, self)
         eventbus.on_async(HexpansionRemovalEvent, self.handle_removal, self)
+
         eventbus.on_async(EmotePositiveEvent, self.handle_positive, self)
         eventbus.on_async(EmoteNegativeEvent, self.handle_negative, self)
 
     async def handle_positive(self, event):
+        if not settings.get("backleds_emotes", True):
+            return
+
         await self.lock.acquire()
         try:
             for brightness in [1, 16, 64, 255, 64, 16, 1, 0]:
@@ -36,6 +40,9 @@ class BackLEDManager(App):
             self.lock.release()
 
     async def handle_negative(self, event):
+        if not settings.get("backleds_emotes", True):
+            return
+
         await self.lock.acquire()
         try:
             for brightness in [1, 16, 64, 255, 64, 16, 1, 0]:

--- a/modules/system/backleds/app.py
+++ b/modules/system/backleds/app.py
@@ -1,6 +1,8 @@
+import asyncio
 import settings
 
 from app import App
+from events.emote import EmotePositiveEvent, EmoteNegativeEvent
 from system.eventbus import eventbus
 from system.hexpansion.events import HexpansionInsertionEvent, HexpansionRemovalEvent
 from tildagonos import tildagonos, led_colours
@@ -13,9 +15,36 @@ active_back_leds = [False] * 6
 
 class BackLEDManager(App):
     def __init__(self):
+        # routines that want to drive the back leds themselves for
+        # a notification should take this lock.
+        self.lock = asyncio.Lock()
         tildagonos.set_led_power(True)
         eventbus.on_async(HexpansionInsertionEvent, self.handle_insertion, self)
         eventbus.on_async(HexpansionRemovalEvent, self.handle_removal, self)
+        eventbus.on_async(EmotePositiveEvent, self.handle_positive, self)
+        eventbus.on_async(EmoteNegativeEvent, self.handle_negative, self)
+
+    async def handle_positive(self, event):
+        await self.lock.acquire()
+        try:
+            for brightness in [1, 16, 64, 255, 64, 16, 1, 0]:
+                for lednum in range(13, 19):
+                    tildagonos.leds[lednum] = (0, brightness, 0)
+                tildagonos.leds.write()
+                await asyncio.sleep(0.05)
+        finally:
+            self.lock.release()
+
+    async def handle_negative(self, event):
+        await self.lock.acquire()
+        try:
+            for brightness in [1, 16, 64, 255, 64, 16, 1, 0]:
+                for lednum in range(13, 19):
+                    tildagonos.leds[lednum] = (brightness, 0, 0)
+                tildagonos.leds.write()
+                await asyncio.sleep(0.05)
+        finally:
+            self.lock.release()
 
     async def handle_insertion(self, event):
         active_back_leds[event.port - 1] = True
@@ -24,6 +53,9 @@ class BackLEDManager(App):
         active_back_leds[event.port - 1] = False
 
     def background_update(self, delta):
+        if self.lock.locked():  # e.g. if emotes are being displayed
+            return
+
         for i in range(0, 6):
             if active_back_leds[i]:
                 if settings.get("pattern_mirror_hexpansions", False):

--- a/modules/system/backleds/app.py
+++ b/modules/system/backleds/app.py
@@ -1,0 +1,35 @@
+import settings
+
+from app import App
+from system.eventbus import eventbus
+from system.hexpansion.events import HexpansionInsertionEvent, HexpansionRemovalEvent
+from tildagonos import tildagonos, led_colours
+
+# note that event.port is indexed from 1-6,
+# hexpansion style, but this list is indexed from 0-5,
+# Python style.
+active_back_leds = [False] * 6
+
+
+class BackLEDManager(App):
+    def __init__(self):
+        tildagonos.set_led_power(True)
+        eventbus.on_async(HexpansionInsertionEvent, self.handle_insertion, self)
+        eventbus.on_async(HexpansionRemovalEvent, self.handle_removal, self)
+
+    async def handle_insertion(self, event):
+        active_back_leds[event.port - 1] = True
+
+    async def handle_removal(self, event):
+        active_back_leds[event.port - 1] = False
+
+    def background_update(self, delta):
+        for i in range(0, 6):
+            if active_back_leds[i]:
+                if settings.get("pattern_mirror_hexpansions", False):
+                    tildagonos.leds[13 + i] = tildagonos.leds[1 + (i * 2)]
+                else:
+                    tildagonos.leds[13 + i] = led_colours[i]
+            else:
+                tildagonos.leds[13 + i] = (0, 0, 0)
+        tildagonos.leds.write()

--- a/modules/system/hexpansion/app.py
+++ b/modules/system/hexpansion/app.py
@@ -23,8 +23,6 @@ from system.scheduler.events import (
     RequestStopAppEvent,
 )
 from tildagonos import EPIN_ND_A, EPIN_ND_B, EPIN_ND_C, EPIN_ND_D, EPIN_ND_E, EPIN_ND_F
-from tildagonos import led_colours
-from tildagonos import tildagonos
 from egpio import ePin
 from system.eventbus import eventbus
 from machine import I2C
@@ -32,29 +30,18 @@ from events.input import Buttons
 import asyncio
 import vfs
 import sys
-import settings
-
-
-active_back_leds = [False] * 6
 
 
 def Hexspansion_inserted(epin):
     for i, nPin in enumerate(HexpansionManagerApp.hexpansion_pins):
         if nPin is epin:
-            if not settings.get("pattern_mirror_hexpansions", False):
-                tildagonos.leds[13 + i] = led_colours[i]
-            active_back_leds[i] = True
             eventbus.emit(HexpansionInsertionEvent(port=i + 1))
-            tildagonos.leds.write()
 
 
 def Hexspansion_removed(epin):
     for i, nPin in enumerate(HexpansionManagerApp.hexpansion_pins):
         if nPin is epin:
-            tildagonos.leds[13 + i] = (0, 0, 0)
-            active_back_leds[i] = False
             eventbus.emit(HexpansionRemovalEvent(port=i + 1))
-            tildagonos.leds.write()
 
 
 class HexpansionManagerApp(app.App):
@@ -83,17 +70,12 @@ class HexpansionManagerApp(app.App):
         self.hexpansion_apps = {}
         self.hexpansion_headers = {}
         self.autolaunch = autolaunch
-        tildagonos.set_led_power(True)
 
         for i, pin in enumerate(HexpansionManagerApp.hexpansion_pins):
             pin.irq(handler=Hexspansion_inserted, trigger=pin.IRQ_FALLING)
             pin.irq(handler=Hexspansion_removed, trigger=pin.IRQ_RISING)
             if not pin.value():
-                if not settings.get("pattern_mirror_hexpansions", False):
-                    tildagonos.leds[13 + i] = led_colours[i]
-                active_back_leds[i] = True
                 eventbus.emit(HexpansionInsertionEvent(port=i + 1))
-        tildagonos.leds.write()
 
     def update(self, delta):
         if len(self.format_requests) > 0 and self.format_dialog is None:
@@ -121,15 +103,6 @@ class HexpansionManagerApp(app.App):
 
             eventbus.emit(RequestForegroundPushEvent(self))
             return True
-
-    def background_update(self, delta):
-        if settings.get("pattern_mirror_hexpansions", False):
-            for i in range(0, 6):
-                if active_back_leds[i]:
-                    tildagonos.leds[13 + i] = tildagonos.leds[1 + (i * 2)]
-                else:
-                    tildagonos.leds[13 + i] = (0, 0, 0)
-            tildagonos.leds.write()
 
     def draw(self, ctx):
         if self.format_dialog is not None:

--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -8,6 +8,7 @@ from app_components.menu import Menu
 from perf_timer import PerfTimer
 from system.eventbus import eventbus
 from events import Event
+from events.emote import EmoteNegativeEvent
 from system.scheduler.events import (
     RequestForegroundPushEvent,
     RequestStartAppEvent,
@@ -161,6 +162,7 @@ class Launcher(App):
                 eventbus.emit(
                     ShowNotificationEvent(message=f"{item['name']} has crashed")
                 )
+                eventbus.emit(EmoteNegativeEvent())
                 return
             self._apps[app_id] = app
             eventbus.emit(RequestStartAppEvent(app, foreground=True))

--- a/modules/system/scheduler/__init__.py
+++ b/modules/system/scheduler/__init__.py
@@ -3,6 +3,7 @@ import display
 import sys
 import time
 
+from events.emote import EmoteNegativeEvent
 from system.a11y.events import ReplaceAccessibiltiyHandlerEvent
 from perf_timer import PerfTimer
 from system.a11y import printer
@@ -194,6 +195,7 @@ class _Scheduler:
                         message=f"{app.__class__.__name__} has crashed"
                     )
                 )
+                eventbus.emit(EmoteNegativeEvent())
 
         self.update_tasks[app] = asyncio.create_task(app_wrapper())
 
@@ -234,6 +236,7 @@ class _Scheduler:
                                     message=f"{app.__class__.__name__} has crashed"
                                 )
                             )
+                            eventbus.emit(EmoteNegativeEvent())
                         ctx.restore()
                 display.end_frame(ctx)
                 if ctx.a11y:


### PR DESCRIPTION
# Description

These are intended for foreground apps to signal to other components (for example hexpansion drivers) that something interesting, good or bad, happened in the user interface, so that the other component can present that in its own way to the user.

This PR has three commits:

* base event definitions in events.emote
* modifications to app store and sponsors to make some emotes
* an example emote driver that flashes the back LEDs when an emote happens.

The app and driver commits are more for discussion about what any default emote behaviour should be rather than immediate merge.

I will also open a separate PR with only the event definitions, intended for actual merge.
        
Guidelines for use:
    
Only send emotes when you are the foreground app: these events are intended to be UI output like writing to the screen is.
    
Send at most a handful of emotes per minute. These events might generate relatively long behaviours on the order of
a few seconds, for example playing a short jingle on an audio hexpansion.
