### PR TITLE
flasher: note the USB device name seen on an unsuccessful debug attempt

### DIFF
--- a/flasher/index.html
+++ b/flasher/index.html
@@ -15,7 +15,7 @@
         <li>Hold <b>boop</b> while plugging USB into <b>USB in</b>.</li>
         <li>Keep holding <b>boop</b> until you click <b>Connect</b> and click on the badge COM port. The device name should appears as <code>USB JTAG/serial debug unit</code>.
           <br><em>Note:</em> If you see <code>Espressif CDC Device</code>, power off the badge and try these steps again, holding down the <b>boop</b> button for longer.</li>
-        <li>Let go of the <b>boop</b>.</li>
+        <li>Let go of the <b>boop</b> after you have selected the right device and see the "Connecting" spinner.</li>
         <li>Select <b>Install Tildagon</b>, and wait.</li>
       </ol>
       <p>For more information, see <a href="https://tildagon.badge.emfcamp.org/using-the-badge/flash-the-badge/">Flash the badge</a>.</p>

--- a/flasher/index.html
+++ b/flasher/index.html
@@ -10,11 +10,14 @@
   <body>
     <div class="content">
       <h1>Provision a Tildagon</h1>
-      <li>1. Power off the badge from the menu, if it's already powered on.</li>
-      <li>2. Hold <b>boop</b> while plugging USB into <b>USB in</b>.</li>
-      <li>3. Keep holding <b>boop</b> until you click <b>Connect</b> and click on the badge COM port. The device name should appears as <code>USB JTAG/serial debug unit</code></li>
-      <li>4. Let go of the <b>boop</b></li>
-      <li>5. Select <b>Install Tildagon</b>, and wait.</li>
+      <ol>
+        <li>Power off the badge from the menu, if it's already powered on.</li>
+        <li>Hold <b>boop</b> while plugging USB into <b>USB in</b>.</li>
+        <li>Keep holding <b>boop</b> until you click <b>Connect</b> and click on the badge COM port. The device name should appears as <code>USB JTAG/serial debug unit</code>.
+          <br><em>Note:</em> If you see <code>Espressif CDC Device</code>, power off the badge and try these steps again, holding down the <b>boop</b> button for longer.</li>
+        <li>Let go of the <b>boop</b>.</li>
+        <li>Select <b>Install Tildagon</b>, and wait.</li>
+      </ol>
       <p>For more information, see <a href="https://tildagon.badge.emfcamp.org/using-the-badge/flash-the-badge/">Flash the badge</a>.</p>
       <br>
       <esp-web-install-button


### PR DESCRIPTION
# Description

I thought I'd discovered an alternative name for the badge USB device in flasher/debug mode - it appeared in the browser as "Espressif CDC Device" - then I realised I hadn't actually held `boop` down for long enough.

It isn't too obvious that you need to power off and try again if you see this device rather than the USB/JTAG name.  Add a line to explain this.

Also, this commit wraps the HTML list items in an actual list tag.