### PR TITLE
Remove duplicate eventbus

### DIFF
--- a/modules/system/eventbus.py
+++ b/modules/system/eventbus.py
@@ -104,4 +104,3 @@ class _EventBus:
 
 
 eventbus = _EventBus()
-eventbus = _EventBus()


### PR DESCRIPTION
I'm fairly certain this was a bad merge as it was introduced without commentary in c55cde73 which had other bad merge in the same source file.