### PR TITLE
Improve error handling for Hexpansion insertion

### DIFF
--- a/modules/system/hexpansion/app.py
+++ b/modules/system/hexpansion/app.py
@@ -234,9 +234,22 @@ class HexpansionManagerApp(app.App):
             return
 
         # Do we have a header?
-        header = read_hexpansion_header(i2c, addr, addr_len=addr_len)
-        if header is None:
+        try:
+            header = read_hexpansion_header(i2c, addr, addr_len=addr_len)
+        except OSError:
+            # We failed to read from the hexpansion header, skip
+            eventbus.emit(
+                ShowNotificationEvent(message="Failed to read EEPROM", port=event.port)
+            )
             return
+        else:
+            if header is None:
+                eventbus.emit(
+                    ShowNotificationEvent(
+                        message="Failed to read header", port=event.port
+                    )
+                )
+                return
 
         if header.friendly_name != "":
             eventbus.emit(


### PR DESCRIPTION
# Description

This improves the Hexpansion insertion experience by catching OSErrors during Hexpansion enumeration, and cancelling the insertion with an error instead. This won't trigger for electronic hexpansions without an EEPROM, only for ones that have a detected EEPROM where the header can't be read.

