### PR TITLE
add retry after 100ms on EEPROM scan

### DIFF
--- a/modules/system/hexpansion/app.py
+++ b/modules/system/hexpansion/app.py
@@ -29,6 +29,7 @@ from egpio import ePin
 from system.eventbus import eventbus
 from machine import I2C
 from events.input import Buttons
+import asyncio
 import vfs
 import sys
 import settings
@@ -235,8 +236,11 @@ class HexpansionManagerApp(app.App):
         print(event)
         i2c = I2C(event.port)
 
-        # Autodetect eeprom addr
+        # Autodetect eeprom addr, retry once after 100ms if not found
         addr, addr_len = detect_eeprom_addr(i2c)
+        if addr is None:
+            await asyncio.sleep(0.1)
+            addr, addr_len = detect_eeprom_addr(i2c)
         if addr is None:
             print("Scan found no eeproms")
             return


### PR DESCRIPTION
Adds a retry to the EEPROM scan if not found first time, with a 100ms delay.

I've implemented the EEPROM in my RP2040 microcontroller on my hexpansion but this takes a good 10ms to be ready after power is applied so the previous scan was sometimes too slow to find it and launch the app.