### PR TITLE
sim: Ensure custom import machinery doesn't hide builtin modules

### DIFF
--- a/sim/run.py
+++ b/sim/run.py
@@ -43,16 +43,25 @@ class UnderscoreFinder(importlib.abc.MetaPathFinder):
         self.pathfinder = pathfinder
 
     def find_spec(self, fullname, path, target=None):
+        # Our fake 'time' module wants to import _time as a backdoor to the
+        # original time module, which is a builtin C module.  Invoke the
+        # BuiltinImporter with "time" to satisfy this.
         if fullname == "_time":
             return self.builtin.find_spec("time", path, target)
-        if fullname in ["random", "math"]:
-            return self.builtin.find_spec(fullname, path, target)
+
+        # Suppress the simulator's sys.path prefixed entries temporarily while
+        # looking for 'json' or 'tarfile'.
         if fullname in ["json", "tarfile"]:
             sys_path_saved = sys.path
             sys.path = sys_path_orig
             res = self.pathfinder.find_spec(fullname, path, target)
             sys.path = sys_path_saved
             return res
+
+        # Provide a general fallback to other builtin (C) modules.
+        # It's OK to do this indiscriminately as the BuiltinImporter won't find
+        # modules that aren't builtin.
+        return self.builtin.find_spec(fullname, path, target)
 
 
 # sys.meta_path.insert(0, Hook())


### PR DESCRIPTION
# Description

There have been a couple of reports in the badge channel of weird failures to import Python standard library modules while trying to start the simulator, in September and again today.  I wrote off the first as a weird/broken Python installation, even though I'd noted there were some `importlib` shenanigans going on in `sim/run.py`, but the second occurrence (happening to another person) led me to look closely at the shenanigans.

I think these changes are the fix required to the sim's custom meta path finder.  However I haven't worked on one of these before and I'd appreciate some eyes and more diverse testing than just my system.

# Issue links

Resolves #278 - even though this issue was closed by the author, a `ModuleNotFoundError` trying to import `_ast` is exactly the reported issue in the second occurrence reported on the badge channel, so I'm fairly sure the cause is the same.