### PR TITLE
Fix simulator crash when drawing images (#269)

### DIFF
--- a/sim/fakes/ctx.py
+++ b/sim/fakes/ctx.py
@@ -162,8 +162,7 @@ class Wasm:
         self.free(p)
         self.free(wh)
 
-        res, w, h, c = r
-        b = mem[res:]
+        b = mem[res:res + w * h * c]
         if c == 3:
             return r
         for j in range(h):


### PR DESCRIPTION
A Tildagon app rendering an image may encounter "ValueError: slice stop is required"

The wasm runtime doesn't permit unbounded slicing of its memory buffers, so just calculate the size we expect the buffer to be and use that as the stop index
