### PR TITLE
Derive `app_module_name` from metadata

### DIFF
--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -558,11 +558,6 @@ def install_app(app):
         except OSError:
             pass
 
-        # I think this is all we need
-        # So like
-        # https://whatever.forge/dave-user/tildagon-some-app
-        # resolves to
-        # dave_user_tildagon_some_app
         app_module_name = "_".join([app["id"]["owner"], app["id"]["title"]]).replace(
             "-", "_"
         )

--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -558,7 +558,14 @@ def install_app(app):
         except OSError:
             pass
 
-        app_module_name = "_".join(prefix.split("-")[0:-1])
+        # I think this is all we need
+        # So like
+        # https://whatever.forge/dave-user/tildagon-some-app
+        # resolves to
+        # dave_user_tildagon_some_app
+        app_module_name = "_".join([app["id"]["owner"], app["id"]["title"]]).replace(
+            "-", "_"
+        )
 
         t = TarFile(fileobj=tar_bytesio)
         for i in t:
@@ -602,13 +609,6 @@ def install_app(app):
     except Exception as e:
         print(e)
         raise e
-
-
-def validate_app_files(tar):
-    prefix = find_app_root_dir(tar)
-    app_py_path = find_app_py_file(prefix, tar)
-    print(f"Found app.py at: {app_py_path}")
-    return prefix
 
 
 def find_app_root_dir(tar):


### PR DESCRIPTION
Codeberg apps were getting [very broken install paths](https://github.com/emfcamp/badge-2024-app-store/issues/85). This solves that problem by constructing the path from the app metadata:

```
app_module_name = "_".join([app["id"]["owner"], app["id"]["title"]]).replace("-", "_")
```

So `https://whatever.forge/dave-user/tildagon-some-app` resolves to `dave_user_tildagon_some_app`

---

The reason *why* it's so broken is to do with tarballs. When we unpack a Github download we get something like:

`username-tildagon-my-app-48582fe`

> Note: what we get from downloading via the API is not the same thing we get from the "Download releases" webpage. Thanks, Github

A Codeberg tarball just unpacks to

`tildagon-my-app`

No owner-name, and no trailing hash.