### PR TITLE
Fix previously installed apps not launching when using mpremote mount

### DIFF
--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -157,7 +157,9 @@ class Launcher(App):
             except ImportError as e:
                 cwd = os.getcwd()
                 if "no module named 'apps'" in str(e) and cwd == "/remote":
-                    print("Failed to launch app from mpremote mount, launching from internal storage instead")
+                    print(
+                        "Failed to launch app from mpremote mount, launching from internal storage instead"
+                    )
                     os.chdir("/")
                     module = __import__(module_name, None, None, (fn,))
                     app = getattr(module, fn)()

--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -154,6 +154,16 @@ class Launcher(App):
             try:
                 module = __import__(module_name, None, None, (fn,))
                 app = getattr(module, fn)()
+            except ImportError as e:
+                cwd = os.getcwd()
+                if "no module named 'apps'" in str(e) and cwd == "/remote":
+                    print("Failed to launch app from mpremote mount, launching from internal storage instead")
+                    os.chdir("/")
+                    module = __import__(module_name, None, None, (fn,))
+                    app = getattr(module, fn)()
+                    os.chdir(cwd)
+                else:
+                    raise
             except Exception as e:
                 print(f"Error creating app: {e}")
                 sys.print_exception(e, sys.stderr)


### PR DESCRIPTION
# Description

This PR fixes a small issue launching apps that were previously already installed when using `mpremote mount`.

`mpremote mount` under the hood does `os.chdir('/remote')` which causes apps previously installed to `/apps` to fail when we try to import them. This provides a fallback that temporarily switches back to the old cwd, imports the app, and restores the /remote cwd after.