### PR TITLE
revert asyncio REPL to move it to an app

### DIFF
--- a/modules/system/scheduler/__init__.py
+++ b/modules/system/scheduler/__init__.py
@@ -1,4 +1,3 @@
-import aiorepl
 import asyncio
 import display
 import sys
@@ -237,8 +236,7 @@ class _Scheduler:
             update_tasks.append(self.start_update_tasks(app))
         render_task = self._render_task()
         event_task = eventbus.run()
-        repl_task = asyncio.create_task(aiorepl.task())
-        await asyncio.gather(render_task, event_task, repl_task, *update_tasks)
+        await asyncio.gather(render_task, event_task, *update_tasks)
 
     def run_forever(self):
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
# Description

asyncio REPL breaks Thonny and other desktop apps. I've written an app to enable the asyncio REPL instead of adding another setting.