### PR TITLE
Fix memory leak with images in ctx

### DIFF
--- a/components/ctx/ctx.h
+++ b/components/ctx/ctx.h
@@ -55483,7 +55483,7 @@ void ctx_draw_image_clipped (Ctx *ctx, const char *path, float x, float y, float
   else
 #endif
   {
-    char reteid[65];
+    char reteid[65] = "";
     int width, height;
     ctx_texture_load (ctx, path, &width, &height, reteid);
     if (reteid[0])

--- a/drivers/gc9a01/display.c
+++ b/drivers/gc9a01/display.c
@@ -69,10 +69,8 @@ void tildagon_blit_fb (void)
 void tildagon_end_frame(Ctx *ctx)
 {
   ctx_restore (ctx);
+  ctx_end_frame (ctx);
   tildagon_blit_fb ();
-  // display.end_frame() does not call ctx_end_frame(), so advance the
-  // texture clock here to let ctx expire stale image cache entries.
-  ctx_set_textureclock (ctx, ctx_textureclock (ctx) + 1);
   st3m_gfx_fps_update ();
 }
 

--- a/drivers/gc9a01/display.c
+++ b/drivers/gc9a01/display.c
@@ -70,6 +70,9 @@ void tildagon_end_frame(Ctx *ctx)
 {
   ctx_restore (ctx);
   tildagon_blit_fb ();
+  // display.end_frame() does not call ctx_end_frame(), so advance the
+  // texture clock here to let ctx expire stale image cache entries.
+  ctx_set_textureclock (ctx, ctx_textureclock (ctx) + 1);
   st3m_gfx_fps_update ();
 }
 

--- a/drivers/gc9a01/display.c
+++ b/drivers/gc9a01/display.c
@@ -69,8 +69,11 @@ void tildagon_blit_fb (void)
 void tildagon_end_frame(Ctx *ctx)
 {
   ctx_restore (ctx);
-  ctx_end_frame (ctx);
   tildagon_blit_fb ();
+  // display.end_frame() cannot call ctx_end_frame() directly here: that resets
+  // rasterizer state, including the framebuffer clip bounds, which leaves
+  // subsequent frames blank. Advance only the texture eviction clock.
+  ctx_set_textureclock (ctx, ctx_textureclock (ctx) + 1);
   st3m_gfx_fps_update ();
 }
 


### PR DESCRIPTION
## Summary

This fixes ctx image texture cache aging on the badge display path.

`display.end_frame()` does not call `ctx_end_frame()`, so ctx's internal texture clock was not advancing between rendered frames. Because texture cache expiry is based on that clock, stale image cache entries could remain alive indefinitely after drawing images with `ctx.image()`.

This means that if an app calls`ctx.image()` multiple times with different images, memory will eventually be exhausted. This fixes #263, verified by building the firmware, flashing the badge and running the sample code from the issue:

```
{'apps.img_test.app.__app_export__': <CarouselApp object at 3c2291c0>}
ImgTest: img_1 size=1247b mem_before=1613488 mem_after=1613456 delta=32
ImgTest: img_2 size=1262b mem_before=1613456 mem_after=1613424 delta=32
ImgTest: img_3 size=1250b mem_before=1613568 mem_after=1613536 delta=32
ImgTest: img_4 size=2945b mem_before=1613680 mem_after=1613600 delta=80
ImgTest: img_5 size=2546b mem_before=1613552 mem_after=1613520 delta=32
ImgTest: img_6 size=1404b mem_before=1613680 mem_after=1613600 delta=80
ImgTest: img_7 size=1408b mem_before=1613472 mem_after=1613440 delta=32
ImgTest: img_8 size=17224b mem_before=1613488 mem_after=1613456 delta=32
ImgTest: img_9 size=16085b mem_before=1613632 mem_after=1613600 delta=32
ImgTest: img_0 size=1261b mem_before=1613568 mem_after=1613536 delta=32
ImgTest: img_1 size=1247b mem_before=1613472 mem_after=1613440 delta=32
ImgTest: img_2 size=1262b mem_before=1613664 mem_after=1613600 delta=64
ImgTest: img_3 size=1250b mem_before=1613472 mem_after=1613440 delta=32
ImgTest: img_4 size=2945b mem_before=1613504 mem_after=1613472 delta=32
```

## Changes

- Advance ctx's texture clock in `tildagon_end_frame()`
- Initialize `reteid` before `ctx_texture_load()` so failed image loads do not read uninitialized stack data (unrelated to the overall issue but probably a good memory safety fix.

## Notes

The decoded STB image buffer is already freed after `ctx_define_texture()`, but ctx keeps its own native texture cache. Advancing the texture clock lets the existing stale-cache logic work as intended.