### PR TITLE
add override to the pattern generator

### DIFF
--- a/modules/system/patterndisplay/app.py
+++ b/modules/system/patterndisplay/app.py
@@ -10,11 +10,21 @@ from system.patterndisplay.events import (
     PatternDisable,
     PatternReload,
     PatternSet,
+    PatternOverride,
+    PatternClearOverride,
 )
 from system.eventbus import eventbus
 from app_components.utils import path_isfile
 from firmware_apps.settings_app import PAT_DIR
 from system.notification.events import ShowNotificationEvent
+
+
+class OverrideNeoPixel:
+    def __init__(self, override_value):
+        self.override = override_value
+
+    def __call__(self, _):
+        return self.override
 
 
 class PatternDisplay(App):
@@ -24,6 +34,8 @@ class PatternDisplay(App):
         eventbus.on_async(PatternDisable, self._disable, self)
         eventbus.on_async(PatternReload, self._reload, self)
         eventbus.on_async(PatternSet, self._set, self)
+        eventbus.on_async(PatternOverride, self._override, self)
+        eventbus.on_async(PatternClearOverride, self._clear_override, self)
         self.load_pattern()
         self.enabled = settings.get("pattern_generator_enabled", True)
         self.correction = neopixel.DimCorrection(1.0)
@@ -103,6 +115,14 @@ class PatternDisplay(App):
 
     async def _set(self, event: PatternSet):
         self._p = event.pattern_class()
+
+    async def _override(self, event: PatternOverride):
+        if event.led < 12:
+            self.leds.alterations[event.led] = OverrideNeoPixel(event.new_value)
+
+    async def _clear_override(self, event: PatternClearOverride):
+        if event.led < 12:
+            self.leds.alterations[event.led] = self.correction
 
     async def background_task(self):
         while True:

--- a/modules/system/patterndisplay/events.py
+++ b/modules/system/patterndisplay/events.py
@@ -13,3 +13,14 @@ class PatternReload(Event): ...
 class PatternSet(Event):
     def __init__(self, pattern_class):
         self.pattern_class = pattern_class
+
+
+class PatternOverride(Event):
+    def __init__(self, led, new_value):
+        self.led = led
+        self.new_value = new_value
+
+
+class PatternClearOverride(Event):
+    def __init__(self, led):
+        self.led = led


### PR DESCRIPTION
# Description
add events to set an individual led without stopping the pattern. I've found this quite slow, but would be useful for notifications for apps. directly changes the list of alterations in the neopixel string to change the value.

for led 1 usage
eventbus.emit(PatternOveride(0, (255,255,255)))
eventbus.emit(PatternClearOveride(0))

do we want an offset adding so it's not 0 indexed?