### PR TITLE
Sim: allow faked sys.print_exception to take multiple arguments

### DIFF
--- a/sim/run.py
+++ b/sim/run.py
@@ -143,7 +143,7 @@ def mkstat(orig_stat):
 os.stat = mkstat(os.stat)
 
 
-sys.print_exception = lambda x: print(traceback.format_exc())
+sys.print_exception = lambda *_: print(traceback.format_exc())
 
 
 def replace_launcher(module_name: str, class_name: str):


### PR DESCRIPTION
The sim creates a fake `sys.print_exception` to match micropython. Its actual arguments are ignored, it will always print the current trace. In some places it is called with 2 arguments, so allow it to handle an arbitary number.

This allows stack traces to be printed correctly in some catch blocks when run in the sim.

Closes #289
