### PR TITLE
Use i2c readfrom_mem family of APIs for reading from EEPROMs

### DIFF
--- a/modules/lib/eeprom_i2c.py
+++ b/modules/lib/eeprom_i2c.py
@@ -31,6 +31,7 @@ class EEPROM(EepromDevice):
         addr=_ADDR,
         max_chips_count=_MAX_CHIPS_COUNT,
         page_size=None,
+        addrsize=8,
     ):
         self._i2c = i2c
         if chip_size not in (T24C32, T24C64, T24C128, T24C256, T24C512):
@@ -42,6 +43,7 @@ class EEPROM(EepromDevice):
         self._buf1 = bytearray(1)
         self._addrbuf = bytearray(2)  # Memory offset into current chip
         self._onebyte = chip_size <= 256  # Single byte address
+        self.addrsize = addrsize
         # superclass figures out _page_size and _page_mask
         super().__init__(block_size, nchips, chip_size, page_size, verbose)
 
@@ -98,8 +100,13 @@ class EEPROM(EepromDevice):
             # Offset address into chip: one or two bytes
             vaddr = self._addrbuf[1:] if self._onebyte else self._addrbuf
             if read:
-                self._i2c.writeto(self._i2c_addr, vaddr)
-                self._i2c.readfrom_into(self._i2c_addr, mvb[start : start + npage])
+                # self._i2c.writeto(self._i2c_addr, vaddr)
+                self._i2c.readfrom_mem_into(
+                    self._i2c_addr,
+                    addr,
+                    mvb[start : start + npage],
+                    addrsize=self.addrsize,
+                )
             else:
                 self._i2c.writevto(self._i2c_addr, (vaddr, buf[start : start + npage]))
                 self._wait_rdy()

--- a/modules/system/hexpansion/header.py
+++ b/modules/system/hexpansion/header.py
@@ -128,7 +128,7 @@ def write_header(port, header, addr=0x50, addr_len=2, page_size=32):
 def read_header(port, addr=0x50, addr_len=2):
     i2c = I2C(port)
 
-    header_bytes = i2c.readfrom_mem(addr, 0, 32, addr_bytes=addr_len * 8)
+    header_bytes = i2c.readfrom_mem(addr, 0, 32, addrsize=addr_len * 8)
     header = HexpansionHeader.from_bytes(header_bytes)
 
     return header

--- a/modules/system/hexpansion/header.py
+++ b/modules/system/hexpansion/header.py
@@ -128,11 +128,7 @@ def write_header(port, header, addr=0x50, addr_len=2, page_size=32):
 def read_header(port, addr=0x50, addr_len=2):
     i2c = I2C(port)
 
-    # Set internal address to 0x00
-    addr_bytes = [0] * addr_len
-    i2c.writeto(addr, bytes(addr_bytes))
-
-    header_bytes = i2c.readfrom(addr, 32)
+    header_bytes = i2c.readfrom_mem(addr, 0, 32, addr_bytes=addr_len * 8)
     header = HexpansionHeader.from_bytes(header_bytes)
 
     return header

--- a/modules/system/hexpansion/util.py
+++ b/modules/system/hexpansion/util.py
@@ -46,11 +46,7 @@ def read_hexpansion_header(
         print(f"No device found at {hex(eeprom_addr)}")
         return None
 
-    if set_read_addr:
-        addr_bytes = [0] * addr_len
-        i2c.writeto(eeprom_addr, bytes(addr_bytes))
-
-    header_bytes = i2c.readfrom(eeprom_addr, 32)
+    header_bytes = i2c.readfrom_mem(eeprom_addr, 0, 32, addrsize=addr_len * 8)
 
     try:
         header = HexpansionHeader.from_bytes(header_bytes)
@@ -75,6 +71,7 @@ def get_hexpansion_block_devices(i2c, header, addr=0x50, addr_len=2):
         chip_size=chip_size,
         page_size=header.eeprom_page_size,
         block_size=block_size,
+        addrsize=addr_len * 8,
     )
     partition = EEPROMPartition(
         eep=eep,

--- a/modules/write_header.py
+++ b/modules/write_header.py
@@ -23,10 +23,7 @@ def write_header(port, addr=0x50):
 def read_header(port, addr=0x50):
     i2c = I2C(port)
 
-    # Set internal address to 0x00
-    i2c.writeto(addr, bytes([0, 0]))
-
-    header_bytes = i2c.readfrom(addr, 32)
+    header_bytes = i2c.readfrom_mem(addr, 0, 32)
     header = HexpansionHeader.from_bytes(header_bytes)
 
     return header

--- a/modules/write_header.py
+++ b/modules/write_header.py
@@ -20,10 +20,10 @@ def write_header(port, addr=0x50):
     i2c.writeto(addr, bytes([0, 0]) + h.to_bytes())
 
 
-def read_header(port, addr=0x50):
+def read_header(port, addr=0x50, addr_len=2):
     i2c = I2C(port)
 
-    header_bytes = i2c.readfrom_mem(addr, 0, 32)
+    header_bytes = i2c.readfrom_mem(addr, 0, 32, addrsize=addr_len * 8)
     header = HexpansionHeader.from_bytes(header_bytes)
 
     return header


### PR DESCRIPTION
Currently, we write addresses then read using the general read/write methods on i2c. This has worked for lots of chips, but I have a Zetta EEPROM which is failing with this. I suspect a timing issue. I've switched the API into the mem variants, and the EEPROMs I have are working correctly, including the new one.
