### PR TITLE
Derive app_module_name from metadata

### DIFF
--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -611,14 +611,6 @@ def install_app(app):
         raise e
 
 
-# I don't believe this is ever called
-# def validate_app_files(tar):
-#     prefix = find_app_root_dir(tar)
-#     app_py_path = find_app_py_file(prefix, tar)
-#     print(f"Found app.py at: {app_py_path}")
-#     return prefix
-
-
 def find_app_root_dir(tar):
     print("Finding root dir...")
     root_dir = None

--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -558,7 +558,14 @@ def install_app(app):
         except OSError:
             pass
 
-        app_module_name = "_".join(prefix.split("-")[0:-1])
+        # I think this is all we need
+        # So like
+        # https://whatever.forge/dave-user/tildagon-some-app
+        # resolves to
+        # dave_user_tildagon_some_app
+        app_module_name = "_".join([app["id"]["owner"], app["id"]["title"]]).replace(
+            "-", "_"
+        )
 
         t = TarFile(fileobj=tar_bytesio)
         for i in t:
@@ -604,11 +611,12 @@ def install_app(app):
         raise e
 
 
-def validate_app_files(tar):
-    prefix = find_app_root_dir(tar)
-    app_py_path = find_app_py_file(prefix, tar)
-    print(f"Found app.py at: {app_py_path}")
-    return prefix
+# I don't believe this is ever called
+# def validate_app_files(tar):
+#     prefix = find_app_root_dir(tar)
+#     app_py_path = find_app_py_file(prefix, tar)
+#     print(f"Found app.py at: {app_py_path}")
+#     return prefix
 
 
 def find_app_root_dir(tar):


### PR DESCRIPTION
# Derive app_module_name from metadata

Codeberg apps were getting [very broken install paths](https://github.com/emfcamp/badge-2024-app-store/issues/85). This solves that problem by constructing the path from the app metadata:

```
app_module_name = "_".join([app["id"]["owner"], app["id"]["title"]]).replace("-", "_")
```

So `https://whatever.forge/dave-user/tildagon-some-app` resolves to `dave_user_tildagon_some_app`

As far as I can tell this is exacly what we want, but this may be very naive on my part (attempting to work out what's happening where this code is digging through the tarball to derive the path just left me confused).

## Note

~As far as I can tell, the only difference between the tarballs from the different forges is that a Github tar unpacks to a directory with the release name appended:~

No, it's actually [way stupider](https://github.com/emfcamp/badge-2024-software/pull/293)

```
tildagon-acapp-0.0.3
```

whereas a Codeberg one does not:

```
tildagon-lemmings
```

So I cannot work out *why* it's generating something so broken