### PR TITLE
Fix images not being rendered in the simulator (#276)

### DIFF
--- a/sim/fakes/ctx.py
+++ b/sim/fakes/ctx.py
@@ -407,10 +407,21 @@ class Context:
             buf = open(path, "rb").read()
             _img_cache[path] = _wasm.stbi_load_from_memory(buf)
         img, width, height, components = _img_cache[path]
+        # Allocate some space to receive the EID as determined by ctx, the
+        # ret_eid param will either be set to the path we pass in unchanged,
+        # or if the path is too long we will get back a SHA sum instead
+        ret_eid = _wasm.malloc(65) # 64 + 1 byte for null terminator
         _wasm.ctx_define_texture(
-            self._ctx, path, width, height, width * components, RGBA8, img, 0
+            self._ctx, path, width, height, width * components, RGBA8, img, ret_eid
         )
-        _wasm.ctx_draw_texture(self._ctx, path, x, y, w, h)
+        mem = _wasm._memory.data_ptr(_wasm._store)
+        eid = ""
+        for b in mem[ret_eid:ret_eid + 65]:
+            if not b:
+                break
+            eid += chr(b)
+        _wasm.free(ret_eid)
+        _wasm.ctx_draw_texture(self._ctx, eid, x, y, w, h)
         return self
 
     def rectangle(self, x, y, width, height):

--- a/sim/fakes/ctx.py
+++ b/sim/fakes/ctx.py
@@ -162,8 +162,7 @@ class Wasm:
         self.free(p)
         self.free(wh)
 
-        res, w, h, c = r
-        b = mem[res:]
+        b = mem[res:res + w * h * c]
         if c == 3:
             return r
         for j in range(h):


### PR DESCRIPTION
When we call ctx_define_texture, we use the image's path as the EID for the texture, but when the path is more than 50 characters, ctx generates a SHA sum to use as the EID.
    
Ctx then expects the SHA sum to be passed into the ctx_draw_texture in order to correctly reference the texture we defined earlier.
    
However we were ignoring the ret_eid parameter of ctx_define_texture where ctx passes the generated EID back to us.
    
This change fixes the problem by allocating a bit of space to receive the generated EID, if ctx generates one, from define_texture so that we can pass the correct EID to ctx_draw_texture.
