### PR TITLE
Construct the `app_module_name` based on the source service

### DIFF
--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -558,7 +558,7 @@ def install_app(app):
         except OSError:
             pass
 
-        app_module_name = "_".join(prefix.split("-")[0:-1])
+        app_module_name = derive_app_module_name(prefix, app)
 
         t = TarFile(fileobj=tar_bytesio)
         for i in t:
@@ -604,11 +604,33 @@ def install_app(app):
         raise e
 
 
-def validate_app_files(tar):
-    prefix = find_app_root_dir(tar)
-    app_py_path = find_app_py_file(prefix, tar)
-    print(f"Found app.py at: {app_py_path}")
-    return prefix
+def derive_app_module_name(prefix, metadata):
+    # with a Github tarball (the default):
+    # the owner name is baked into the root directory
+    owner = ""
+
+    # and a hash is attached to the end, which we want to strip
+    final_index = -1
+
+    # with a Codeberg tarball:
+    if metadata["id"]["service"] == "codeberg":
+        # the owner name is not in the archive, so we need to supply it
+        owner = metadata["id"]["owner"]
+
+        # and there's no trailing hash, so we don't strip it (we want the whole array)
+        final_index = None
+
+    # we could add additional forges here which might have different requirements
+
+    return "_".join([owner] + prefix.split("-")[0:final_index])
+
+
+# I don't think this is ever called
+# def validate_app_files(tar):
+#     prefix = find_app_root_dir(tar)
+#     app_py_path = find_app_py_file(prefix, tar)
+#     print(f"Found app.py at: {app_py_path}")
+#     return prefix
 
 
 def find_app_root_dir(tar):


### PR DESCRIPTION
# Derive app_module_name based on source service

A possibly safer (but maybe less elegant) approach than #291 

The problem is all in the tarballs. When we unpack a Github download we get something like:

`username-tildagon-my-app-48582fe`

> Note: what we get from downloading via the API is _not_ the same thing we get from the "Download releases" webpage. Thanks, Github

A Codeberg tarball just unpacks to

`tildagon-my-app`

No owner-name, and no trailing hash. This PR adds a little helper method that prepends the ownername if we're coming from Codeberg, and only strips the trailing hash if we're coming from Github

If we like this approach, I can clean it up a little and maybe write some tests