### PR TITLE
Performance fixes for core UI menus

### DIFF
--- a/modules/app_components/layout.py
+++ b/modules/app_components/layout.py
@@ -80,9 +80,25 @@ class ButtonDisplay(Layoutable):
 class DefinitionDisplay(Layoutable):
     def __init__(self, label, value, button_handler=None):
         self.label = label
-        self.value = value
+        self._value = value
+        self._label_lines = None
+        self._label_widths = None
+        self._label_height = 0
+        self._value_lines = None
+        self._value_widths = None
+        self._value_height = 0
         self.height = 0
         self.button_handler = button_handler
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, v):
+        self._value = v
+        self._value_lines = None
+        self._value_widths = None
 
     async def button_event(self, event):
         if self.button_handler:
@@ -91,34 +107,45 @@ class DefinitionDisplay(Layoutable):
 
     def draw(self, ctx, focused=False):
         ctx.save()
-        self.height = 0
-
-        # Draw heading
-        ctx.font_size = tokens.one_pt * 8
         ctx.text_align = ctx.LEFT
+
+        # Pre-compute label line geometry (happens once)
+        if self._label_lines is None:
+            ctx.font_size = tokens.one_pt * 8
+            self._label_lines = utils.wrap_text(ctx, self.label, tokens.label_font_size)
+            self._label_widths = [ctx.text_width(line) for line in self._label_lines]
+            self._label_height = len(self._label_lines) * ctx.font_size
+
+        # Pre-compute value line geometry (happens each time a value changes)
+        if self._value_lines is None:
+            ctx.font_size = tokens.ten_pt
+            self._value_lines = utils.wrap_text(
+                ctx, self._value, tokens.label_font_size, 230
+            )
+            self._value_widths = [ctx.text_width(line) for line in self._value_lines]
+            self._value_height = len(self._value_lines) * ctx.font_size
+
+        self.height = self._label_height + self._value_height
+
+        # Draw label
+        ctx.font_size = tokens.one_pt * 8
         if focused:
             ctx.rgb(*tokens.colors["orange"])
         else:
             ctx.rgb(*tokens.colors["yellow"])
-
-        # Draw label
-        label_lines = utils.wrap_text(ctx, self.label, tokens.label_font_size)
-        for line in label_lines:
-            width = ctx.text_width(line)
-            ctx.move_to(115 - width / 2, self.height)
+        y = 0
+        for line, width in zip(self._label_lines, self._label_widths):
+            ctx.move_to(115 - width / 2, y)
             ctx.text(line)
-            self.height += ctx.font_size
-
-        ctx.rgb(*tokens.ui_colors["label"])
+            y += tokens.one_pt * 8
 
         # Draw value
+        ctx.rgb(*tokens.ui_colors["label"])
         ctx.font_size = tokens.ten_pt
-        value_lines = utils.wrap_text(ctx, self.value, tokens.label_font_size, 230)
-        for line in value_lines:
-            width = ctx.text_width(line)
-            ctx.move_to(115 - width / 2, self.height)
+        for line, width in zip(self._value_lines, self._value_widths):
+            ctx.move_to(115 - width / 2, y)
             ctx.text(line)
-            self.height += ctx.font_size
+            y += tokens.ten_pt
 
         ctx.restore()
 
@@ -146,19 +173,35 @@ class LinearLayout(Layoutable):
         ctx.scale(self.scale_factor, self.scale_factor)
         ctx.translate(12, 0)
 
-        # Draw each item in turn
+        # Draw each item in turn, skipping any that cannot be visible
+        above_threshold = -self.y_offset / self.scale_factor
+        below_threshold = (240 - self.y_offset) / self.scale_factor
+
+        cumulative_y = 0
         for item in self.items:
-            item.draw(ctx, focused=item == focused_child)
-            ctx.translate(0, item.height)
-            self.height += item.height
+            item_height = item.height
+            if item_height > 0 and (
+                cumulative_y + item_height < above_threshold
+                or cumulative_y > below_threshold
+            ):
+                # Off-screen: skip drawing but maintain layout position
+                ctx.translate(0, item_height)
+                self.height += item_height
+                cumulative_y += item_height
+            else:
+                item.draw(ctx, focused=item == focused_child)
+                ctx.translate(0, item.height)
+                self.height += item.height
+                cumulative_y += item.height
 
         ctx.restore()
 
     def centred_component(self):
         cumulative_height = 0
+        threshold = round(120 - self.y_offset)
         for item in self.items:
             cumulative_height += item.height * self.scale_factor
-            if round(cumulative_height) > round(120 - self.y_offset):
+            if round(cumulative_height) > threshold:
                 return item
         return self.items[0]
 

--- a/modules/app_components/menu.py
+++ b/modules/app_components/menu.py
@@ -141,63 +141,52 @@ class Menu:
         else:
             # calculate biggest font size a menu item should grow to
             if not self.focused_item_font_size_arr:
-                for item in self.menu_items:
-                    fs = self._calculate_max_focussed_font_size(item, ctx)
-                    self.focused_item_font_size_arr = (
-                        self.focused_item_font_size_arr + [fs]
-                    )
+                self.focused_item_font_size_arr = [
+                    self._calculate_max_focussed_font_size(item, ctx)
+                    for item in self.menu_items
+                ]
 
-            animation_progress = ease_out_quart(self.animation_time_ms / self.speed_ms)
-            animation_direction = 1 if self.is_animating == "up" else -1
+            if self.is_animating == "none":
+                animation_progress = 1.0
+                y_offset = 0
+            else:
+                animation_progress = ease_out_quart(
+                    self.animation_time_ms / self.speed_ms
+                )
+                animation_direction = 1 if self.is_animating == "up" else -1
+                y_offset = animation_direction * 30 * (animation_progress - 1)
 
             ctx.text_align = ctx.CENTER
             ctx.text_baseline = ctx.MIDDLE
 
             set_color(ctx, "label")
             num_menu_items = len(self.menu_items)
+            pos = self.position % num_menu_items if num_menu_items > 0 else 0
 
             # Current menu item
             ctx.font_size = self.item_font_size + animation_progress * (
-                self.focused_item_font_size_arr[
-                    self.position % num_menu_items if num_menu_items > 0 else 1
-                ]
-                - self.item_font_size
+                self.focused_item_font_size_arr[pos] - self.item_font_size
             )
-
-            label = ""
-            try:
-                label = self.menu_items[
-                    self.position % num_menu_items if num_menu_items > 0 else 1
-                ]
-            except IndexError:
-                label = "Empty Menu"
-            ctx.move_to(
-                0,
-                animation_direction * -30
-                + animation_progress * animation_direction * 30,
-            ).text(label)
+            label = self.menu_items[pos] if num_menu_items > 0 else "Empty Menu"
+            ctx.move_to(0, y_offset).text(label)
 
             # Previous menu items
             ctx.font_size = self.item_font_size
             for i in range(1, 4):
-                if (self.position - i) >= 0 and len(self.menu_items):
+                if (self.position - i) >= 0 and num_menu_items:
                     ctx.move_to(
                         0,
                         -self.focused_item_margin
-                        + -i * self.item_line_height
-                        - animation_direction * 30
-                        + animation_progress * animation_direction * 30,
+                        - i * self.item_line_height
+                        + y_offset,
                     ).text(self.menu_items[self.position - i])
 
             # Next menu items
             for i in range(1, 4):
-                if (self.position + i) < len(self.menu_items):
+                if (self.position + i) < num_menu_items:
                     ctx.move_to(
                         0,
-                        self.focused_item_margin
-                        + i * self.item_line_height
-                        - animation_direction * 30
-                        + animation_progress * animation_direction * 30,
+                        self.focused_item_margin + i * self.item_line_height + y_offset,
                     ).text(self.menu_items[self.position + i])
 
     def update(self, delta):

--- a/modules/firmware_apps/settings_app.py
+++ b/modules/firmware_apps/settings_app.py
@@ -272,8 +272,6 @@ class SettingsApp(app.App):
                 await render_update()
                 current_time = time.ticks_ms()
                 self.update(current_time - previous_time)
-                if self.ctx:
-                    self.draw(self.ctx)
                 if self.dialog:
                     result = await self.dialog.run(render_update)
                     if (


### PR DESCRIPTION
This introduces some performance fixes for the launcher and settings app.

1. Some intermediate values are cached, either by lifting out of loops, or caching between draw calls
2. An extraneous draw call in the settings app has been removed
3. Better iteration in the layout system to skip rendering things that fall outside of the visible window
