### PR TITLE
Add brand font and additional glyphs

### DIFF
--- a/components/ctx/ctx_config.h
+++ b/components/ctx/ctx_config.h
@@ -97,9 +97,10 @@
 
 #define CTX_MAX_FONTS 3
 
-#include "Arimo-Regular.h"
-#define CTX_FONT_0 CTX_STATIC_FONT(Arimo_Regular)
-
+#include "EMFCampFont.h"
+#define CTX_FONT_0 CTX_STATIC_FONT(EMF_Camp_Font)
+// #include "MaterialIcons.h"
+// #define CTX_FONT_1 CTX_STATIC_FONT(MaterialIcons)
 // there is room for a mono font, but then the partition is full
 //
 //#include "Comic-Mono.h"

--- a/components/ctx/fonts/EMFCampFont.h
+++ b/components/ctx/fonts/EMFCampFont.h
@@ -1,0 +1,12487 @@
+#ifndef CTX_FONT_EMF_Camp_Font
+/* glyph index: 
+ !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghi
+  jklmnopqrstuvwxyz{|}~ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔ
+  ÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿǩ←↑→↓↔↕↖↗↘↙⇩⏎␈␏□▲△▶▼◀◇○♣✕⬡⬢⬣⭍䇩燩
+  臩  */
+  
+
+/* Copyright 2024 tildagon Project Authors.
+
+Based on Font "Raleway" by Matt McInerny (https://www.theleagueofmoveabletype.com/raleway).
+See FONTLOG.txt for changes.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1. */
+
+/* Solder Party logo is licensed under the Creative Commons Attribution-ShareAlike
+4.0 International License. To view a copy of this license, visit 
+http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to Creative Commons,
+PO Box 1866, Mountain View, CA 94042, USA.*/
+
+/* Keebdeck icons are licensed under the CERN Open Hardware Licence v1.2
+Available to view at: https://github.com/solderparty/keebdeck_keyboard_hw */
+
+static const struct __attribute__ ((packed)) {uint8_t code; uint32_t a; uint32_t b;}
+ctx_font_EMF_Camp_Font[]={
+{15, 0x00000000, 0x000030a7},/* length:12455 CTX_SUBDIV:8 CTX_BAKE_FONT_SIZE:160 */
+{'(', 0x0000000f, 0x00000002},/* EMF Camp Font*/
+{32, 0x20464d45, 0x706d6143},
+{32, 0x746e6f46, 0x00000000},
+{')', 0x0000000f, 0x00000002},
+{'@', 0x00000020, 0x00002800},/*                 x-advance: 40.000000 */
+{'M', 0x00000000, 0x00000000},
+{'[', 0x00220020, 0xfffffffc},/*kerning    " : -0.015625 */
+{'[', 0x00270020, 0xfffffffc},/*kerning    ' : -0.015625 */
+{'[', 0x00410020, 0xfffffff9},/*kerning    A : -0.027344 */
+{'[', 0x004a0020, 0xfffffffa},/*kerning    J : -0.023438 */
+{'[', 0x00540020, 0xfffffff9},/*kerning    T : -0.027344 */
+{'[', 0x00560020, 0xfffffff8},/*kerning    V : -0.031250 */
+{'[', 0x00570020, 0xfffffff8},/*kerning    W : -0.031250 */
+{'[', 0x00580020, 0xfffffffe},/*kerning    X : -0.007812 */
+{'[', 0x00590020, 0xfffffff7},/*kerning    Y : -0.035156 */
+{'[', 0x00760020, 0xfffffffa},/*kerning    v : -0.023438 */
+{'[', 0x00770020, 0xfffffff9},/*kerning    w : -0.027344 */
+{'[', 0x00790020, 0xfffffffa},/*kerning    y : -0.023438 */
+{'[', 0x00c00020, 0xfffffff9},/*kerning    À : -0.027344 */
+{'[', 0x00c10020, 0xfffffff9},/*kerning    Á : -0.027344 */
+{'[', 0x00c20020, 0xfffffff9},/*kerning    Â : -0.027344 */
+{'[', 0x00c30020, 0xfffffff9},/*kerning    Ã : -0.027344 */
+{'[', 0x00c40020, 0xfffffff9},/*kerning    Ä : -0.027344 */
+{'[', 0x00c50020, 0xfffffff9},/*kerning    Å : -0.027344 */
+{'[', 0x00c60020, 0xfffffff6},/*kerning    Æ : -0.039062 */
+{'[', 0x00dd0020, 0xfffffff7},/*kerning    Ý : -0.035156 */
+{'[', 0x00fd0020, 0xfffffffa},/*kerning    ý : -0.023438 */
+{'[', 0x00ff0020, 0xfffffffa},/*kerning    ÿ : -0.023438 */
+{'@', 0x00000021, 0x00002900},/*        !        x-advance: 41.000000 */
+{'M', 0x415eb852, 0xc2199999},
+{'l', 0x00000000, 0xc298a3d8},
+{'4', 0x00000070, 0x02620000},
+{'l', 0xc16147ae, 0xb6800000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x415eb852, 0x80000000},
+{'l', 0x00000000, 0xc19eb852},
+{'4', 0x00000070, 0x009e0000},
+{'l', 0xc16147ae, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00000022, 0x00003300},/*        "        x-advance: 51.000000 */
+{'M', 0x412b851e, 0xc2a0a3d7},
+{'l', 0x00000000, 0xc20a3d70},
+{'4', 0x00000061, 0x01140000},
+{'l', 0xc1428f5c, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41e7ae14, 0xc2a0a3d7},
+{'l', 0x00000000, 0xc20a3d70},
+{'4', 0x00000061, 0x01140000},
+{'l', 0xc1428f5c, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200022, 0xfffffffc},/*kerning  "   : -0.015625 */
+{'[', 0x002c0022, 0xffffffe7},/*kerning  " , : -0.097656 */
+{'[', 0x002e0022, 0xffffffe7},/*kerning  " . : -0.097656 */
+{'[', 0x002f0022, 0xffffffec},/*kerning  " / : -0.078125 */
+{'[', 0x00340022, 0xffffffee},/*kerning  " 4 : -0.070312 */
+{'[', 0x00350022, 0xfffffffc},/*kerning  " 5 : -0.015625 */
+{'[', 0x00390022, 0xfffffffe},/*kerning  " 9 : -0.007812 */
+{'[', 0x00400022, 0xfffffffb},/*kerning  " @ : -0.019531 */
+{'[', 0x00410022, 0xfffffff0},/*kerning  " A : -0.062500 */
+{'[', 0x004a0022, 0xffffffe9},/*kerning  " J : -0.089844 */
+{'[', 0x00630022, 0xfffffff7},/*kerning  " c : -0.035156 */
+{'[', 0x00640022, 0xfffffffc},/*kerning  " d : -0.015625 */
+{'[', 0x00650022, 0xfffffff7},/*kerning  " e : -0.035156 */
+{'[', 0x00670022, 0xfffffffc},/*kerning  " g : -0.015625 */
+{'[', 0x00690022, 0x00000005},/*kerning  " i : 0.019531 */
+{'[', 0x006a0022, 0x00000005},/*kerning  " j : 0.019531 */
+{'[', 0x006f0022, 0xfffffff7},/*kerning  " o : -0.035156 */
+{'[', 0x00710022, 0xfffffffc},/*kerning  " q : -0.015625 */
+{'[', 0x00730022, 0xfffffffe},/*kerning  " s : -0.007812 */
+{'[', 0x00ab0022, 0xfffffffb},/*kerning  " « : -0.019531 */
+{'[', 0x00c00022, 0xfffffff0},/*kerning  " À : -0.062500 */
+{'[', 0x00c10022, 0xfffffff0},/*kerning  " Á : -0.062500 */
+{'[', 0x00c20022, 0xfffffff0},/*kerning  " Â : -0.062500 */
+{'[', 0x00c30022, 0xfffffff0},/*kerning  " Ã : -0.062500 */
+{'[', 0x00c40022, 0xfffffff0},/*kerning  " Ä : -0.062500 */
+{'[', 0x00c50022, 0xfffffff0},/*kerning  " Å : -0.062500 */
+{'[', 0x00c60022, 0xffffffea},/*kerning  " Æ : -0.085938 */
+{'[', 0x00e70022, 0xfffffff7},/*kerning  " ç : -0.035156 */
+{'[', 0x00e80022, 0xfffffff7},/*kerning  " è : -0.035156 */
+{'[', 0x00e90022, 0xfffffff7},/*kerning  " é : -0.035156 */
+{'[', 0x00ea0022, 0xfffffff7},/*kerning  " ê : -0.035156 */
+{'[', 0x00eb0022, 0xfffffff7},/*kerning  " ë : -0.035156 */
+{'[', 0x00ec0022, 0x00000005},/*kerning  " ì : 0.019531 */
+{'[', 0x00ed0022, 0x00000005},/*kerning  " í : 0.019531 */
+{'[', 0x00ee0022, 0x00000005},/*kerning  " î : 0.019531 */
+{'[', 0x00ef0022, 0x00000005},/*kerning  " ï : 0.019531 */
+{'[', 0x00f00022, 0xfffffffb},/*kerning  " ð : -0.019531 */
+{'[', 0x00f20022, 0xfffffff7},/*kerning  " ò : -0.035156 */
+{'[', 0x00f30022, 0xfffffff7},/*kerning  " ó : -0.035156 */
+{'[', 0x00f40022, 0xfffffff7},/*kerning  " ô : -0.035156 */
+{'[', 0x00f50022, 0xfffffff7},/*kerning  " õ : -0.035156 */
+{'[', 0x00f60022, 0xfffffff7},/*kerning  " ö : -0.035156 */
+{'[', 0x00f80022, 0xfffffff7},/*kerning  " ø : -0.035156 */
+{'@', 0x00000023, 0x00006e00},/*        #        x-advance: 110.000000 */
+{'M', 0x42d19999, 0xc28f0a3d},
+{'l', 0xc1ab851c, 0x00000000},
+{'l', 0xc0dc2900, 0x41e3d708},
+{'l', 0x41aa3d70, 0x00000000},
+{'l', 0x00000000, 0x412e147c},
+{'l', 0xc1beb850, 0x00000000},
+{'l', 0xc0fae140, 0x4200a3d7},
+{'l', 0xc13ae14c, 0x80000000},
+{'l', 0x41000000, 0xc200a3d7},
+{'l', 0xc1d70a3c, 0x00000000},
+{'l', 0xc0fae148, 0x4200a3d7},
+{'l', 0xc13ae148, 0x80000000},
+{'l', 0x41000000, 0xc200a3d7},
+{'l', 0xc190a3d7, 0x00000000},
+{'l', 0x00000000, 0xc12e147c},
+{'l', 0x41a51eb8, 0x00000000},
+{'l', 0x40dc28f4, 0xc1e3d708},
+{'l', 0xc1a3d70a, 0x00000000},
+{'l', 0x35800000, 0xc123d708},
+{'l', 0x41b851ec, 0x00000000},
+{'l', 0x40f5c290, 0xc1feb854},
+{'l', 0x413ae148, 0x00000000},
+{'l', 0xc0fae148, 0x41feb854},
+{'l', 0x41d70a3e, 0x00000000},
+{'l', 0x40f5c290, 0xc1feb854},
+{'l', 0x413ae140, 0x00000000},
+{'4', 0x00feffc2, 0x00000097},
+{'l', 0x00000000, 0x4123d708},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4281eb85, 0xc22c28f6},
+{'l', 0x40dc28f0, 0xc1e3d708},
+{'4', 0x0000ff29, 0x00e3ffc9},
+{'l', 0x41d70a3e, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00340023, 0xfffffffe},/*kerning  # 4 : -0.007812 */
+{'@', 0x00000024, 0x00006300},/*        $        x-advance: 99.000000 */
+{'M', 0x42a28f5c, 0xc2b3851e},
+{'q', 0xc06b8520, 0xc0851ec0},
+{0, 0xc131eb88, 0xc0f33340},
+{'9', 0xffe5ffc5, 0xffe0ff7c},
+{'4', 0x01300000, 0x00020008},
+{'q', 0x413d70a4, 0x4023d700},
+{0, 0x41a3d70a, 0x40c7ae10},
+{'q', 0x410a3d70, 0x406b8520},
+{0, 0x41547ae0, 0x411d70a4},
+{'q', 0x40947ae0, 0x40c51eb8},
+{0, 0x40947ae0, 0x41833333},
+{'q', 0x00000000, 0x4128f5c2},
+{0, 0xc0a147a0, 0x418b851e},
+{'q', 0xc0a147b0, 0x40dc28f8},
+{0, 0xc15c28f8, 0x41251eb9},
+{'9', 0x001bffbb, 0x001fff62},
+{'4', 0x007f0000, 0x0000ffb9},
+{'l', 0x00000000, 0xc1828f5c},
+{'9', 0xfff2ff49, 0xff83fec0},
+{'l', 0x40dc28f8, 0xc1428f5b},
+{'q', 0x40947ae0, 0x40999998},
+{0, 0x415ae148, 0x41147ae0},
+{'9', 0x00230048, 0x002c00a1},
+{'l', 0x00000000, 0xc2199999},
+{'q', 0xbf23d700, 0xbe23d700},
+{0, 0xbfb851e0, 0xbea3d700},
+{'q', 0xc13851ec, 0xc03851f0},
+{0, 0xc19a3d70, 0xc0ca3d70},
+{'q', 0xc0f851ec, 0xc05c2900},
+{0, 0xc13c28f6, 0xc110a3d8},
+{'q', 0xc0800000, 0xc0b33330},
+{0, 0xc0800000, 0xc168f5c0},
+{'q', 0x00000000, 0xc12147b0},
+{0, 0x4091eb84, 0xc18a3d74},
+{'q', 0x4091eb84, 0xc0e66660},
+{0, 0x414a3d70, 0xc1347ae0},
+{'9', 0xffe00040, 0xffd90093},
+{'4', 0xff7f0000, 0x00000047},
+{'l', 0x00000000, 0x418147ac},
+{'q', 0x412147b0, 0x3ef5c300},
+{0, 0x4193d708, 0x407ae160},
+{'9', 0x001b0043, 0x00470077},
+{'l', 0xc0d70a40, 0x413ae148},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41c66666, 0xc2a6147b},
+{'q', 0x00000000, 0x40fae150},
+{0, 0x40a8f5c4, 0x413851f0},
+{'9', 0x001d002a, 0x00340082},
+{'l', 0x00000000, 0xc211eb84},
+{'q', 0xc130a3d4, 0x3f4ccc80},
+{0, 0xc1828f5b, 0x40b33330},
+{'9', 0x0026ffd6, 0x0066ffd6},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429b851e, 0xc1e8f5c2},
+{'q', 0x00000000, 0xc1028f5c},
+{0, 0xc0c7ae10, 0xc143d70c},
+{'9', 0xffe0ffcf, 0xffc6ff71},
+{'l', 0x00000000, 0x42133333},
+{'q', 0x413851e8, 0xbea3d700},
+{0, 0x418eb850, 0xc0947ae0},
+{'q', 0x40ca3d70, 0xc08a3d70},
+{0, 0x40ca3d70, 0xc14a3d70},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00000025, 0x00007500},/*        %        x-advance: 117.000000 */
+{'M', 0x41f47ae1, 0xc288f5c2},
+{'8', 0xe89e00cb, 0xbdb9e8d4},
+{'8', 0xa2e6d6e6, 0xa21acc00},
+{'8', 0xbd47d61a, 0xe862e82c},
+{'8', 0x18630037, 0x4347182c},
+{'8', 0x5e1a2a1a, 0x5ee63300},
+{'8', 0x43b92ae6, 0x189d18d4},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4135c28f, 0xc0a8f5c2},
+{'l', 0x42333333, 0xc257ae14},
+{'l', 0x422b851f, 0xc25ccccc},
+{'l', 0x40dc28f0, 0x40bd70a0},
+{'4', 0x01acfe9e, 0x01bdfea4},
+{'l', 0xc0d70a42, 0xc0c28f5a},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41f47ae1, 0xc29851eb},
+{'8', 0xdb510030, 0xa921db21},
+{'8', 0xa8decc00, 0xdcb0dcde},
+{'8', 0x25af00d1, 0x57df25df},
+{'8', 0x58213300, 0x25512521},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42ad70a4, 0x3fcccccc},
+{'8', 0xe89d00c9, 0xbdb9e8d4},
+{'8', 0xa2e6d6e6, 0xa21acc00},
+{'8', 0xbd47d61a, 0xe863e82c},
+{'8', 0x18630037, 0x4347182c},
+{'8', 0x5e1a2a1a, 0x5ee63300},
+{'8', 0x43b92ae6, 0x189d18d4},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42ad70a4, 0xc0c28f5c},
+{'8', 0xdb510030, 0xa821db21},
+{'8', 0xa8decc00, 0xdcb0dcde},
+{'8', 0x25af00d1, 0x57df25df},
+{'8', 0x58213300, 0x25512521},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00000026, 0x00006c00},/*        &        x-advance: 108.000000 */
+{'M', 0x42b33333, 0x80000000},
+{'l', 0xc13d70a8, 0xc147ae14},
+{'q', 0xc0d70a30, 0x40d70a3d},
+{0, 0xc175c288, 0x41266666},
+{'q', 0xc10a3d74, 0x406b851e},
+{0, 0xc1933334, 0x406b851e},
+{'q', 0xc1266668, 0x00000000},
+{0, 0xc1966667, 0xc0851eb8},
+{'q', 0xc1066666, 0xc0851eb8},
+{0, 0xc1533332, 0xc1347ae0},
+{'q', 0xc099999a, 0xc0e3d70c},
+{0, 0xc099999a, 0xc181eb86},
+{'8', 0x9418c400, 0xaa41d018},
+{'q', 0x40a3d70c, 0xc0999998},
+{0, 0x41333334, 0xc10ccccc},
+{'q', 0xc1000000, 0xc10cccd0},
+{0, 0xc1333334, 0xc168f5c0},
+{'8', 0xa3e7d2e7, 0x981ec600},
+{'q', 0x4075c290, 0xc0b851f0},
+{0, 0x4127ae16, 0xc111eb88},
+{'q', 0x40d47ae0, 0xc0570a40},
+{0, 0x416f5c28, 0xc0570a40},
+{'8', 0x166f003d, 0x40501631},
+{'8', 0x631e291e, 0x5de83400},
+{'8', 0x4cbd28e8, 0x45a223d6},
+{'l', 0x41e8f5c4, 0x41f33333},
+{'q', 0x403851e0, 0xc0b851ec},
+{0, 0x4091eb80, 0xc14a3d6e},
+{'9', 0xffc9000d, 0xff8d000d},
+{'l', 0x413ae148, 0x00000000},
+{'q', 0x00000000, 0x4123d708},
+{0, 0xc023d700, 0x419a3d70},
+{'9', 0x0048ffec, 0x0083ffc7},
+{'4', 0x00b700af, 0x0000ff6c},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41e28f5c, 0xc2b3851e},
+{'8', 0x25081100, 0x2e1e1308},
+{'8', 0x473d1b15, 0xaf6bd542},
+{'8', 0xa928da28, 0xb7dfd400},
+{'8', 0xe4ace4df, 0x21a300c8},
+{'9', 0x0021ffdb, 0x0052ffdb},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a66666, 0xc1ef5c29},
+{'8', 0x571c3300, 0x3749241c},
+{'8', 0x135f132d, 0xe96a0038},
+{'9', 0xffe90032, 0xffc0005a},
+{'l', 0xc200a3d8, 0xc20851eb},
+{'8', 0x599d2ac3, 0x6bdb2fdb},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00220026, 0xfffffff4},/*kerning  & " : -0.046875 */
+{'[', 0x00270026, 0xfffffff4},/*kerning  & ' : -0.046875 */
+{'[', 0x00410026, 0x00000005},/*kerning  & A : 0.019531 */
+{'[', 0x00540026, 0xfffffff1},/*kerning  & T : -0.058594 */
+{'[', 0x00550026, 0xfffffffe},/*kerning  & U : -0.007812 */
+{'[', 0x00560026, 0xfffffff3},/*kerning  & V : -0.050781 */
+{'[', 0x00570026, 0xfffffff3},/*kerning  & W : -0.050781 */
+{'[', 0x00580026, 0x00000005},/*kerning  & X : 0.019531 */
+{'[', 0x00590026, 0xffffffee},/*kerning  & Y : -0.070312 */
+{'[', 0x00760026, 0xfffffffc},/*kerning  & v : -0.015625 */
+{'[', 0x00770026, 0xfffffffc},/*kerning  & w : -0.015625 */
+{'[', 0x00780026, 0x00000004},/*kerning  & x : 0.015625 */
+{'[', 0x00790026, 0xfffffffb},/*kerning  & y : -0.019531 */
+{'[', 0x00c00026, 0x00000005},/*kerning  & À : 0.019531 */
+{'[', 0x00c10026, 0x00000005},/*kerning  & Á : 0.019531 */
+{'[', 0x00c20026, 0x00000005},/*kerning  & Â : 0.019531 */
+{'[', 0x00c30026, 0x00000005},/*kerning  & Ã : 0.019531 */
+{'[', 0x00c40026, 0x00000005},/*kerning  & Ä : 0.019531 */
+{'[', 0x00c50026, 0x00000005},/*kerning  & Å : 0.019531 */
+{'[', 0x00c60026, 0x0000000e},/*kerning  & Æ : 0.054688 */
+{'[', 0x00d90026, 0xfffffffe},/*kerning  & Ù : -0.007812 */
+{'[', 0x00da0026, 0xfffffffe},/*kerning  & Ú : -0.007812 */
+{'[', 0x00db0026, 0xfffffffe},/*kerning  & Û : -0.007812 */
+{'[', 0x00dc0026, 0xfffffffe},/*kerning  & Ü : -0.007812 */
+{'[', 0x00dd0026, 0xffffffee},/*kerning  & Ý : -0.070312 */
+{'[', 0x00fd0026, 0xfffffffb},/*kerning  & ý : -0.019531 */
+{'[', 0x00ff0026, 0xfffffffb},/*kerning  & ÿ : -0.019531 */
+{'@', 0x00000027, 0x00002100},/*        '        x-advance: 33.000000 */
+{'M', 0x412b851e, 0xc2a051eb},
+{'l', 0x00000000, 0xc20ae148},
+{'4', 0x00000061, 0x01150000},
+{'l', 0xc1428f5c, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200027, 0xfffffffc},/*kerning  '   : -0.015625 */
+{'[', 0x002c0027, 0xffffffe7},/*kerning  ' , : -0.097656 */
+{'[', 0x002e0027, 0xffffffe7},/*kerning  ' . : -0.097656 */
+{'[', 0x002f0027, 0xffffffec},/*kerning  ' / : -0.078125 */
+{'[', 0x00340027, 0xffffffee},/*kerning  ' 4 : -0.070312 */
+{'[', 0x00350027, 0xfffffffc},/*kerning  ' 5 : -0.015625 */
+{'[', 0x00390027, 0xfffffffe},/*kerning  ' 9 : -0.007812 */
+{'[', 0x00400027, 0xfffffffb},/*kerning  ' @ : -0.019531 */
+{'[', 0x00410027, 0xfffffff0},/*kerning  ' A : -0.062500 */
+{'[', 0x004a0027, 0xffffffe9},/*kerning  ' J : -0.089844 */
+{'[', 0x00630027, 0xfffffff7},/*kerning  ' c : -0.035156 */
+{'[', 0x00640027, 0xfffffffc},/*kerning  ' d : -0.015625 */
+{'[', 0x00650027, 0xfffffff7},/*kerning  ' e : -0.035156 */
+{'[', 0x00670027, 0xfffffffc},/*kerning  ' g : -0.015625 */
+{'[', 0x00690027, 0x00000005},/*kerning  ' i : 0.019531 */
+{'[', 0x006a0027, 0x00000005},/*kerning  ' j : 0.019531 */
+{'[', 0x006f0027, 0xfffffff7},/*kerning  ' o : -0.035156 */
+{'[', 0x00710027, 0xfffffffc},/*kerning  ' q : -0.015625 */
+{'[', 0x00730027, 0xfffffffe},/*kerning  ' s : -0.007812 */
+{'[', 0x00ab0027, 0xfffffffb},/*kerning  ' « : -0.019531 */
+{'[', 0x00c00027, 0xfffffff0},/*kerning  ' À : -0.062500 */
+{'[', 0x00c10027, 0xfffffff0},/*kerning  ' Á : -0.062500 */
+{'[', 0x00c20027, 0xfffffff0},/*kerning  ' Â : -0.062500 */
+{'[', 0x00c30027, 0xfffffff0},/*kerning  ' Ã : -0.062500 */
+{'[', 0x00c40027, 0xfffffff0},/*kerning  ' Ä : -0.062500 */
+{'[', 0x00c50027, 0xfffffff0},/*kerning  ' Å : -0.062500 */
+{'[', 0x00c60027, 0xffffffea},/*kerning  ' Æ : -0.085938 */
+{'[', 0x00e70027, 0xfffffff7},/*kerning  ' ç : -0.035156 */
+{'[', 0x00e80027, 0xfffffff7},/*kerning  ' è : -0.035156 */
+{'[', 0x00e90027, 0xfffffff7},/*kerning  ' é : -0.035156 */
+{'[', 0x00ea0027, 0xfffffff7},/*kerning  ' ê : -0.035156 */
+{'[', 0x00eb0027, 0xfffffff7},/*kerning  ' ë : -0.035156 */
+{'[', 0x00ec0027, 0x00000005},/*kerning  ' ì : 0.019531 */
+{'[', 0x00ed0027, 0x00000005},/*kerning  ' í : 0.019531 */
+{'[', 0x00ee0027, 0x00000005},/*kerning  ' î : 0.019531 */
+{'[', 0x00ef0027, 0x00000005},/*kerning  ' ï : 0.019531 */
+{'[', 0x00f00027, 0xfffffffb},/*kerning  ' ð : -0.019531 */
+{'[', 0x00f20027, 0xfffffff7},/*kerning  ' ò : -0.035156 */
+{'[', 0x00f30027, 0xfffffff7},/*kerning  ' ó : -0.035156 */
+{'[', 0x00f40027, 0xfffffff7},/*kerning  ' ô : -0.035156 */
+{'[', 0x00f50027, 0xfffffff7},/*kerning  ' õ : -0.035156 */
+{'[', 0x00f60027, 0xfffffff7},/*kerning  ' ö : -0.035156 */
+{'[', 0x00f80027, 0xfffffff7},/*kerning  ' ø : -0.035156 */
+{'@', 0x00000028, 0x00002d00},/*        (        x-advance: 45.000000 */
+{'M', 0x40d70a3d, 0xc25d70a4},
+{'q', 0x00000000, 0xc1828f5c},
+{0, 0x40d47ae1, 0xc2000000},
+{'9', 0xff830035, 0xff030080},
+{'l', 0x412e147c, 0x409999a0},
+{'q', 0xc0428f60, 0x408f5c30},
+{0, 0xc0d1eb88, 0x4135c290},
+{'q', 0xc06147a8, 0x40dc28f0},
+{0, 0xc0d70a38, 0x4170a3d8},
+{'q', 0xc04cccd0, 0x41028f58},
+{0, 0xc0a66668, 0x41851eb8},
+{'q', 0xc0000000, 0x4107ae14},
+{0, 0xc0000000, 0x41828f5c},
+{'q', 0x00000000, 0x414a3d70},
+{0, 0x40ae1478, 0x41d8f5c2},
+{'9', 0x0073002b, 0x00e80075},
+{'l', 0xc1266668, 0x40ae1479},
+{'q', 0xc12147ac, 0xc170a3d6},
+{0, 0xc183d70a, 0xc1f66666},
+{'q', 0xc0cccccb, 0xc17c28f6},
+{0, 0xc0cccccb, 0xc1fa3d71},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00280028, 0xfffffffe},/*kerning  ( ( : -0.007812 */
+{'[', 0x00300028, 0xfffffffc},/*kerning  ( 0 : -0.015625 */
+{'[', 0x00360028, 0xfffffffe},/*kerning  ( 6 : -0.007812 */
+{'[', 0x00430028, 0xfffffffb},/*kerning  ( C : -0.019531 */
+{'[', 0x00470028, 0xfffffffb},/*kerning  ( G : -0.019531 */
+{'[', 0x004f0028, 0xfffffffb},/*kerning  ( O : -0.019531 */
+{'[', 0x00510028, 0xfffffffb},/*kerning  ( Q : -0.019531 */
+{'[', 0x00630028, 0xfffffffb},/*kerning  ( c : -0.019531 */
+{'[', 0x00640028, 0xfffffffb},/*kerning  ( d : -0.019531 */
+{'[', 0x00650028, 0xfffffffb},/*kerning  ( e : -0.019531 */
+{'[', 0x00670028, 0xfffffffb},/*kerning  ( g : -0.019531 */
+{'[', 0x006f0028, 0xfffffffb},/*kerning  ( o : -0.019531 */
+{'[', 0x00710028, 0xfffffffb},/*kerning  ( q : -0.019531 */
+{'[', 0x00750028, 0xfffffffd},/*kerning  ( u : -0.011719 */
+{'[', 0x00760028, 0xfffffffc},/*kerning  ( v : -0.015625 */
+{'[', 0x00770028, 0xfffffffc},/*kerning  ( w : -0.015625 */
+{'[', 0x00790028, 0xfffffffd},/*kerning  ( y : -0.011719 */
+{'[', 0x00c60028, 0x00000005},/*kerning  ( Æ : 0.019531 */
+{'[', 0x00c70028, 0xfffffffb},/*kerning  ( Ç : -0.019531 */
+{'[', 0x00d20028, 0xfffffffb},/*kerning  ( Ò : -0.019531 */
+{'[', 0x00d30028, 0xfffffffb},/*kerning  ( Ó : -0.019531 */
+{'[', 0x00d40028, 0xfffffffb},/*kerning  ( Ô : -0.019531 */
+{'[', 0x00d50028, 0xfffffffb},/*kerning  ( Õ : -0.019531 */
+{'[', 0x00d60028, 0xfffffffb},/*kerning  ( Ö : -0.019531 */
+{'[', 0x00d80028, 0xfffffffb},/*kerning  ( Ø : -0.019531 */
+{'[', 0x00e70028, 0xfffffffb},/*kerning  ( ç : -0.019531 */
+{'[', 0x00e80028, 0xfffffffb},/*kerning  ( è : -0.019531 */
+{'[', 0x00e90028, 0xfffffffb},/*kerning  ( é : -0.019531 */
+{'[', 0x00ea0028, 0xfffffffb},/*kerning  ( ê : -0.019531 */
+{'[', 0x00eb0028, 0xfffffffb},/*kerning  ( ë : -0.019531 */
+{'[', 0x00f00028, 0xfffffffb},/*kerning  ( ð : -0.019531 */
+{'[', 0x00f20028, 0xfffffffb},/*kerning  ( ò : -0.019531 */
+{'[', 0x00f30028, 0xfffffffb},/*kerning  ( ó : -0.019531 */
+{'[', 0x00f40028, 0xfffffffb},/*kerning  ( ô : -0.019531 */
+{'[', 0x00f50028, 0xfffffffb},/*kerning  ( õ : -0.019531 */
+{'[', 0x00f60028, 0xfffffffb},/*kerning  ( ö : -0.019531 */
+{'[', 0x00f80028, 0xfffffffb},/*kerning  ( ø : -0.019531 */
+{'[', 0x00f90028, 0xfffffffd},/*kerning  ( ù : -0.011719 */
+{'[', 0x00fa0028, 0xfffffffd},/*kerning  ( ú : -0.011719 */
+{'[', 0x00fb0028, 0xfffffffd},/*kerning  ( û : -0.011719 */
+{'[', 0x00fc0028, 0xfffffffd},/*kerning  ( ü : -0.011719 */
+{'[', 0x00fd0028, 0xfffffffd},/*kerning  ( ý : -0.011719 */
+{'[', 0x00ff0028, 0xfffffffd},/*kerning  ( ÿ : -0.011719 */
+{'@', 0x00000029, 0x00002d00},/*        )        x-advance: 45.000000 */
+{'M', 0x421a3d70, 0xc25d70a4},
+{'q', 0x00000000, 0x417851ec},
+{0, 0xc0ccccc8, 0x41fa3d71},
+{'9', 0x007effcd, 0x00f6ff7d},
+{'l', 0xc1266667, 0xc0ae147a},
+{'q', 0x41147ae1, 0xc168f5c2},
+{0, 0x416b851f, 0xc1e851ea},
+{'q', 0x40ae1478, 0xc167ae14},
+{0, 0x40ae1478, 0xc1d8f5c2},
+{'q', 0x00000000, 0xc0fae148},
+{0, 0xc0000000, 0xc1828f5c},
+{'q', 0xc0000000, 0xc107ae18},
+{0, 0xc0a66664, 0xc1851eb8},
+{'q', 0xc04ccccc, 0xc1028f60},
+{0, 0xc0d70a3c, 0xc170a3d8},
+{'9', 0xffc9ffe4, 0xffa6ffcc},
+{'l', 0x412e147a, 0xc09999a0},
+{'q', 0x41170a3d, 0x41800000},
+{0, 0x4180a3d6, 0x41fd70a4},
+{'q', 0x40d47ae0, 0x417ae148},
+{0, 0x40d47ae0, 0x42000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00290029, 0xfffffffe},/*kerning  ) ) : -0.007812 */
+{'@', 0x0000002a, 0x00003400},/*        *        x-advance: 52.000000 */
+{'M', 0x41570a3d, 0xc2ac28f6},
+{'0', 0xe4a8ad38, 0x2259cb10},
+{'0', 0x0041a2fd, 0xde595efd},
+{'0', 0x1ca83510, 0x20d05339},
+{'4', 0xffabffc9, 0x0055ffc8},
+{'l', 0xc0bd70a2, 0xc0800000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0041002a, 0xffffffef},/*kerning  * A : -0.066406 */
+{'[', 0x004a002a, 0xffffffe8},/*kerning  * J : -0.093750 */
+{'[', 0x0061002a, 0xfffffffd},/*kerning  * a : -0.011719 */
+{'[', 0x0063002a, 0xfffffffb},/*kerning  * c : -0.019531 */
+{'[', 0x0064002a, 0xfffffffa},/*kerning  * d : -0.023438 */
+{'[', 0x0065002a, 0xfffffffb},/*kerning  * e : -0.019531 */
+{'[', 0x0067002a, 0xfffffffa},/*kerning  * g : -0.023438 */
+{'[', 0x006f002a, 0xfffffffb},/*kerning  * o : -0.019531 */
+{'[', 0x0071002a, 0xfffffffa},/*kerning  * q : -0.023438 */
+{'[', 0x0073002a, 0xfffffffd},/*kerning  * s : -0.011719 */
+{'[', 0x00c0002a, 0xffffffef},/*kerning  * À : -0.066406 */
+{'[', 0x00c1002a, 0xffffffef},/*kerning  * Á : -0.066406 */
+{'[', 0x00c2002a, 0xffffffef},/*kerning  * Â : -0.066406 */
+{'[', 0x00c3002a, 0xffffffef},/*kerning  * Ã : -0.066406 */
+{'[', 0x00c4002a, 0xffffffef},/*kerning  * Ä : -0.066406 */
+{'[', 0x00c5002a, 0xffffffef},/*kerning  * Å : -0.066406 */
+{'[', 0x00c6002a, 0xffffffe9},/*kerning  * Æ : -0.089844 */
+{'[', 0x00e0002a, 0xfffffffd},/*kerning  * à : -0.011719 */
+{'[', 0x00e1002a, 0xfffffffd},/*kerning  * á : -0.011719 */
+{'[', 0x00e2002a, 0xfffffffd},/*kerning  * â : -0.011719 */
+{'[', 0x00e3002a, 0xfffffffd},/*kerning  * ã : -0.011719 */
+{'[', 0x00e4002a, 0xfffffffd},/*kerning  * ä : -0.011719 */
+{'[', 0x00e5002a, 0xfffffffd},/*kerning  * å : -0.011719 */
+{'[', 0x00e6002a, 0xfffffffd},/*kerning  * æ : -0.011719 */
+{'[', 0x00e7002a, 0xfffffffb},/*kerning  * ç : -0.019531 */
+{'[', 0x00e8002a, 0xfffffffb},/*kerning  * è : -0.019531 */
+{'[', 0x00e9002a, 0xfffffffb},/*kerning  * é : -0.019531 */
+{'[', 0x00ea002a, 0xfffffffb},/*kerning  * ê : -0.019531 */
+{'[', 0x00eb002a, 0xfffffffb},/*kerning  * ë : -0.019531 */
+{'[', 0x00ee002a, 0x00000006},/*kerning  * î : 0.023438 */
+{'[', 0x00ef002a, 0x00000002},/*kerning  * ï : 0.007812 */
+{'[', 0x00f0002a, 0xfffffff9},/*kerning  * ð : -0.027344 */
+{'[', 0x00f2002a, 0xfffffffb},/*kerning  * ò : -0.019531 */
+{'[', 0x00f3002a, 0xfffffffb},/*kerning  * ó : -0.019531 */
+{'[', 0x00f4002a, 0xfffffffb},/*kerning  * ô : -0.019531 */
+{'[', 0x00f5002a, 0xfffffffb},/*kerning  * õ : -0.019531 */
+{'[', 0x00f6002a, 0xfffffffb},/*kerning  * ö : -0.019531 */
+{'[', 0x00f8002a, 0xfffffffb},/*kerning  * ø : -0.019531 */
+{'@', 0x0000002b, 0x00004200},/*        +        x-advance: 66.000000 */
+{'M', 0x426a3d70, 0xc27a3d70},
+{'l', 0x00000000, 0x413851ec},
+{'l', 0xc1970a3c, 0x00000000},
+{'l', 0x00000000, 0x41a3d709},
+{'l', 0xc14cccce, 0x00000000},
+{'l', 0x00000000, 0xc1a3d709},
+{'l', 0xc1970a3d, 0x00000000},
+{'l', 0x00000000, 0xc13851ec},
+{'l', 0x41970a3d, 0x00000000},
+{'l', 0x00000000, 0xc1a3d70c},
+{'4', 0x00000066, 0x00a30000},
+{'l', 0x41970a3c, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0032002b, 0xfffffffd},/*kerning  + 2 : -0.011719 */
+{'[', 0x0033002b, 0xfffffffd},/*kerning  + 3 : -0.011719 */
+{'[', 0x0034002b, 0xfffffffb},/*kerning  + 4 : -0.019531 */
+{'[', 0x0037002b, 0xfffffffb},/*kerning  + 7 : -0.019531 */
+{'@', 0x0000002c, 0x00002100},/*        ,        x-advance: 33.000000 */
+{'M', 0x413d70a4, 0x414f5c29},
+{'l', 0x404ccccc, 0xc163d70a},
+{'l', 0xc099999a, 0xb4800000},
+{'l', 0x00000000, 0xc1851eb8},
+{'l', 0x41547ae0, 0x00000000},
+{'4', 0x00850000, 0x0071ffda},
+{'l', 0xc0dc28f4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0022002c, 0xffffffe7},/*kerning  , " : -0.097656 */
+{'[', 0x0027002c, 0xffffffe7},/*kerning  , ' : -0.097656 */
+{'[', 0x0037002c, 0xfffffffb},/*kerning  , 7 : -0.019531 */
+{'[', 0x0043002c, 0xfffffffd},/*kerning  , C : -0.011719 */
+{'[', 0x0047002c, 0xfffffffd},/*kerning  , G : -0.011719 */
+{'[', 0x004f002c, 0xfffffffd},/*kerning  , O : -0.011719 */
+{'[', 0x0051002c, 0xfffffffd},/*kerning  , Q : -0.011719 */
+{'[', 0x0054002c, 0xffffffef},/*kerning  , T : -0.066406 */
+{'[', 0x0055002c, 0xfffffffd},/*kerning  , U : -0.011719 */
+{'[', 0x0056002c, 0xffffffee},/*kerning  , V : -0.070312 */
+{'[', 0x0057002c, 0xffffffee},/*kerning  , W : -0.070312 */
+{'[', 0x0059002c, 0xffffffeb},/*kerning  , Y : -0.082031 */
+{'[', 0x0063002c, 0xfffffffb},/*kerning  , c : -0.019531 */
+{'[', 0x0065002c, 0xfffffffb},/*kerning  , e : -0.019531 */
+{'[', 0x0066002c, 0xfffffffe},/*kerning  , f : -0.007812 */
+{'[', 0x006f002c, 0xfffffffb},/*kerning  , o : -0.019531 */
+{'[', 0x0076002c, 0xffffffee},/*kerning  , v : -0.070312 */
+{'[', 0x0077002c, 0xffffffee},/*kerning  , w : -0.070312 */
+{'[', 0x0079002c, 0xffffffee},/*kerning  , y : -0.070312 */
+{'[', 0x00c7002c, 0xfffffffd},/*kerning  , Ç : -0.011719 */
+{'[', 0x00d2002c, 0xfffffffd},/*kerning  , Ò : -0.011719 */
+{'[', 0x00d3002c, 0xfffffffd},/*kerning  , Ó : -0.011719 */
+{'[', 0x00d4002c, 0xfffffffd},/*kerning  , Ô : -0.011719 */
+{'[', 0x00d5002c, 0xfffffffd},/*kerning  , Õ : -0.011719 */
+{'[', 0x00d6002c, 0xfffffffd},/*kerning  , Ö : -0.011719 */
+{'[', 0x00d8002c, 0xfffffffd},/*kerning  , Ø : -0.011719 */
+{'[', 0x00d9002c, 0xfffffffd},/*kerning  , Ù : -0.011719 */
+{'[', 0x00da002c, 0xfffffffd},/*kerning  , Ú : -0.011719 */
+{'[', 0x00db002c, 0xfffffffd},/*kerning  , Û : -0.011719 */
+{'[', 0x00dc002c, 0xfffffffd},/*kerning  , Ü : -0.011719 */
+{'[', 0x00dd002c, 0xffffffeb},/*kerning  , Ý : -0.082031 */
+{'[', 0x00e7002c, 0xfffffffb},/*kerning  , ç : -0.019531 */
+{'[', 0x00e8002c, 0xfffffffb},/*kerning  , è : -0.019531 */
+{'[', 0x00e9002c, 0xfffffffb},/*kerning  , é : -0.019531 */
+{'[', 0x00ea002c, 0xfffffffb},/*kerning  , ê : -0.019531 */
+{'[', 0x00eb002c, 0xfffffffb},/*kerning  , ë : -0.019531 */
+{'[', 0x00f2002c, 0xfffffffb},/*kerning  , ò : -0.019531 */
+{'[', 0x00f3002c, 0xfffffffb},/*kerning  , ó : -0.019531 */
+{'[', 0x00f4002c, 0xfffffffb},/*kerning  , ô : -0.019531 */
+{'[', 0x00f5002c, 0xfffffffb},/*kerning  , õ : -0.019531 */
+{'[', 0x00f6002c, 0xfffffffb},/*kerning  , ö : -0.019531 */
+{'[', 0x00f8002c, 0xfffffffb},/*kerning  , ø : -0.019531 */
+{'[', 0x00fd002c, 0xffffffee},/*kerning  , ý : -0.070312 */
+{'[', 0x00ff002c, 0xffffffee},/*kerning  , ÿ : -0.070312 */
+{'@', 0x0000002d, 0x00004300},/*        -        x-advance: 67.000000 */
+{'M', 0x4123d70a, 0xc2151eb8},
+{'l', 0x00000000, 0xc14ccccc},
+{'4', 0x00000179, 0x00660000},
+{'l', 0xc23ccccc, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0033002d, 0xfffffff9},/*kerning  - 3 : -0.027344 */
+{'[', 0x0037002d, 0xfffffff8},/*kerning  - 7 : -0.031250 */
+{'[', 0x004a002d, 0xfffffff5},/*kerning  - J : -0.042969 */
+{'[', 0x0054002d, 0xfffffff1},/*kerning  - T : -0.058594 */
+{'[', 0x0056002d, 0xfffffff8},/*kerning  - V : -0.031250 */
+{'[', 0x0057002d, 0xfffffff8},/*kerning  - W : -0.031250 */
+{'[', 0x0058002d, 0xfffffffc},/*kerning  - X : -0.015625 */
+{'[', 0x0059002d, 0xfffffff0},/*kerning  - Y : -0.062500 */
+{'[', 0x0076002d, 0xfffffffe},/*kerning  - v : -0.007812 */
+{'[', 0x0077002d, 0xfffffffe},/*kerning  - w : -0.007812 */
+{'[', 0x0078002d, 0xfffffffc},/*kerning  - x : -0.015625 */
+{'[', 0x0079002d, 0xfffffffd},/*kerning  - y : -0.011719 */
+{'[', 0x007a002d, 0xfffffffc},/*kerning  - z : -0.015625 */
+{'[', 0x00dd002d, 0xfffffff0},/*kerning  - Ý : -0.062500 */
+{'[', 0x00fd002d, 0xfffffffd},/*kerning  - ý : -0.011719 */
+{'[', 0x00ff002d, 0xfffffffd},/*kerning  - ÿ : -0.011719 */
+{'@', 0x0000002e, 0x00002000},/*        .        x-advance: 32.000000 */
+{'M', 0x4123d70a, 0x80000000},
+{'l', 0x00000000, 0xc18f5c29},
+{'4', 0x0000005e, 0x008f0000},
+{'l', 0xc13d70a4, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0022002e, 0xffffffe7},/*kerning  . " : -0.097656 */
+{'[', 0x0027002e, 0xffffffe7},/*kerning  . ' : -0.097656 */
+{'[', 0x0037002e, 0xfffffffb},/*kerning  . 7 : -0.019531 */
+{'[', 0x0043002e, 0xfffffffd},/*kerning  . C : -0.011719 */
+{'[', 0x0047002e, 0xfffffffd},/*kerning  . G : -0.011719 */
+{'[', 0x004f002e, 0xfffffffd},/*kerning  . O : -0.011719 */
+{'[', 0x0051002e, 0xfffffffd},/*kerning  . Q : -0.011719 */
+{'[', 0x0054002e, 0xffffffef},/*kerning  . T : -0.066406 */
+{'[', 0x0055002e, 0xfffffffd},/*kerning  . U : -0.011719 */
+{'[', 0x0056002e, 0xffffffee},/*kerning  . V : -0.070312 */
+{'[', 0x0057002e, 0xffffffee},/*kerning  . W : -0.070312 */
+{'[', 0x0059002e, 0xffffffeb},/*kerning  . Y : -0.082031 */
+{'[', 0x0063002e, 0xfffffffb},/*kerning  . c : -0.019531 */
+{'[', 0x0065002e, 0xfffffffb},/*kerning  . e : -0.019531 */
+{'[', 0x0066002e, 0xfffffffe},/*kerning  . f : -0.007812 */
+{'[', 0x006f002e, 0xfffffffb},/*kerning  . o : -0.019531 */
+{'[', 0x0076002e, 0xffffffee},/*kerning  . v : -0.070312 */
+{'[', 0x0077002e, 0xffffffee},/*kerning  . w : -0.070312 */
+{'[', 0x0079002e, 0xffffffee},/*kerning  . y : -0.070312 */
+{'[', 0x00c7002e, 0xfffffffd},/*kerning  . Ç : -0.011719 */
+{'[', 0x00d2002e, 0xfffffffd},/*kerning  . Ò : -0.011719 */
+{'[', 0x00d3002e, 0xfffffffd},/*kerning  . Ó : -0.011719 */
+{'[', 0x00d4002e, 0xfffffffd},/*kerning  . Ô : -0.011719 */
+{'[', 0x00d5002e, 0xfffffffd},/*kerning  . Õ : -0.011719 */
+{'[', 0x00d6002e, 0xfffffffd},/*kerning  . Ö : -0.011719 */
+{'[', 0x00d8002e, 0xfffffffd},/*kerning  . Ø : -0.011719 */
+{'[', 0x00d9002e, 0xfffffffd},/*kerning  . Ù : -0.011719 */
+{'[', 0x00da002e, 0xfffffffd},/*kerning  . Ú : -0.011719 */
+{'[', 0x00db002e, 0xfffffffd},/*kerning  . Û : -0.011719 */
+{'[', 0x00dc002e, 0xfffffffd},/*kerning  . Ü : -0.011719 */
+{'[', 0x00dd002e, 0xffffffeb},/*kerning  . Ý : -0.082031 */
+{'[', 0x00e7002e, 0xfffffffb},/*kerning  . ç : -0.019531 */
+{'[', 0x00e8002e, 0xfffffffb},/*kerning  . è : -0.019531 */
+{'[', 0x00e9002e, 0xfffffffb},/*kerning  . é : -0.019531 */
+{'[', 0x00ea002e, 0xfffffffb},/*kerning  . ê : -0.019531 */
+{'[', 0x00eb002e, 0xfffffffb},/*kerning  . ë : -0.019531 */
+{'[', 0x00f2002e, 0xfffffffb},/*kerning  . ò : -0.019531 */
+{'[', 0x00f3002e, 0xfffffffb},/*kerning  . ó : -0.019531 */
+{'[', 0x00f4002e, 0xfffffffb},/*kerning  . ô : -0.019531 */
+{'[', 0x00f5002e, 0xfffffffb},/*kerning  . õ : -0.019531 */
+{'[', 0x00f6002e, 0xfffffffb},/*kerning  . ö : -0.019531 */
+{'[', 0x00f8002e, 0xfffffffb},/*kerning  . ø : -0.019531 */
+{'[', 0x00fd002e, 0xffffffee},/*kerning  . ý : -0.070312 */
+{'[', 0x00ff002e, 0xffffffee},/*kerning  . ÿ : -0.070312 */
+{'@', 0x0000002f, 0x00006500},/*        /        x-advance: 101.000000 */
+{'M', 0x42c19999, 0xc2e33333},
+{'l', 0xc2999999, 0x42e33333},
+{'4', 0x0000ff83, 0xfc740265},
+{'l', 0x417d70a0, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002f002f, 0xffffffbc},/*kerning  / / : -0.265625 */
+{'[', 0x0030002f, 0xfffffff5},/*kerning  / 0 : -0.042969 */
+{'[', 0x0031002f, 0xfffffffb},/*kerning  / 1 : -0.019531 */
+{'[', 0x0032002f, 0xfffffffa},/*kerning  / 2 : -0.023438 */
+{'[', 0x0033002f, 0xfffffff9},/*kerning  / 3 : -0.027344 */
+{'[', 0x0034002f, 0xffffffea},/*kerning  / 4 : -0.085938 */
+{'[', 0x0035002f, 0xfffffff7},/*kerning  / 5 : -0.035156 */
+{'[', 0x0036002f, 0xfffffffc},/*kerning  / 6 : -0.015625 */
+{'[', 0x0038002f, 0xfffffffe},/*kerning  / 8 : -0.007812 */
+{'[', 0x0039002f, 0xfffffff8},/*kerning  / 9 : -0.031250 */
+{'[', 0x0041002f, 0xffffffec},/*kerning  / A : -0.078125 */
+{'[', 0x0043002f, 0xfffffffa},/*kerning  / C : -0.023438 */
+{'[', 0x0047002f, 0xfffffffa},/*kerning  / G : -0.023438 */
+{'[', 0x004a002f, 0xffffffe8},/*kerning  / J : -0.093750 */
+{'[', 0x004f002f, 0xfffffffa},/*kerning  / O : -0.023438 */
+{'[', 0x0051002f, 0xfffffffa},/*kerning  / Q : -0.023438 */
+{'[', 0x0058002f, 0x00000001},/*kerning  / X : 0.003906 */
+{'[', 0x0061002f, 0xfffffff7},/*kerning  / a : -0.035156 */
+{'[', 0x0063002f, 0xfffffff4},/*kerning  / c : -0.046875 */
+{'[', 0x0064002f, 0xfffffff4},/*kerning  / d : -0.046875 */
+{'[', 0x0065002f, 0xfffffff4},/*kerning  / e : -0.046875 */
+{'[', 0x0066002f, 0xfffffffe},/*kerning  / f : -0.007812 */
+{'[', 0x0067002f, 0xfffffff4},/*kerning  / g : -0.046875 */
+{'[', 0x006d002f, 0xfffffff9},/*kerning  / m : -0.027344 */
+{'[', 0x006e002f, 0xfffffff9},/*kerning  / n : -0.027344 */
+{'[', 0x006f002f, 0xfffffff4},/*kerning  / o : -0.046875 */
+{'[', 0x0070002f, 0xfffffff9},/*kerning  / p : -0.027344 */
+{'[', 0x0071002f, 0xfffffff4},/*kerning  / q : -0.046875 */
+{'[', 0x0072002f, 0xfffffff9},/*kerning  / r : -0.027344 */
+{'[', 0x0073002f, 0xfffffff6},/*kerning  / s : -0.039062 */
+{'[', 0x0075002f, 0xfffffffa},/*kerning  / u : -0.023438 */
+{'[', 0x0076002f, 0xfffffffc},/*kerning  / v : -0.015625 */
+{'[', 0x0077002f, 0xfffffffd},/*kerning  / w : -0.011719 */
+{'[', 0x0078002f, 0xfffffffd},/*kerning  / x : -0.011719 */
+{'[', 0x0079002f, 0xfffffffd},/*kerning  / y : -0.011719 */
+{'[', 0x007a002f, 0xfffffffb},/*kerning  / z : -0.019531 */
+{'[', 0x00c0002f, 0xffffffec},/*kerning  / À : -0.078125 */
+{'[', 0x00c1002f, 0xffffffec},/*kerning  / Á : -0.078125 */
+{'[', 0x00c2002f, 0xffffffec},/*kerning  / Â : -0.078125 */
+{'[', 0x00c3002f, 0xffffffec},/*kerning  / Ã : -0.078125 */
+{'[', 0x00c4002f, 0xffffffec},/*kerning  / Ä : -0.078125 */
+{'[', 0x00c5002f, 0xffffffec},/*kerning  / Å : -0.078125 */
+{'[', 0x00c6002f, 0xffffffe4},/*kerning  / Æ : -0.109375 */
+{'[', 0x00c7002f, 0xfffffffa},/*kerning  / Ç : -0.023438 */
+{'[', 0x00d2002f, 0xfffffffa},/*kerning  / Ò : -0.023438 */
+{'[', 0x00d3002f, 0xfffffffa},/*kerning  / Ó : -0.023438 */
+{'[', 0x00d4002f, 0xfffffffa},/*kerning  / Ô : -0.023438 */
+{'[', 0x00d5002f, 0xfffffffa},/*kerning  / Õ : -0.023438 */
+{'[', 0x00d6002f, 0xfffffffa},/*kerning  / Ö : -0.023438 */
+{'[', 0x00d8002f, 0xfffffffa},/*kerning  / Ø : -0.023438 */
+{'[', 0x00e0002f, 0xfffffff7},/*kerning  / à : -0.035156 */
+{'[', 0x00e1002f, 0xfffffff7},/*kerning  / á : -0.035156 */
+{'[', 0x00e2002f, 0xfffffff7},/*kerning  / â : -0.035156 */
+{'[', 0x00e3002f, 0xfffffff7},/*kerning  / ã : -0.035156 */
+{'[', 0x00e4002f, 0xfffffff7},/*kerning  / ä : -0.035156 */
+{'[', 0x00e5002f, 0xfffffff7},/*kerning  / å : -0.035156 */
+{'[', 0x00e6002f, 0xfffffff7},/*kerning  / æ : -0.035156 */
+{'[', 0x00e7002f, 0xfffffff4},/*kerning  / ç : -0.046875 */
+{'[', 0x00e8002f, 0xfffffff4},/*kerning  / è : -0.046875 */
+{'[', 0x00e9002f, 0xfffffff4},/*kerning  / é : -0.046875 */
+{'[', 0x00ea002f, 0xfffffff4},/*kerning  / ê : -0.046875 */
+{'[', 0x00eb002f, 0xfffffff4},/*kerning  / ë : -0.046875 */
+{'[', 0x00ef002f, 0x00000001},/*kerning  / ï : 0.003906 */
+{'[', 0x00f0002f, 0xfffffff3},/*kerning  / ð : -0.050781 */
+{'[', 0x00f1002f, 0xfffffff9},/*kerning  / ñ : -0.027344 */
+{'[', 0x00f2002f, 0xfffffff4},/*kerning  / ò : -0.046875 */
+{'[', 0x00f3002f, 0xfffffff4},/*kerning  / ó : -0.046875 */
+{'[', 0x00f4002f, 0xfffffff4},/*kerning  / ô : -0.046875 */
+{'[', 0x00f5002f, 0xfffffff4},/*kerning  / õ : -0.046875 */
+{'[', 0x00f6002f, 0xfffffff4},/*kerning  / ö : -0.046875 */
+{'[', 0x00f8002f, 0xfffffff4},/*kerning  / ø : -0.046875 */
+{'[', 0x00f9002f, 0xfffffffa},/*kerning  / ù : -0.023438 */
+{'[', 0x00fa002f, 0xfffffffa},/*kerning  / ú : -0.023438 */
+{'[', 0x00fb002f, 0xfffffffa},/*kerning  / û : -0.023438 */
+{'[', 0x00fc002f, 0xfffffffa},/*kerning  / ü : -0.023438 */
+{'[', 0x00fd002f, 0xfffffffd},/*kerning  / ý : -0.011719 */
+{'[', 0x00ff002f, 0xfffffffd},/*kerning  / ÿ : -0.011719 */
+{'@', 0x00000030, 0x00006200},/*        0        x-advance: 98.000000 */
+{'M', 0x42b33333, 0xc23b851e},
+{'q', 0x00000000, 0x416147ac},
+{0, 0xc0a8f5c0, 0x41c851ea},
+{'q', 0xc0a8f5c0, 0x412f5c29},
+{0, 0xc1666668, 0x4189999a},
+{'q', 0xc111eb84, 0x40c7ae13},
+{0, 0xc1a66666, 0x40c7ae13},
+{'q', 0xc13ae148, 0x00000000},
+{0, 0xc1a66666, 0xc0c7ae15},
+{'q', 0xc111eb86, 0xc0c7ae14},
+{0, 0xc1666667, 0xc189999a},
+{'q', 0xc0a8f5c2, 0xc12f5c28},
+{0, 0xc0a8f5c2, 0xc1c851ea},
+{'q', 0x00000000, 0xc16147b0},
+{0, 0x40a8f5c2, 0xc1c851ec},
+{'q', 0x40a8f5c2, 0xc12f5c28},
+{0, 0x41666667, 0xc18a3d70},
+{'q', 0x4111eb84, 0xc0ca3d70},
+{0, 0x41a66666, 0xc0ca3d70},
+{'q', 0x413ae148, 0x00000000},
+{0, 0x41a66666, 0x40ca3d70},
+{'q', 0x4111eb88, 0x40ca3d70},
+{0, 0x41666668, 0x418a3d70},
+{'9', 0x0057002a, 0x00c8002a},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4296b852, 0xc23b851e},
+{'q', 0x00000000, 0xc128f5c4},
+{0, 0xc0570a40, 0xc1947ae0},
+{'8', 0x9db6c0e6, 0xdd94ddd1},
+{'8', 0x239200c2, 0x63b623d1},
+{'q', 0xc0570a38, 0x40fffff8},
+{0, 0xc0570a38, 0x41947ae0},
+{'q', 0x00000000, 0x4128f5c0},
+{0, 0x40570a38, 0x4193d709},
+{'8', 0x634a3f1a, 0x236e232f},
+{'8', 0xdd6c003d, 0x9d4add2f},
+{'q', 0x40570a40, 0xc0fd70a4},
+{0, 0x40570a40, 0xc193d709},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00290030, 0xfffffffc},/*kerning  0 ) : -0.015625 */
+{'[', 0x002f0030, 0xfffffffe},/*kerning  0 / : -0.007812 */
+{'[', 0x00410030, 0xfffffffc},/*kerning  0 A : -0.015625 */
+{'[', 0x00540030, 0xfffffff3},/*kerning  0 T : -0.050781 */
+{'[', 0x00560030, 0xfffffff7},/*kerning  0 V : -0.035156 */
+{'[', 0x00570030, 0xfffffff7},/*kerning  0 W : -0.035156 */
+{'[', 0x00580030, 0xfffffffc},/*kerning  0 X : -0.015625 */
+{'[', 0x00590030, 0xfffffff1},/*kerning  0 Y : -0.058594 */
+{'[', 0x005a0030, 0xfffffffe},/*kerning  0 Z : -0.007812 */
+{'[', 0x005c0030, 0xfffffff7},/*kerning  0 \ : -0.035156 */
+{'[', 0x00b00030, 0xfffffffc},/*kerning  0 ° : -0.015625 */
+{'[', 0x00c00030, 0xfffffffc},/*kerning  0 À : -0.015625 */
+{'[', 0x00c10030, 0xfffffffc},/*kerning  0 Á : -0.015625 */
+{'[', 0x00c20030, 0xfffffffc},/*kerning  0 Â : -0.015625 */
+{'[', 0x00c30030, 0xfffffffc},/*kerning  0 Ã : -0.015625 */
+{'[', 0x00c40030, 0xfffffffc},/*kerning  0 Ä : -0.015625 */
+{'[', 0x00c50030, 0xfffffffc},/*kerning  0 Å : -0.015625 */
+{'[', 0x00c60030, 0xfffffffd},/*kerning  0 Æ : -0.011719 */
+{'[', 0x00dd0030, 0xfffffff1},/*kerning  0 Ý : -0.058594 */
+{'@', 0x00000031, 0x00004800},/*        1        x-advance: 72.000000 */
+{'M', 0x428851eb, 0xc14ccccc},
+{'l', 0x00000000, 0x414ccccc},
+{'l', 0xc265c28e, 0x80000000},
+{'4', 0xff9a0000, 0x000000b5},
+{'l', 0x00000000, 0xc2799999},
+{'8', 0x2acd13f2, 0x28b017db},
+{'9', 0x0010ffd5, 0x0010ffb4},
+{'l', 0x00000000, 0xc1570a3c},
+{'8', 0xf03e001c, 0xdb41f021},
+{'8', 0xd836eb20, 0xe61aed16},
+{'4', 0x00000073, 0x02740000},
+{'l', 0x41a28f5a, 0x36800000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00220031, 0xfffffffb},/*kerning  1 " : -0.019531 */
+{'[', 0x00270031, 0xfffffffb},/*kerning  1 ' : -0.019531 */
+{'[', 0x002b0031, 0xfffffffb},/*kerning  1 + : -0.019531 */
+{'[', 0x002d0031, 0xfffffffe},/*kerning  1 - : -0.007812 */
+{'[', 0x00540031, 0xfffffff4},/*kerning  1 T : -0.046875 */
+{'[', 0x00550031, 0xfffffffd},/*kerning  1 U : -0.011719 */
+{'[', 0x00560031, 0xfffffff4},/*kerning  1 V : -0.046875 */
+{'[', 0x00570031, 0xfffffff4},/*kerning  1 W : -0.046875 */
+{'[', 0x00590031, 0xfffffff0},/*kerning  1 Y : -0.062500 */
+{'[', 0x005c0031, 0xfffffff5},/*kerning  1 \ : -0.042969 */
+{'[', 0x00b00031, 0xfffffffb},/*kerning  1 ° : -0.019531 */
+{'[', 0x00b70031, 0xfffffffc},/*kerning  1 · : -0.015625 */
+{'[', 0x00c60031, 0x00000008},/*kerning  1 Æ : 0.031250 */
+{'[', 0x00d90031, 0xfffffffd},/*kerning  1 Ù : -0.011719 */
+{'[', 0x00da0031, 0xfffffffd},/*kerning  1 Ú : -0.011719 */
+{'[', 0x00db0031, 0xfffffffd},/*kerning  1 Û : -0.011719 */
+{'[', 0x00dc0031, 0xfffffffd},/*kerning  1 Ü : -0.011719 */
+{'[', 0x00dd0031, 0xfffffff0},/*kerning  1 Ý : -0.062500 */
+{'[', 0x00f70031, 0xfffffffb},/*kerning  1 ÷ : -0.019531 */
+{'@', 0x00000032, 0x00005500},/*        2        x-advance: 85.000000 */
+{'M', 0x40dc28f5, 0x80000000},
+{'q', 0x00000000, 0xc10a3d70},
+{0, 0x40000002, 0xc17c28f5},
+{'q', 0x40000000, 0xc0e3d70a},
+{0, 0x40f5c28e, 0xc15851eb},
+{'q', 0x40b5c290, 0xc0ccccd0},
+{0, 0x41833333, 0xc147ae14},
+{'8', 0xca67e433, 0xc657e633},
+{'8', 0xb323e023, 0xafd9d400},
+{'q', 0xc09c28f0, 0xc0947ae0},
+{0, 0xc1628f5c, 0xc0947ae0},
+{'8', 0x11a700cf, 0x28bd11d9},
+{'9', 0x0017ffe5, 0x002affd4},
+{'l', 0xc10ccccc, 0xc11eb850},
+{'8', 0xd434f10e, 0xcb62e426},
+{'q', 0x40f0a3d4, 0xc0428f60},
+{0, 0x418b851f, 0xc0428f60},
+{'q', 0x411eb850, 0x00000000},
+{0, 0x418851ea, 0x405c28e0},
+{'8', 0x4a571b38, 0x681e2e1e},
+{'8', 0x57eb3100, 0x41cb25eb},
+{'8', 0x30bd1ce0, 0x21c113dd},
+{'q', 0xc1199998, 0x40999998},
+{0, 0xc17851e8, 0x41066664},
+{'8', 0x3bb91cd1, 0x4add1ee8},
+{'4', 0x000001c3, 0x00660000},
+{'l', 0xc28e6667, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00540032, 0xfffffff4},/*kerning  2 T : -0.046875 */
+{'[', 0x00560032, 0xfffffff9},/*kerning  2 V : -0.027344 */
+{'[', 0x00570032, 0xfffffff9},/*kerning  2 W : -0.027344 */
+{'[', 0x00590032, 0xfffffff4},/*kerning  2 Y : -0.046875 */
+{'[', 0x005c0032, 0xfffffff9},/*kerning  2 \ : -0.027344 */
+{'[', 0x00b00032, 0xfffffffe},/*kerning  2 ° : -0.007812 */
+{'[', 0x00c60032, 0x00000002},/*kerning  2 Æ : 0.007812 */
+{'[', 0x00dd0032, 0xfffffff4},/*kerning  2 Ý : -0.046875 */
+{'@', 0x00000033, 0x00005600},/*        3        x-advance: 86.000000 */
+{'M', 0x42651eb8, 0xc2170a3d},
+{'q', 0x4123d708, 0x3fe147a0},
+{0, 0x4181eb84, 0x41170a3c},
+{'q', 0x40c00000, 0x40f5c290},
+{0, 0x40c00000, 0x419851ec},
+{'q', 0x00000000, 0x411c28f4},
+{0, 0xc0970a30, 0x41899999},
+{'q', 0xc0970a40, 0x40ee147a},
+{0, 0xc155c290, 0x413851ea},
+{'q', 0xc10a3d74, 0x40828f5c},
+{0, 0xc1a147b0, 0x40828f5c},
+{'q', 0xc1428f5c, 0x00000000},
+{0, 0xc1aae148, 0xc091eb84},
+{'9', 0xffdcffb7, 0xff99ff8e},
+{'l', 0x41170a3d, 0xc1170a3d},
+{'q', 0x406b851c, 0x40cccccc},
+{0, 0x411fffff, 0x4123d70a},
+{'q', 0x40ca3d70, 0x4075c28c},
+{0, 0x4181eb85, 0x4075c28c},
+{'q', 0x4130a3d8, 0x00000000},
+{0, 0x418ae148, 0xc0a147ad},
+{'q', 0x40ca3d70, 0xc0a147ae},
+{0, 0x40ca3d70, 0xc16f5c28},
+{'q', 0x00000000, 0xc12147ae},
+{0, 0xc0d99998, 0xc180a3d7},
+{'9', 0xffd0ffca, 0xffd0ff62},
+{'4', 0x0000ffdf, 0xffa20000},
+{'l', 0x408f5c28, 0x00000000},
+{'q', 0x413851ec, 0x00000000},
+{0, 0x418d70a4, 0xc0b33330},
+{'8', 0x9131d431, 0x9bd1bd00},
+{'q', 0xc0bd70a8, 0xc0851eb0},
+{0, 0xc16e147c, 0xc0851eb0},
+{'q', 0xc10ccccc, 0x00000000},
+{0, 0xc1770a3c, 0x4070a3e0},
+{'9', 0x001effcb, 0x0053ffae},
+{'l', 0xc10a3d71, 0xc10f5c28},
+{'q', 0x40851eb8, 0xc1000000},
+{0, 0x415fffff, 0xc14f5c28},
+{'q', 0x411d70a4, 0xc09eb850},
+{0, 0x41aeb853, 0xc09eb850},
+{'q', 0x412147ac, 0x00000000},
+{0, 0x418eb850, 0x406147a0},
+{'q', 0x40f851e8, 0x406147c0},
+{0, 0x414147ac, 0x411eb850},
+{'q', 0x408a3d70, 0x40ccccd0},
+{0, 0x408a3d70, 0x4170a3d8},
+{'q', 0x00000000, 0x41170a40},
+{0, 0xc0ab8510, 0x41870a3e},
+{'q', 0xc0ab8520, 0x40ee1478},
+{0, 0xc16cccd0, 0x4110a3d8},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00540033, 0xfffffff1},/*kerning  3 T : -0.058594 */
+{'[', 0x00560033, 0xfffffff8},/*kerning  3 V : -0.031250 */
+{'[', 0x00570033, 0xfffffff8},/*kerning  3 W : -0.031250 */
+{'[', 0x00590033, 0xfffffff3},/*kerning  3 Y : -0.050781 */
+{'[', 0x005c0033, 0xfffffff8},/*kerning  3 \ : -0.031250 */
+{'[', 0x00b00033, 0xfffffffb},/*kerning  3 ° : -0.019531 */
+{'[', 0x00c60033, 0x00000001},/*kerning  3 Æ : 0.003906 */
+{'[', 0x00dd0033, 0xfffffff3},/*kerning  3 Ý : -0.050781 */
+{'@', 0x00000034, 0x00005900},/*        4        x-advance: 89.000000 */
+{'M', 0x425ccccc, 0x41a28f5c},
+{'l', 0x00000000, 0xc1d851eb},
+{'l', 0xc24d70a3, 0xb5000000},
+{'l', 0xb4800000, 0xc147ae14},
+{'l', 0x425f5c29, 0xc29051ec},
+{'l', 0x41199998, 0x00000000},
+{'l', 0x00000000, 0x428fae14},
+{'l', 0x416147b0, 0x36800000},
+{'l', 0x00000000, 0x414cccce},
+{'4', 0x0000ff90, 0x00d80000},
+{'l', 0xc16147b0, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41933333, 0xc19c28f6},
+{'4', 0x00000131, 0xfe700000},
+{'l', 0xc218f5c2, 0x424851eb},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002b0034, 0xfffffffd},/*kerning  4 + : -0.011719 */
+{'[', 0x00540034, 0xfffffff7},/*kerning  4 T : -0.035156 */
+{'[', 0x00560034, 0xfffffff7},/*kerning  4 V : -0.035156 */
+{'[', 0x00570034, 0xfffffff7},/*kerning  4 W : -0.035156 */
+{'[', 0x00590034, 0xfffffff3},/*kerning  4 Y : -0.050781 */
+{'[', 0x005c0034, 0xfffffff8},/*kerning  4 \ : -0.031250 */
+{'[', 0x00b00034, 0xfffffffe},/*kerning  4 ° : -0.007812 */
+{'[', 0x00dd0034, 0xfffffff3},/*kerning  4 Ý : -0.050781 */
+{'[', 0x00f70034, 0xfffffffd},/*kerning  4 ÷ : -0.011719 */
+{'@', 0x00000035, 0x00005700},/*        5        x-advance: 87.000000 */
+{'M', 0x4227ae14, 0x41beb852},
+{'q', 0xc1428f5a, 0x00000000},
+{0, 0xc1af5c28, 0xc0b851ec},
+{'9', 0xffd2ffb2, 0xff86ff8b},
+{'l', 0x410ccccd, 0xc0f5c290},
+{'q', 0x408f5c28, 0x40eb851e},
+{0, 0x413eb852, 0x413d70a4},
+{'q', 0x40ee1478, 0x408f5c28},
+{0, 0x4180a3d6, 0x408f5c28},
+{'8', 0xe768003a, 0xb948e72e},
+{'8', 0x981ad31a, 0x9be6c700},
+{'8', 0xbdbad5e6, 0xe89de8d4},
+{'8', 0x189900c9, 0x45b218d0},
+{'l', 0xc14a3d70, 0x00000000},
+{'l', 0x414ccccc, 0xc2823d71},
+{'l', 0x425ccccc, 0x00000000},
+{'4', 0x00670000, 0x0000fe9a},
+{'l', 0xc0dc28f8, 0x4210a3d8},
+{'8', 0xd247e31c, 0xef5fef2a},
+{'q', 0x4128f5c4, 0x00000000},
+{0, 0x4197ae14, 0x40947ae0},
+{'q', 0x41066668, 0x40947ae0},
+{0, 0x41547ae0, 0x414ccccc},
+{'q', 0x409c2900, 0x41028f5c},
+{0, 0x409c2900, 0x41970a3d},
+{'q', 0x00000000, 0x41333333},
+{0, 0xc0ab8520, 0x419e147b},
+{'q', 0xc0ab8520, 0x4108f5c2},
+{0, 0xc167ae18, 0x41547ae0},
+{'q', 0xc111eb84, 0x40970a40},
+{0, 0xc1a28f5c, 0x40970a40},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002b0035, 0xfffffffb},/*kerning  5 + : -0.019531 */
+{'[', 0x00540035, 0xfffffffd},/*kerning  5 T : -0.011719 */
+{'[', 0x00560035, 0xfffffffc},/*kerning  5 V : -0.015625 */
+{'[', 0x00570035, 0xfffffffc},/*kerning  5 W : -0.015625 */
+{'[', 0x00590035, 0xfffffffa},/*kerning  5 Y : -0.023438 */
+{'[', 0x005c0035, 0xfffffffd},/*kerning  5 \ : -0.011719 */
+{'[', 0x00c60035, 0x00000002},/*kerning  5 Æ : 0.007812 */
+{'[', 0x00dd0035, 0xfffffffa},/*kerning  5 Ý : -0.023438 */
+{'[', 0x00f70035, 0xfffffffd},/*kerning  5 ÷ : -0.011719 */
+{'@', 0x00000036, 0x00006000},/*        6        x-advance: 96.000000 */
+{'M', 0x42b3d70a, 0xc2166666},
+{'q', 0x00000000, 0x412e147a},
+{0, 0xc0ab8520, 0x419e147a},
+{'q', 0xc0ab8520, 0x410e147b},
+{0, 0xc168f5c0, 0x41628f5c},
+{'q', 0xc1133334, 0x40a8f5c3},
+{0, 0xc1a5c290, 0x40a8f5c3},
+{'q', 0xc1428f5c, 0x00000000},
+{0, 0xc1ab851e, 0xc0bae147},
+{'q', 0xc1147ae2, 0xc0bae148},
+{0, 0xc167ae15, 0xc1870a3d},
+{'q', 0xc0a66666, 0xc130a3d8},
+{0, 0xc0a66666, 0xc1d1eb86},
+{'q', 0x00000000, 0xc2066666},
+{0, 0x413ae148, 0xc24947ac},
+{'q', 0x413ae146, 0xc185c290},
+{0, 0x41f70a3c, 0xc185c290},
+{'q', 0x4130a3d8, 0x00000000},
+{0, 0x41a0a3d6, 0x40ab8520},
+{'9', 0x002a0048, 0x00760071},
+{'l', 0xc10a3d70, 0x4107ae18},
+{'q', 0xc06147c0, 0xc0f0a3e0},
+{0, 0xc1266668, 0xc13eb850},
+{'q', 0xc0dc28f8, 0xc08cccd0},
+{0, 0xc175c290, 0xc08cccd0},
+{'q', 0xc151eb84, 0x00000000},
+{0, 0xc1a7ae14, 0x413ae148},
+{'q', 0xc0fae144, 0x413ae140},
+{0, 0xc1028f5c, 0x42033332},
+{'q', 0x406147b0, 0xc1051eb8},
+{0, 0x41370a3c, 0xc1547ae0},
+{'q', 0x40fd70a8, 0xc09eb850},
+{0, 0x418eb852, 0xc09eb850},
+{'q', 0x4130a3d8, 0x00000000},
+{0, 0x419f5c2a, 0x40a3d700},
+{'q', 0x410e1478, 0x40a3d710},
+{0, 0x416147b0, 0x415c28f8},
+{'9', 0x00450029, 0x009a0029},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4245c28f, 0xc128f5c2},
+{'8', 0xe36c003a, 0xb24ee331},
+{'8', 0x941dcf1d, 0x95e3c600},
+{'8', 0xb2b2d0e3, 0xe394e3cf},
+{'8', 0x1d9400c6, 0x4eb21dcf},
+{'8', 0x6be330e3, 0x6c1d3a00},
+{'8', 0x4e4e311d, 0x1d6c1d31},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00410036, 0xfffffffd},/*kerning  6 A : -0.011719 */
+{'[', 0x00560036, 0xfffffffc},/*kerning  6 V : -0.015625 */
+{'[', 0x00570036, 0xfffffffc},/*kerning  6 W : -0.015625 */
+{'[', 0x00590036, 0xfffffffa},/*kerning  6 Y : -0.023438 */
+{'[', 0x00c00036, 0xfffffffd},/*kerning  6 À : -0.011719 */
+{'[', 0x00c10036, 0xfffffffd},/*kerning  6 Á : -0.011719 */
+{'[', 0x00c20036, 0xfffffffd},/*kerning  6 Â : -0.011719 */
+{'[', 0x00c30036, 0xfffffffd},/*kerning  6 Ã : -0.011719 */
+{'[', 0x00c40036, 0xfffffffd},/*kerning  6 Ä : -0.011719 */
+{'[', 0x00c50036, 0xfffffffd},/*kerning  6 Å : -0.011719 */
+{'[', 0x00c60036, 0xfffffffd},/*kerning  6 Æ : -0.011719 */
+{'[', 0x00dd0036, 0xfffffffa},/*kerning  6 Ý : -0.023438 */
+{'@', 0x00000037, 0x00005500},/*        7        x-advance: 85.000000 */
+{'M', 0x427ae147, 0xc2a0a3d7},
+{'l', 0xc2699999, 0x00000000},
+{'l', 0x00000000, 0xc14f5c28},
+{'l', 0x42a147ae, 0x00000000},
+{'4', 0x038cfe38, 0x0000ff80},
+{'l', 0x424b851e, 0xc2c947ae},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002b0037, 0xfffffffe},/*kerning  7 + : -0.007812 */
+{'[', 0x002c0037, 0xfffffff0},/*kerning  7 , : -0.062500 */
+{'[', 0x002d0037, 0xfffffffa},/*kerning  7 - : -0.023438 */
+{'[', 0x002e0037, 0xfffffff0},/*kerning  7 . : -0.062500 */
+{'[', 0x002f0037, 0xfffffff2},/*kerning  7 / : -0.054688 */
+{'[', 0x00340037, 0xfffffff4},/*kerning  7 4 : -0.046875 */
+{'[', 0x00350037, 0xfffffffd},/*kerning  7 5 : -0.011719 */
+{'[', 0x003d0037, 0xfffffffd},/*kerning  7 = : -0.011719 */
+{'[', 0x00410037, 0xfffffff6},/*kerning  7 A : -0.039062 */
+{'[', 0x004a0037, 0xfffffff1},/*kerning  7 J : -0.058594 */
+{'[', 0x00a20037, 0xfffffffc},/*kerning  7 ¢ : -0.015625 */
+{'[', 0x00b70037, 0xfffffffb},/*kerning  7 · : -0.019531 */
+{'[', 0x00c00037, 0xfffffff6},/*kerning  7 À : -0.039062 */
+{'[', 0x00c10037, 0xfffffff6},/*kerning  7 Á : -0.039062 */
+{'[', 0x00c20037, 0xfffffff6},/*kerning  7 Â : -0.039062 */
+{'[', 0x00c30037, 0xfffffff6},/*kerning  7 Ã : -0.039062 */
+{'[', 0x00c40037, 0xfffffff6},/*kerning  7 Ä : -0.039062 */
+{'[', 0x00c50037, 0xfffffff6},/*kerning  7 Å : -0.039062 */
+{'[', 0x00c60037, 0xfffffff2},/*kerning  7 Æ : -0.054688 */
+{'[', 0x00d70037, 0xfffffffc},/*kerning  7 × : -0.015625 */
+{'[', 0x00f70037, 0xfffffffa},/*kerning  7 ÷ : -0.023438 */
+{'@', 0x00000038, 0x00005f00},/*        8        x-advance: 95.000000 */
+{'M', 0x42afae14, 0xc200a3d7},
+{'q', 0x00000000, 0x412147ae},
+{0, 0xc0b0a3e0, 0x418ccccd},
+{'q', 0xc0b0a3d0, 0x40f0a3d6},
+{0, 0xc16b8518, 0x413ae147},
+{'q', 0xc1133334, 0x40851eb8},
+{0, 0xc1a0a3d6, 0x40851eb8},
+{'q', 0xc135c290, 0x34800000},
+{0, 0xc1a28f5c, 0xc091eb84},
+{'q', 0xc10f5c2a, 0xc091eb85},
+{0, 0xc1628f5d, 0xc143d70a},
+{'q', 0xc0a66667, 0xc0f5c28e},
+{0, 0xc0a66667, 0xc18a3d70},
+{'8', 0x9b19c800, 0xb440d419},
+{'8', 0xd250e127, 0xb89fe8c8},
+{'8', 0x91d7d0d7, 0x9b19c700},
+{'8', 0xb643d419, 0xd25de22a},
+{'8', 0xf166f133, 0x0f660033},
+{'8', 0x2d5e0f33, 0x4a441e2a},
+{'q', 0x404ccce0, 0x40b0a3e0},
+{0, 0x404ccce0, 0x414b8520},
+{'q', 0x00000000, 0x40fae150},
+{0, 0xc0a8f5c0, 0x41600000},
+{'q', 0xc0a8f5c0, 0x40c51eb8},
+{0, 0xc147ae10, 0x41133334},
+{'q', 0x410a3d70, 0x40570a40},
+{0, 0x4170a3d8, 0x412ccccc},
+{'9', 0x003b0033, 0x008e0033},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41cf5c29, 0xc2a6b852},
+{'8', 0x4c1a2c00, 0x2f431f1a},
+{'8', 0x10501028, 0xf0510028},
+{'8', 0xd043f028, 0xb21ae01a},
+{'8', 0xb6e8d500, 0xd1bfe2e8},
+{'8', 0xf0aaf0d8, 0x11ab00d4},
+{'8', 0x30c011d8, 0x4ae81fe8},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42933333, 0xc2047ae1},
+{'8', 0xa2e1c900, 0xc5b2d9e1},
+{'8', 0xec9fecd1, 0x159f00cd},
+{'8', 0x3cb415d2, 0x5ce327e3},
+{'8', 0x5c1e3500, 0x3b4e261e},
+{'8', 0x15601530, 0xeb610033},
+{'8', 0xc34ceb2e, 0xa61ed91e},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00410038, 0xfffffffd},/*kerning  8 A : -0.011719 */
+{'[', 0x00560038, 0xfffffffc},/*kerning  8 V : -0.015625 */
+{'[', 0x00570038, 0xfffffffc},/*kerning  8 W : -0.015625 */
+{'[', 0x00590038, 0xfffffffa},/*kerning  8 Y : -0.023438 */
+{'[', 0x00c00038, 0xfffffffd},/*kerning  8 À : -0.011719 */
+{'[', 0x00c10038, 0xfffffffd},/*kerning  8 Á : -0.011719 */
+{'[', 0x00c20038, 0xfffffffd},/*kerning  8 Â : -0.011719 */
+{'[', 0x00c30038, 0xfffffffd},/*kerning  8 Ã : -0.011719 */
+{'[', 0x00c40038, 0xfffffffd},/*kerning  8 Ä : -0.011719 */
+{'[', 0x00c50038, 0xfffffffd},/*kerning  8 Å : -0.011719 */
+{'[', 0x00c60038, 0xfffffffe},/*kerning  8 Æ : -0.007812 */
+{'[', 0x00dd0038, 0xfffffffa},/*kerning  8 Ý : -0.023438 */
+{'@', 0x00000039, 0x00005e00},/*        9        x-advance: 94.000000 */
+{'M', 0x40b851eb, 0xc250a3d7},
+{'q', 0x00000000, 0xc12e1478},
+{0, 0x40ab851f, 0xc19e147a},
+{'q', 0x40ab851e, 0xc10e1478},
+{0, 0x416a3d71, 0xc1628f60},
+{'q', 0x41147ae2, 0xc0a8f5c0},
+{0, 0x41a51eb7, 0xc0a8f5c0},
+{'q', 0x41451eb8, 0x00000000},
+{0, 0x41ac28f6, 0x40bae140},
+{'q', 0x41133330, 0x40bae150},
+{0, 0x41666660, 0x41866668},
+{'q', 0x40a66670, 0x412f5c2c},
+{0, 0x40a66670, 0x41d28f5e},
+{'q', 0x00000000, 0x42066666},
+{0, 0xc13ae148, 0x424947ad},
+{'q', 0xc13ae148, 0x4185c290},
+{0, 0xc1f70a3c, 0x4185c290},
+{'q', 0xc130a3d8, 0x00000000},
+{0, 0xc1a0a3d7, 0xc0ab8520},
+{'9', 0xffd6ffb8, 0xff8aff8f},
+{'l', 0x410a3d70, 0xc107ae14},
+{'q', 0x406147b0, 0x40eb851e},
+{0, 0x4127ae16, 0x413d70a4},
+{'q', 0x40deb850, 0x408f5c28},
+{0, 0x41747ae0, 0x408f5c28},
+{'q', 0x4151eb84, 0x00000000},
+{0, 0x41a851ee, 0xc13ae148},
+{'q', 0x40fd70a0, 0xc13ae147},
+{0, 0x410147a8, 0xc2033333},
+{'q', 0xc06147a0, 0x41051eb8},
+{0, 0xc1370a3c, 0x41547ae0},
+{'q', 0xc0fd70a8, 0x409eb854},
+{0, 0xc18eb852, 0x409eb854},
+{'q', 0xc12e147c, 0x00000000},
+{0, 0xc19eb852, 0xc0a3d70c},
+{'q', 0xc10f5c28, 0xc0a3d708},
+{0, 0xc1628f5b, 0xc15c28f4},
+{'9', 0xffbbffd7, 0xff66ffd7},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4238f5c2, 0xc29e6666},
+{'8', 0x1d9400c6, 0x4eb21dcf},
+{'8', 0x6ce330e3, 0x6b1d3a00},
+{'8', 0x4e4e301d, 0x1d6c1d31},
+{'8', 0xe36c003c, 0xb24ee330},
+{'8', 0x951dd01d, 0x94e3c600},
+{'8', 0xb2b2cfe3, 0xe394e3cf},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00220039, 0xfffffffc},/*kerning  9 " : -0.015625 */
+{'[', 0x00270039, 0xfffffffc},/*kerning  9 ' : -0.015625 */
+{'[', 0x00540039, 0xffffffef},/*kerning  9 T : -0.066406 */
+{'[', 0x00560039, 0xfffffff6},/*kerning  9 V : -0.039062 */
+{'[', 0x00570039, 0xfffffff6},/*kerning  9 W : -0.039062 */
+{'[', 0x00590039, 0xfffffff1},/*kerning  9 Y : -0.058594 */
+{'[', 0x005c0039, 0xfffffff7},/*kerning  9 \ : -0.035156 */
+{'[', 0x00b00039, 0xfffffff8},/*kerning  9 ° : -0.031250 */
+{'[', 0x00dd0039, 0xfffffff1},/*kerning  9 Ý : -0.058594 */
+{'@', 0x0000003a, 0x00002000},/*        :        x-advance: 32.000000 */
+{'M', 0x4123d70a, 0xc281eb85},
+{'l', 0x00000000, 0xc18f5c28},
+{'4', 0x0000005d, 0x008f0000},
+{'l', 0xc13ae148, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4123d70a, 0x80000000},
+{'l', 0x00000000, 0xc18f5c29},
+{'4', 0x0000005d, 0x008f0000},
+{'l', 0xc13ae148, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0054003a, 0xfffffff5},/*kerning  : T : -0.042969 */
+{'[', 0x0056003a, 0xfffffffc},/*kerning  : V : -0.015625 */
+{'[', 0x0057003a, 0xfffffffc},/*kerning  : W : -0.015625 */
+{'[', 0x0059003a, 0xfffffff9},/*kerning  : Y : -0.027344 */
+{'[', 0x00dd003a, 0xfffffff9},/*kerning  : Ý : -0.027344 */
+{'@', 0x0000003b, 0x00002300},/*        ;        x-advance: 35.000000 */
+{'M', 0x4130a3d7, 0xc281eb85},
+{'l', 0x00000000, 0xc18f5c28},
+{'4', 0x0000005d, 0x008f0000},
+{'l', 0xc13ae147, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x414a3d70, 0x414f5c29},
+{'l', 0x404ccccc, 0xc163d70a},
+{'l', 0xc0999998, 0xb4800000},
+{'l', 0x00000000, 0xc1851eb8},
+{'l', 0x41547ae1, 0x00000000},
+{'4', 0x00850000, 0x0071ffda},
+{'l', 0xc0dc28f8, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0054003b, 0xfffffff5},/*kerning  ; T : -0.042969 */
+{'[', 0x0056003b, 0xfffffffc},/*kerning  ; V : -0.015625 */
+{'[', 0x0057003b, 0xfffffffc},/*kerning  ; W : -0.015625 */
+{'[', 0x0059003b, 0xfffffff9},/*kerning  ; Y : -0.027344 */
+{'[', 0x00dd003b, 0xfffffff9},/*kerning  ; Ý : -0.027344 */
+{'@', 0x0000003c, 0x00005100},/*        <        x-advance: 81.000000 */
+{'M', 0x40a8f5c2, 0xc2333333},
+{'l', 0x42866666, 0xc221eb85},
+{'l', 0x00000000, 0x4170a3d8},
+{'l', 0xc23ae146, 0x41e66666},
+{'l', 0x423ae146, 0x41e28f5c},
+{'4', 0x007d0000, 0xfec0fde7},
+{'l', 0x35800000, 0xc0eb8518},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x0000003d, 0x00004600},/*        =        x-advance: 70.000000 */
+{'M', 0x412b851e, 0xc24851eb},
+{'l', 0x00000000, 0xc119999c},
+{'4', 0x00000186, 0x004c0000},
+{'l', 0xc2433334, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x412b851e, 0xc1e51eb8},
+{'l', 0x00000000, 0xc1199998},
+{'4', 0x00000186, 0x004c0000},
+{'l', 0xc2433334, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0033003d, 0xfffffffd},/*kerning  = 3 : -0.011719 */
+{'[', 0x0037003d, 0xfffffffc},/*kerning  = 7 : -0.015625 */
+{'@', 0x0000003e, 0x00005100},/*        >        x-advance: 81.000000 */
+{'M', 0x4298a3d7, 0xc215c28f},
+{'l', 0xc2866666, 0x42200000},
+{'l', 0xb6400000, 0xc17ae149},
+{'l', 0x423ae148, 0xc1e28f5c},
+{'l', 0xc23ae148, 0xc1e66666},
+{'4', 0xff880000, 0x01430219},
+{'l', 0x00000000, 0x40eb8520},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x0000003f, 0x00004c00},/*        ?        x-advance: 76.000000 */
+{'M', 0x41b851eb, 0xc2070a3d},
+{'q', 0x00000000, 0xc10a3d70},
+{0, 0x40428f58, 0xc171eb84},
+{'8', 0xa853cd18, 0xe035f117},
+{'8', 0xd939f01e, 0xcb2dea1b},
+{'8', 0xb611e111, 0xafead000},
+{'8', 0xcfc6e0ea, 0xf0b4f0dd},
+{'q', 0xc0fffffc, 0x00000000},
+{0, 0xc163d708, 0x4091eb80},
+{'9', 0x0024ffcf, 0x0055ffb5},
+{'l', 0xc1170a3e, 0xc0c7ae20},
+{'q', 0x408a3d72, 0xc11eb850},
+{0, 0x4159999b, 0xc1747ae0},
+{'q', 0x41147ae0, 0xc0ab8520},
+{0, 0x419eb850, 0xc0ab8520},
+{'q', 0x41000000, 0x00000000},
+{0, 0x41747ae0, 0x4051eba0},
+{'q', 0x40e8f5c8, 0x4051eb80},
+{0, 0x413eb858, 0x412147b0},
+{'q', 0x40947ae0, 0x40d99990},
+{0, 0x40947ae0, 0x418ae144},
+{'8', 0x69ea4000, 0x44c629ea},
+{'8', 0x33b01adc, 0x25c510e2},
+{'8', 0x35d114e4, 0x58ee20ee},
+{'l', 0xc13d70a6, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41bae147, 0x80000000},
+{'l', 0x00000000, 0xc1947ae1},
+{'4', 0x0000005e, 0x00940000},
+{'l', 0xc13d70a6, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00000040, 0x00008600},/*        @        x-advance: 134.000000 */
+{'M', 0x4286147b, 0xc2c0f5c2},
+{'q', 0x413d70a0, 0x00000000},
+{0, 0x41b33334, 0x4087ae10},
+{'q', 0x4128f5c0, 0x4087ae10},
+{0, 0x4195c290, 0x4143d708},
+{'q', 0x41028f58, 0x41000000},
+{0, 0x414e1470, 0x419a3d70},
+{'q', 0x40970a40, 0x41347ae4},
+{0, 0x40970a40, 0x41c9999a},
+{'8', 0x3afd1500, 0x4ff325fd},
+{'8', 0x50e22af6, 0x3ec925ec},
+{'8', 0x18a918dd, 0xf0be00d5},
+{'8', 0xd6e0f0e9, 0xcaf4e6f8},
+{'q', 0xc08f5c30, 0x40999999},
+{0, 0xc13999a0, 0x410147ae},
+{'q', 0xc0e3d700, 0x4051eb83},
+{0, 0xc1799994, 0x4051eb83},
+{'q', 0xc13ae148, 0xb3800000},
+{0, 0xc1900000, 0xc0c7ae14},
+{'q', 0xc0ca3d70, 0xc0c7ae14},
+{0, 0xc0ca3d70, 0xc17851ec},
+{'8', 0x9623bd00, 0xc95bda23},
+{'q', 0x40deb850, 0xc0051ec0},
+{0, 0x41600004, 0xc0051ec0},
+{'8', 0x0a5f0037, 0x123d0a28},
+{'8', 0x9df4c800, 0xbdd2d6f4},
+{'8', 0xe8a1e8df, 0x10a000cd},
+{'9', 0x000fffd4, 0x002affb0},
+{'l', 0xc04cccd0, 0xc0fae148},
+{'q', 0x40b851f0, 0xc075c280},
+{0, 0x4147ae14, 0xc0bffff0},
+{'q', 0x40d70a40, 0xc00a3d80},
+{0, 0x416147b0, 0xc00a3d80},
+{'q', 0x41170a38, 0x00000000},
+{0, 0x416e1478, 0x403d70a0},
+{'8', 0x3e40172b, 0x551a2714},
+{'9', 0x002e0006, 0x005b0006},
+{'l', 0x00000000, 0x419851ec},
+{'8', 0x5e0a3800, 0x2636260a},
+{'8', 0xe63f0026, 0xbe26e618},
+{'8', 0xad13d80d, 0xb605d605},
+{'q', 0x00000000, 0xc13851ec},
+{0, 0xc07ae160, 0xc1aae148},
+{'q', 0xc07ae140, 0xc11d70a4},
+{0, 0xc12f5c28, 0xc1899996},
+{'q', 0xc0e147b0, 0xc0eb8520},
+{0, 0xc1847ae0, 0xc13851f0},
+{'q', 0xc11851e8, 0xc0851eb0},
+{0, 0xc1a70a3c, 0xc0851eb0},
+{'q', 0xc130a3d8, 0x00000000},
+{0, 0xc1a51eb8, 0x407ae140},
+{'q', 0xc119999c, 0x407ae140},
+{0, 0xc185c290, 0x4131eb88},
+{'q', 0xc0e3d70c, 0x40e66660},
+{0, 0xc1333334, 0x4187ae12},
+{'q', 0xc0828f5c, 0x411c28f4},
+{0, 0xc0828f5c, 0x41aa3d70},
+{'q', 0x00000000, 0x41333334},
+{0, 0x4075c290, 0x41a7ae14},
+{'q', 0x4075c290, 0x411c28f6},
+{0, 0x412b851e, 0x4188f5c2},
+{'q', 0x40dc28f8, 0x40eb8520},
+{0, 0x41828f5c, 0x413851ec},
+{'q', 0x41170a3c, 0x40851eb8},
+{0, 0x41a51eb8, 0x40851eb8},
+{'8', 0xf3670038, 0xdd5ef32e},
+{'l', 0x400f5c20, 0x40c28f5a},
+{'8', 0x269619cd, 0x0c920cc9},
+{'q', 0xc13ffffc, 0x00000000},
+{0, 0xc1b3d708, 0xc08ccccc},
+{'q', 0xc127ae14, 0xc08ccccc},
+{0, 0xc193d70a, 0xc147ae14},
+{'q', 0xc1000000, 0xc10147ae},
+{0, 0xc148f5c2, 0xc198f5c2},
+{'q', 0xc091eb86, 0xc130a3d8},
+{0, 0xc091eb86, 0xc1c147ae},
+{'q', 0x00000000, 0xc15c28f4},
+{0, 0x409c28f6, 0xc1c66666},
+{'q', 0x409c28f4, 0xc130a3d8},
+{0, 0x41547ae0, 0xc1966664},
+{'q', 0x41066666, 0xc0f851f0},
+{0, 0x4198f5c3, 0xc13eb850},
+{'9', 0xffdf0055, 0xffdf00b3},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429851eb, 0xc1428f5c},
+{'8', 0xc940e931, 0xbf0ee00e},
+{'l', 0x00000000, 0xc0bd70a4},
+{'8', 0xf1c6fef0, 0xf49df4d7},
+{'8', 0x0aaf00d5, 0x23c40adb},
+{'8', 0x43e918e9, 0x50222f00},
+{'8', 0x205c2022, 0xf83e001e},
+{'q', 0x407ae140, 0xbf851eb8},
+{0, 0x40deb850, 0xc01eb854},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00220040, 0xfffffffc},/*kerning  @ " : -0.015625 */
+{'[', 0x00270040, 0xfffffffc},/*kerning  @ ' : -0.015625 */
+{'[', 0x00410040, 0xfffffffd},/*kerning  @ A : -0.011719 */
+{'[', 0x00540040, 0xffffffee},/*kerning  @ T : -0.070312 */
+{'[', 0x00560040, 0xfffffff4},/*kerning  @ V : -0.046875 */
+{'[', 0x00570040, 0xfffffff4},/*kerning  @ W : -0.046875 */
+{'[', 0x00590040, 0xffffffee},/*kerning  @ Y : -0.070312 */
+{'[', 0x00760040, 0xfffffffe},/*kerning  @ v : -0.007812 */
+{'[', 0x00770040, 0xfffffffe},/*kerning  @ w : -0.007812 */
+{'[', 0x00790040, 0xfffffffd},/*kerning  @ y : -0.011719 */
+{'[', 0x00c00040, 0xfffffffd},/*kerning  @ À : -0.011719 */
+{'[', 0x00c10040, 0xfffffffd},/*kerning  @ Á : -0.011719 */
+{'[', 0x00c20040, 0xfffffffd},/*kerning  @ Â : -0.011719 */
+{'[', 0x00c30040, 0xfffffffd},/*kerning  @ Ã : -0.011719 */
+{'[', 0x00c40040, 0xfffffffd},/*kerning  @ Ä : -0.011719 */
+{'[', 0x00c50040, 0xfffffffd},/*kerning  @ Å : -0.011719 */
+{'[', 0x00dd0040, 0xffffffee},/*kerning  @ Ý : -0.070312 */
+{'[', 0x00fd0040, 0xfffffffd},/*kerning  @ ý : -0.011719 */
+{'[', 0x00ff0040, 0xfffffffd},/*kerning  @ ÿ : -0.011719 */
+{'@', 0x00000041, 0x00006c00},/*        A        x-advance: 108.000000 */
+{'M', 0x4240a3d7, 0xc2e33333},
+{'l', 0x41428f5c, 0x00000000},
+{'l', 0x4239999a, 0x42e33333},
+{'l', 0xc175c290, 0x80000000},
+{'l', 0xc1570a40, 0xc2051eb8},
+{'l', 0xc23eb852, 0x00000000},
+{'4', 0x010aff96, 0x0000ff86},
+{'l', 0x423a3d70, 0xc2e33333},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429570a4, 0xc231eb85},
+{'4', 0xfe5dff5d, 0x01a3ff58},
+{'l', 0x42266667, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200041, 0xfffffff9},/*kerning  A   : -0.027344 */
+{'[', 0x00220041, 0xfffffff0},/*kerning  A " : -0.062500 */
+{'[', 0x00260041, 0xfffffffd},/*kerning  A & : -0.011719 */
+{'[', 0x00270041, 0xfffffff0},/*kerning  A ' : -0.062500 */
+{'[', 0x002a0041, 0xffffffef},/*kerning  A * : -0.066406 */
+{'[', 0x00300041, 0xfffffffc},/*kerning  A 0 : -0.015625 */
+{'[', 0x00360041, 0xfffffffc},/*kerning  A 6 : -0.015625 */
+{'[', 0x00370041, 0xfffffffd},/*kerning  A 7 : -0.011719 */
+{'[', 0x00380041, 0xfffffffd},/*kerning  A 8 : -0.011719 */
+{'[', 0x003f0041, 0xfffffffa},/*kerning  A ? : -0.023438 */
+{'[', 0x00400041, 0xfffffffd},/*kerning  A @ : -0.011719 */
+{'[', 0x00430041, 0xfffffffa},/*kerning  A C : -0.023438 */
+{'[', 0x00470041, 0xfffffffa},/*kerning  A G : -0.023438 */
+{'[', 0x004f0041, 0xfffffffa},/*kerning  A O : -0.023438 */
+{'[', 0x00510041, 0xfffffffa},/*kerning  A Q : -0.023438 */
+{'[', 0x00530041, 0xfffffffe},/*kerning  A S : -0.007812 */
+{'[', 0x00540041, 0xffffffef},/*kerning  A T : -0.066406 */
+{'[', 0x00550041, 0xfffffff9},/*kerning  A U : -0.027344 */
+{'[', 0x00560041, 0xfffffff2},/*kerning  A V : -0.054688 */
+{'[', 0x00570041, 0xfffffff1},/*kerning  A W : -0.058594 */
+{'[', 0x00590041, 0xffffffed},/*kerning  A Y : -0.074219 */
+{'[', 0x005c0041, 0xffffffed},/*kerning  A \ : -0.074219 */
+{'[', 0x00610041, 0xfffffffe},/*kerning  A a : -0.007812 */
+{'[', 0x00630041, 0xfffffffc},/*kerning  A c : -0.015625 */
+{'[', 0x00640041, 0xfffffffd},/*kerning  A d : -0.011719 */
+{'[', 0x00650041, 0xfffffffc},/*kerning  A e : -0.015625 */
+{'[', 0x00660041, 0xfffffffc},/*kerning  A f : -0.015625 */
+{'[', 0x00670041, 0xfffffffd},/*kerning  A g : -0.011719 */
+{'[', 0x006f0041, 0xfffffffc},/*kerning  A o : -0.015625 */
+{'[', 0x00710041, 0xfffffffd},/*kerning  A q : -0.011719 */
+{'[', 0x00730041, 0xfffffffe},/*kerning  A s : -0.007812 */
+{'[', 0x00740041, 0xfffffffb},/*kerning  A t : -0.019531 */
+{'[', 0x00750041, 0xfffffffe},/*kerning  A u : -0.007812 */
+{'[', 0x00760041, 0xfffffff8},/*kerning  A v : -0.031250 */
+{'[', 0x00770041, 0xfffffff8},/*kerning  A w : -0.031250 */
+{'[', 0x00790041, 0xfffffff8},/*kerning  A y : -0.031250 */
+{'[', 0x00a90041, 0xfffffffb},/*kerning  A © : -0.019531 */
+{'[', 0x00aa0041, 0xfffffff4},/*kerning  A ª : -0.046875 */
+{'[', 0x00ab0041, 0xfffffffd},/*kerning  A « : -0.011719 */
+{'[', 0x00ae0041, 0xfffffffb},/*kerning  A ® : -0.019531 */
+{'[', 0x00ba0041, 0xfffffff3},/*kerning  A º : -0.050781 */
+{'[', 0x00c70041, 0xfffffffa},/*kerning  A Ç : -0.023438 */
+{'[', 0x00d20041, 0xfffffffa},/*kerning  A Ò : -0.023438 */
+{'[', 0x00d30041, 0xfffffffa},/*kerning  A Ó : -0.023438 */
+{'[', 0x00d40041, 0xfffffffa},/*kerning  A Ô : -0.023438 */
+{'[', 0x00d50041, 0xfffffffa},/*kerning  A Õ : -0.023438 */
+{'[', 0x00d60041, 0xfffffffa},/*kerning  A Ö : -0.023438 */
+{'[', 0x00d80041, 0xfffffffa},/*kerning  A Ø : -0.023438 */
+{'[', 0x00d90041, 0xfffffff9},/*kerning  A Ù : -0.027344 */
+{'[', 0x00da0041, 0xfffffff9},/*kerning  A Ú : -0.027344 */
+{'[', 0x00db0041, 0xfffffff9},/*kerning  A Û : -0.027344 */
+{'[', 0x00dc0041, 0xfffffff9},/*kerning  A Ü : -0.027344 */
+{'[', 0x00dd0041, 0xffffffed},/*kerning  A Ý : -0.074219 */
+{'[', 0x00e00041, 0xfffffffe},/*kerning  A à : -0.007812 */
+{'[', 0x00e10041, 0xfffffffe},/*kerning  A á : -0.007812 */
+{'[', 0x00e20041, 0xfffffffe},/*kerning  A â : -0.007812 */
+{'[', 0x00e30041, 0xfffffffe},/*kerning  A ã : -0.007812 */
+{'[', 0x00e40041, 0xfffffffe},/*kerning  A ä : -0.007812 */
+{'[', 0x00e50041, 0xfffffffe},/*kerning  A å : -0.007812 */
+{'[', 0x00e60041, 0xfffffffe},/*kerning  A æ : -0.007812 */
+{'[', 0x00e70041, 0xfffffffc},/*kerning  A ç : -0.015625 */
+{'[', 0x00e80041, 0xfffffffc},/*kerning  A è : -0.015625 */
+{'[', 0x00e90041, 0xfffffffc},/*kerning  A é : -0.015625 */
+{'[', 0x00ea0041, 0xfffffffc},/*kerning  A ê : -0.015625 */
+{'[', 0x00eb0041, 0xfffffffc},/*kerning  A ë : -0.015625 */
+{'[', 0x00f00041, 0xfffffffd},/*kerning  A ð : -0.011719 */
+{'[', 0x00f20041, 0xfffffffc},/*kerning  A ò : -0.015625 */
+{'[', 0x00f30041, 0xfffffffc},/*kerning  A ó : -0.015625 */
+{'[', 0x00f40041, 0xfffffffc},/*kerning  A ô : -0.015625 */
+{'[', 0x00f50041, 0xfffffffc},/*kerning  A õ : -0.015625 */
+{'[', 0x00f60041, 0xfffffffc},/*kerning  A ö : -0.015625 */
+{'[', 0x00f80041, 0xfffffffc},/*kerning  A ø : -0.015625 */
+{'[', 0x00f90041, 0xfffffffe},/*kerning  A ù : -0.007812 */
+{'[', 0x00fa0041, 0xfffffffe},/*kerning  A ú : -0.007812 */
+{'[', 0x00fb0041, 0xfffffffe},/*kerning  A û : -0.007812 */
+{'[', 0x00fc0041, 0xfffffffe},/*kerning  A ü : -0.007812 */
+{'[', 0x00fd0041, 0xfffffff8},/*kerning  A ý : -0.031250 */
+{'[', 0x00ff0041, 0xfffffff8},/*kerning  A ÿ : -0.031250 */
+{'@', 0x00000042, 0x00006b00},/*        B        x-advance: 107.000000 */
+{'M', 0x42c99999, 0xc1ea3d70},
+{'q', 0x00000000, 0x410ccccc},
+{0, 0xc08f5c30, 0x4175c28e},
+{'q', 0xc08f5c20, 0x40d1eb86},
+{0, 0xc14147a8, 0x4123d70a},
+{'9', 0x001dffc4, 0x001dff7b},
+{'4', 0x0000fe51, 0xfc740000},
+{'l', 0x4261eb86, 0x00000000},
+{'8', 0x216e0040, 0x5747212e},
+{'q', 0x4047ae20, 0x40d47ae0},
+{0, 0x4047ae20, 0x415d70a0},
+{'q', 0x00000000, 0x41051eb8},
+{0, 0xc087ae20, 0x41799998},
+{'q', 0xc087ae10, 0x40e8f5c8},
+{0, 0xc14147a8, 0x412cccd0},
+{'q', 0x411c28f0, 0x403851e0},
+{0, 0x41770a38, 0x412a3d70},
+{'9', 0x003e002d, 0x0092002d},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41e00000, 0xc2ca3d70},
+{'4', 0x012f0000, 0x00000121},
+{'8', 0xd464003c, 0x9628d428},
+{'8', 0x94dbc100, 0xd4a1d4db},
+{'l', 0xc2147ae0, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42ac7ae1, 0xc1feb852},
+{'8', 0xb2eed600, 0xc7cfddee},
+{'9', 0xffebffe1, 0xffebffb8},
+{'4', 0x0000febb, 0x01380000},
+{'l', 0x421e147a, 0x00000000},
+{'8', 0xeb4c002a, 0xc835eb21},
+{'q', 0x401eb860, 0xc08ccccc},
+{0, 0x401eb860, 0xc11851ec},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00410042, 0xfffffffd},/*kerning  B A : -0.011719 */
+{'[', 0x00540042, 0xffffffff},/*kerning  B T : -0.003906 */
+{'[', 0x00560042, 0xfffffffb},/*kerning  B V : -0.019531 */
+{'[', 0x00570042, 0xfffffffb},/*kerning  B W : -0.019531 */
+{'[', 0x00580042, 0xfffffffd},/*kerning  B X : -0.011719 */
+{'[', 0x00590042, 0xfffffff9},/*kerning  B Y : -0.027344 */
+{'[', 0x005c0042, 0xfffffffe},/*kerning  B \ : -0.007812 */
+{'[', 0x00660042, 0xffffffff},/*kerning  B f : -0.003906 */
+{'[', 0x00730042, 0xffffffff},/*kerning  B s : -0.003906 */
+{'[', 0x00740042, 0xffffffff},/*kerning  B t : -0.003906 */
+{'[', 0x00760042, 0xffffffff},/*kerning  B v : -0.003906 */
+{'[', 0x00770042, 0xffffffff},/*kerning  B w : -0.003906 */
+{'[', 0x00780042, 0xfffffffe},/*kerning  B x : -0.007812 */
+{'[', 0x00790042, 0xffffffff},/*kerning  B y : -0.003906 */
+{'[', 0x00c00042, 0xfffffffd},/*kerning  B À : -0.011719 */
+{'[', 0x00c10042, 0xfffffffd},/*kerning  B Á : -0.011719 */
+{'[', 0x00c20042, 0xfffffffd},/*kerning  B Â : -0.011719 */
+{'[', 0x00c30042, 0xfffffffd},/*kerning  B Ã : -0.011719 */
+{'[', 0x00c40042, 0xfffffffd},/*kerning  B Ä : -0.011719 */
+{'[', 0x00c50042, 0xfffffffd},/*kerning  B Å : -0.011719 */
+{'[', 0x00c60042, 0xfffffffd},/*kerning  B Æ : -0.011719 */
+{'[', 0x00dd0042, 0xfffffff9},/*kerning  B Ý : -0.027344 */
+{'[', 0x00fd0042, 0xffffffff},/*kerning  B ý : -0.003906 */
+{'[', 0x00ff0042, 0xffffffff},/*kerning  B ÿ : -0.003906 */
+{'@', 0x00000043, 0x00006d00},/*        C        x-advance: 109.000000 */
+{'M', 0x40c7ae14, 0xc2666666},
+{'q', 0x00000000, 0xc1266668},
+{0, 0x40666668, 0xc1a33334},
+{'q', 0x40666664, 0xc1200000},
+{0, 0x4128f5c2, 0xc191eb84},
+{'q', 0x40deb850, 0xc103d708},
+{0, 0x418851eb, 0xc151eb88},
+{'q', 0x412147b0, 0xc09c28f0},
+{0, 0x41b70a3e, 0xc09c28f0},
+{'q', 0x41733330, 0x00000000},
+{0, 0x41d0a3d4, 0x40deb850},
+{'9', 0x00370057, 0x008e0081},
+{'l', 0xc135c290, 0x40eb8510},
+{'8', 0xa5bcc7e6, 0xd0a7dfd7},
+{'q', 0xc0c00000, 0xbfe147c0},
+{0, 0xc13c28f0, 0xbfe147c0},
+{'q', 0xc1170a40, 0x00000000},
+{0, 0xc185c290, 0x4075c280},
+{'q', 0xc0e8f5c0, 0x4075c2a0},
+{0, 0xc143d708, 0x4123d710},
+{'q', 0xc09eb854, 0x40ccccd0},
+{0, 0xc0ee1480, 0x41651eb8},
+{'q', 0xc01eb850, 0x40fd70a0},
+{0, 0xc01eb850, 0x417eb850},
+{'q', 0x00000000, 0x410ccccc},
+{0, 0x403d70a0, 0x4187ae14},
+{'q', 0x403d70a8, 0x41028f5c},
+{0, 0x4103d70c, 0x41666668},
+{'q', 0x40a8f5c0, 0x40c7ae14},
+{0, 0x4147ae14, 0x411eb851},
+{'q', 0x40e66668, 0x406b851c},
+{0, 0x417ae148, 0x406b851c},
+{'8', 0xf061002f, 0xcd5df031},
+{'9', 0xffdd002b, 0xffa50045},
+{'l', 0x41400000, 0x40d1eb88},
+{'q', 0xc06147c0, 0x4107ae14},
+{0, 0xc12e1480, 0x41666666},
+{'q', 0xc0eb8510, 0x40bd70a2},
+{0, 0xc1833330, 0x410f5c28},
+{'q', 0xc110a3d8, 0x40428f5c},
+{0, 0xc18eb852, 0x40428f5c},
+{'q', 0xc13ae148, 0xb3800000},
+{0, 0xc1ab851e, 0xc0a147ae},
+{'q', 0xc11c28f8, 0xc0a147ae},
+{0, 0xc1870a3e, 0xc1570a3e},
+{'q', 0xc0e3d70c, 0xc1066666},
+{0, 0xc130a3d8, 0xc1970a3c},
+{'q', 0xc07ae148, 0xc127ae14},
+{0, 0xc07ae148, 0xc1a9999a},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00410043, 0xfffffffe},/*kerning  C A : -0.007812 */
+{'[', 0x00430043, 0xfffffffe},/*kerning  C C : -0.007812 */
+{'[', 0x00470043, 0xfffffffe},/*kerning  C G : -0.007812 */
+{'[', 0x004f0043, 0xfffffffe},/*kerning  C O : -0.007812 */
+{'[', 0x00510043, 0xfffffffe},/*kerning  C Q : -0.007812 */
+{'[', 0x00560043, 0xfffffffd},/*kerning  C V : -0.011719 */
+{'[', 0x00570043, 0xfffffffe},/*kerning  C W : -0.007812 */
+{'[', 0x00580043, 0xffffffff},/*kerning  C X : -0.003906 */
+{'[', 0x00590043, 0xfffffffc},/*kerning  C Y : -0.015625 */
+{'[', 0x00c00043, 0xfffffffe},/*kerning  C À : -0.007812 */
+{'[', 0x00c10043, 0xfffffffe},/*kerning  C Á : -0.007812 */
+{'[', 0x00c20043, 0xfffffffe},/*kerning  C Â : -0.007812 */
+{'[', 0x00c30043, 0xfffffffe},/*kerning  C Ã : -0.007812 */
+{'[', 0x00c40043, 0xfffffffe},/*kerning  C Ä : -0.007812 */
+{'[', 0x00c50043, 0xfffffffe},/*kerning  C Å : -0.007812 */
+{'[', 0x00c60043, 0xfffffffe},/*kerning  C Æ : -0.007812 */
+{'[', 0x00c70043, 0xfffffffe},/*kerning  C Ç : -0.007812 */
+{'[', 0x00d20043, 0xfffffffe},/*kerning  C Ò : -0.007812 */
+{'[', 0x00d30043, 0xfffffffe},/*kerning  C Ó : -0.007812 */
+{'[', 0x00d40043, 0xfffffffe},/*kerning  C Ô : -0.007812 */
+{'[', 0x00d50043, 0xfffffffe},/*kerning  C Õ : -0.007812 */
+{'[', 0x00d60043, 0xfffffffe},/*kerning  C Ö : -0.007812 */
+{'[', 0x00d80043, 0xfffffffe},/*kerning  C Ø : -0.007812 */
+{'[', 0x00dd0043, 0xfffffffc},/*kerning  C Ý : -0.015625 */
+{'@', 0x00000044, 0x00007200},/*        D        x-advance: 114.000000 */
+{'M', 0x41599999, 0x80000000},
+{'4', 0xfc740000, 0x0000013a},
+{'q', 0x4191eb84, 0x00000000},
+{0, 0x41f3d70c, 0x40f33330},
+{'q', 0x4143d708, 0x40f33330},
+{0, 0x41928f58, 0x41a3d708},
+{'q', 0x40c28f60, 0x414e1480},
+{0, 0x40c28f60, 0x41e47ae4},
+{'q', 0x00000000, 0x418a3d70},
+{0, 0xc0d70a40, 0x41f0a3d6},
+{'q', 0xc0d70a30, 0x414cccce},
+{0, 0xc19851e8, 0x419eb852},
+{'9', 0x0038ff9e, 0x0038ff18},
+{'l', 0xc21d70a4, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42ba8f5c, 0xc263d70a},
+{'q', 0x00000000, 0xc14cccd0},
+{0, 0xc0970a40, 0xc1b5c290},
+{'q', 0xc0970a40, 0xc11eb850},
+{0, 0xc15ae148, 0xc17851e8},
+{'9', 0xffd4ffb9, 0xffd4ff51},
+{'4', 0x0000ff39, 0x02c00000},
+{'l', 0x41c7ae14, 0xb6800000},
+{'q', 0x4151eb88, 0x00000000},
+{0, 0x41b0a3d8, 0xc0bae148},
+{'q', 0x410f5c28, 0xc0bae148},
+{0, 0x41599998, 0xc17d70a4},
+{'q', 0x40947ae0, 0xc1200000},
+{0, 0x40947ae0, 0xc1b3d70a},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00290044, 0xfffffffc},/*kerning  D ) : -0.015625 */
+{'[', 0x002c0044, 0xfffffffd},/*kerning  D , : -0.011719 */
+{'[', 0x002e0044, 0xfffffffd},/*kerning  D . : -0.011719 */
+{'[', 0x002f0044, 0xfffffffa},/*kerning  D / : -0.023438 */
+{'[', 0x00410044, 0xfffffffa},/*kerning  D A : -0.023438 */
+{'[', 0x004a0044, 0xfffffffb},/*kerning  D J : -0.019531 */
+{'[', 0x00540044, 0xfffffffc},/*kerning  D T : -0.015625 */
+{'[', 0x00560044, 0xfffffffa},/*kerning  D V : -0.023438 */
+{'[', 0x00570044, 0xfffffffa},/*kerning  D W : -0.023438 */
+{'[', 0x00580044, 0xfffffff8},/*kerning  D X : -0.031250 */
+{'[', 0x00590044, 0xfffffff5},/*kerning  D Y : -0.042969 */
+{'[', 0x005a0044, 0xfffffffd},/*kerning  D Z : -0.011719 */
+{'[', 0x005c0044, 0xfffffffb},/*kerning  D \ : -0.019531 */
+{'[', 0x00610044, 0xffffffff},/*kerning  D a : -0.003906 */
+{'[', 0x00730044, 0xffffffff},/*kerning  D s : -0.003906 */
+{'[', 0x00780044, 0xfffffffe},/*kerning  D x : -0.007812 */
+{'[', 0x00c00044, 0xfffffffa},/*kerning  D À : -0.023438 */
+{'[', 0x00c10044, 0xfffffffa},/*kerning  D Á : -0.023438 */
+{'[', 0x00c20044, 0xfffffffa},/*kerning  D Â : -0.023438 */
+{'[', 0x00c30044, 0xfffffffa},/*kerning  D Ã : -0.023438 */
+{'[', 0x00c40044, 0xfffffffa},/*kerning  D Ä : -0.023438 */
+{'[', 0x00c50044, 0xfffffffa},/*kerning  D Å : -0.023438 */
+{'[', 0x00c60044, 0xfffffff9},/*kerning  D Æ : -0.027344 */
+{'[', 0x00d00044, 0xffffffff},/*kerning  D Ð : -0.003906 */
+{'[', 0x00dd0044, 0xfffffff5},/*kerning  D Ý : -0.042969 */
+{'[', 0x00e00044, 0xffffffff},/*kerning  D à : -0.003906 */
+{'[', 0x00e10044, 0xffffffff},/*kerning  D á : -0.003906 */
+{'[', 0x00e20044, 0xffffffff},/*kerning  D â : -0.003906 */
+{'[', 0x00e30044, 0xffffffff},/*kerning  D ã : -0.003906 */
+{'[', 0x00e40044, 0xffffffff},/*kerning  D ä : -0.003906 */
+{'[', 0x00e50044, 0xffffffff},/*kerning  D å : -0.003906 */
+{'[', 0x00e60044, 0xffffffff},/*kerning  D æ : -0.003906 */
+{'@', 0x00000045, 0x00006000},/*        E        x-advance: 96.000000 */
+{'M', 0x42b570a4, 0xc14ccccc},
+{'l', 0x00000000, 0x414ccccc},
+{'l', 0xc29a3d71, 0x80000000},
+{'l', 0x35800000, 0xc2e33333},
+{'l', 0x42975c29, 0x00000000},
+{'l', 0x00000000, 0x414cccd0},
+{'l', 0xc2751eb8, 0x00000000},
+{'l', 0x00000000, 0x42133332},
+{'l', 0x42551eb8, 0x00000000},
+{'l', 0x00000000, 0x41400000},
+{'4', 0x0000fe56, 0x01390000},
+{'l', 0x427ae148, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00430045, 0xfffffffd},/*kerning  E C : -0.011719 */
+{'[', 0x00470045, 0xfffffffd},/*kerning  E G : -0.011719 */
+{'[', 0x004f0045, 0xfffffffd},/*kerning  E O : -0.011719 */
+{'[', 0x00510045, 0xfffffffd},/*kerning  E Q : -0.011719 */
+{'[', 0x00630045, 0xfffffffd},/*kerning  E c : -0.011719 */
+{'[', 0x00640045, 0xfffffffe},/*kerning  E d : -0.007812 */
+{'[', 0x00650045, 0xfffffffd},/*kerning  E e : -0.011719 */
+{'[', 0x00660045, 0xfffffffe},/*kerning  E f : -0.007812 */
+{'[', 0x00670045, 0xfffffffe},/*kerning  E g : -0.007812 */
+{'[', 0x006d0045, 0xffffffff},/*kerning  E m : -0.003906 */
+{'[', 0x006e0045, 0xffffffff},/*kerning  E n : -0.003906 */
+{'[', 0x006f0045, 0xfffffffd},/*kerning  E o : -0.011719 */
+{'[', 0x00700045, 0xffffffff},/*kerning  E p : -0.003906 */
+{'[', 0x00710045, 0xfffffffe},/*kerning  E q : -0.007812 */
+{'[', 0x00720045, 0xffffffff},/*kerning  E r : -0.003906 */
+{'[', 0x00740045, 0xffffffff},/*kerning  E t : -0.003906 */
+{'[', 0x00750045, 0xfffffffe},/*kerning  E u : -0.007812 */
+{'[', 0x00760045, 0xfffffffd},/*kerning  E v : -0.011719 */
+{'[', 0x00770045, 0xfffffffd},/*kerning  E w : -0.011719 */
+{'[', 0x00790045, 0xfffffffd},/*kerning  E y : -0.011719 */
+{'[', 0x00c70045, 0xfffffffd},/*kerning  E Ç : -0.011719 */
+{'[', 0x00d20045, 0xfffffffd},/*kerning  E Ò : -0.011719 */
+{'[', 0x00d30045, 0xfffffffd},/*kerning  E Ó : -0.011719 */
+{'[', 0x00d40045, 0xfffffffd},/*kerning  E Ô : -0.011719 */
+{'[', 0x00d50045, 0xfffffffd},/*kerning  E Õ : -0.011719 */
+{'[', 0x00d60045, 0xfffffffd},/*kerning  E Ö : -0.011719 */
+{'[', 0x00d80045, 0xfffffffd},/*kerning  E Ø : -0.011719 */
+{'[', 0x00e70045, 0xfffffffd},/*kerning  E ç : -0.011719 */
+{'[', 0x00e80045, 0xfffffffd},/*kerning  E è : -0.011719 */
+{'[', 0x00e90045, 0xfffffffd},/*kerning  E é : -0.011719 */
+{'[', 0x00ea0045, 0xfffffffd},/*kerning  E ê : -0.011719 */
+{'[', 0x00eb0045, 0xfffffffd},/*kerning  E ë : -0.011719 */
+{'[', 0x00f00045, 0xfffffffd},/*kerning  E ð : -0.011719 */
+{'[', 0x00f10045, 0xffffffff},/*kerning  E ñ : -0.003906 */
+{'[', 0x00f20045, 0xfffffffd},/*kerning  E ò : -0.011719 */
+{'[', 0x00f30045, 0xfffffffd},/*kerning  E ó : -0.011719 */
+{'[', 0x00f40045, 0xfffffffd},/*kerning  E ô : -0.011719 */
+{'[', 0x00f50045, 0xfffffffd},/*kerning  E õ : -0.011719 */
+{'[', 0x00f60045, 0xfffffffd},/*kerning  E ö : -0.011719 */
+{'[', 0x00f80045, 0xfffffffd},/*kerning  E ø : -0.011719 */
+{'[', 0x00f90045, 0xfffffffe},/*kerning  E ù : -0.007812 */
+{'[', 0x00fa0045, 0xfffffffe},/*kerning  E ú : -0.007812 */
+{'[', 0x00fb0045, 0xfffffffe},/*kerning  E û : -0.007812 */
+{'[', 0x00fc0045, 0xfffffffe},/*kerning  E ü : -0.007812 */
+{'[', 0x00fd0045, 0xfffffffd},/*kerning  E ý : -0.011719 */
+{'[', 0x00ff0045, 0xfffffffd},/*kerning  E ÿ : -0.011719 */
+{'@', 0x00000046, 0x00005d00},/*        F        x-advance: 93.000000 */
+{'M', 0x41599999, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'l', 0x4296147b, 0x00000000},
+{'l', 0x00000000, 0x414cccd0},
+{'l', 0xc2728f5c, 0x00000000},
+{'l', 0x00000000, 0x4217ae14},
+{'l', 0x424c28f6, 0x00000000},
+{'l', 0x00000000, 0x41400000},
+{'4', 0x0000fe68, 0x01970000},
+{'l', 0xc1666667, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200046, 0xfffffffa},/*kerning  F   : -0.023438 */
+{'[', 0x002c0046, 0xffffffe8},/*kerning  F , : -0.093750 */
+{'[', 0x002d0046, 0xfffffffe},/*kerning  F - : -0.007812 */
+{'[', 0x002e0046, 0xffffffe8},/*kerning  F . : -0.093750 */
+{'[', 0x002f0046, 0xffffffed},/*kerning  F / : -0.074219 */
+{'[', 0x00310046, 0xfffffffd},/*kerning  F 1 : -0.011719 */
+{'[', 0x00320046, 0xfffffffb},/*kerning  F 2 : -0.019531 */
+{'[', 0x00330046, 0xfffffffa},/*kerning  F 3 : -0.023438 */
+{'[', 0x00340046, 0xfffffff1},/*kerning  F 4 : -0.058594 */
+{'[', 0x00350046, 0xfffffffa},/*kerning  F 5 : -0.023438 */
+{'[', 0x00390046, 0xfffffffe},/*kerning  F 9 : -0.007812 */
+{'[', 0x003a0046, 0xfffffffe},/*kerning  F : : -0.007812 */
+{'[', 0x003b0046, 0xfffffffe},/*kerning  F ; : -0.007812 */
+{'[', 0x00400046, 0xfffffffd},/*kerning  F @ : -0.011719 */
+{'[', 0x00410046, 0xfffffff2},/*kerning  F A : -0.054688 */
+{'[', 0x00430046, 0xfffffffd},/*kerning  F C : -0.011719 */
+{'[', 0x00470046, 0xfffffffd},/*kerning  F G : -0.011719 */
+{'[', 0x004a0046, 0xffffffe3},/*kerning  F J : -0.113281 */
+{'[', 0x004f0046, 0xfffffffd},/*kerning  F O : -0.011719 */
+{'[', 0x00510046, 0xfffffffd},/*kerning  F Q : -0.011719 */
+{'[', 0x00530046, 0xfffffffd},/*kerning  F S : -0.011719 */
+{'[', 0x00610046, 0xfffffff2},/*kerning  F a : -0.054688 */
+{'[', 0x00630046, 0xfffffff8},/*kerning  F c : -0.031250 */
+{'[', 0x00640046, 0xfffffff9},/*kerning  F d : -0.027344 */
+{'[', 0x00650046, 0xfffffff8},/*kerning  F e : -0.031250 */
+{'[', 0x00660046, 0xfffffffd},/*kerning  F f : -0.011719 */
+{'[', 0x00670046, 0xfffffff9},/*kerning  F g : -0.027344 */
+{'[', 0x006d0046, 0xfffffff7},/*kerning  F m : -0.035156 */
+{'[', 0x006e0046, 0xfffffff7},/*kerning  F n : -0.035156 */
+{'[', 0x006f0046, 0xfffffff8},/*kerning  F o : -0.031250 */
+{'[', 0x00700046, 0xfffffff7},/*kerning  F p : -0.035156 */
+{'[', 0x00710046, 0xfffffff9},/*kerning  F q : -0.027344 */
+{'[', 0x00720046, 0xfffffff7},/*kerning  F r : -0.035156 */
+{'[', 0x00730046, 0xfffffff6},/*kerning  F s : -0.039062 */
+{'[', 0x00740046, 0xffffffff},/*kerning  F t : -0.003906 */
+{'[', 0x00750046, 0xfffffff8},/*kerning  F u : -0.031250 */
+{'[', 0x00760046, 0xfffffffd},/*kerning  F v : -0.011719 */
+{'[', 0x00770046, 0xfffffffd},/*kerning  F w : -0.011719 */
+{'[', 0x00780046, 0xfffffffd},/*kerning  F x : -0.011719 */
+{'[', 0x00790046, 0xfffffffd},/*kerning  F y : -0.011719 */
+{'[', 0x007a0046, 0xfffffffa},/*kerning  F z : -0.023438 */
+{'[', 0x00ab0046, 0xfffffffa},/*kerning  F « : -0.023438 */
+{'[', 0x00bb0046, 0xfffffffb},/*kerning  F » : -0.019531 */
+{'[', 0x00c00046, 0xfffffff2},/*kerning  F À : -0.054688 */
+{'[', 0x00c10046, 0xfffffff2},/*kerning  F Á : -0.054688 */
+{'[', 0x00c20046, 0xfffffff2},/*kerning  F Â : -0.054688 */
+{'[', 0x00c30046, 0xfffffff2},/*kerning  F Ã : -0.054688 */
+{'[', 0x00c40046, 0xfffffff2},/*kerning  F Ä : -0.054688 */
+{'[', 0x00c50046, 0xfffffff2},/*kerning  F Å : -0.054688 */
+{'[', 0x00c60046, 0xffffffe4},/*kerning  F Æ : -0.109375 */
+{'[', 0x00c70046, 0xfffffffd},/*kerning  F Ç : -0.011719 */
+{'[', 0x00d20046, 0xfffffffd},/*kerning  F Ò : -0.011719 */
+{'[', 0x00d30046, 0xfffffffd},/*kerning  F Ó : -0.011719 */
+{'[', 0x00d40046, 0xfffffffd},/*kerning  F Ô : -0.011719 */
+{'[', 0x00d50046, 0xfffffffd},/*kerning  F Õ : -0.011719 */
+{'[', 0x00d60046, 0xfffffffd},/*kerning  F Ö : -0.011719 */
+{'[', 0x00d80046, 0xfffffffd},/*kerning  F Ø : -0.011719 */
+{'[', 0x00df0046, 0xffffffff},/*kerning  F ß : -0.003906 */
+{'[', 0x00e00046, 0xfffffff2},/*kerning  F à : -0.054688 */
+{'[', 0x00e10046, 0xfffffff2},/*kerning  F á : -0.054688 */
+{'[', 0x00e20046, 0xfffffff2},/*kerning  F â : -0.054688 */
+{'[', 0x00e30046, 0xfffffff2},/*kerning  F ã : -0.054688 */
+{'[', 0x00e40046, 0xfffffff2},/*kerning  F ä : -0.054688 */
+{'[', 0x00e50046, 0xfffffff2},/*kerning  F å : -0.054688 */
+{'[', 0x00e60046, 0xfffffff2},/*kerning  F æ : -0.054688 */
+{'[', 0x00e70046, 0xfffffff8},/*kerning  F ç : -0.031250 */
+{'[', 0x00e80046, 0xfffffff8},/*kerning  F è : -0.031250 */
+{'[', 0x00e90046, 0xfffffff8},/*kerning  F é : -0.031250 */
+{'[', 0x00ea0046, 0xfffffff8},/*kerning  F ê : -0.031250 */
+{'[', 0x00eb0046, 0xfffffff8},/*kerning  F ë : -0.031250 */
+{'[', 0x00ee0046, 0x00000004},/*kerning  F î : 0.015625 */
+{'[', 0x00f00046, 0xfffffff5},/*kerning  F ð : -0.042969 */
+{'[', 0x00f10046, 0xfffffff7},/*kerning  F ñ : -0.035156 */
+{'[', 0x00f20046, 0xfffffff8},/*kerning  F ò : -0.031250 */
+{'[', 0x00f30046, 0xfffffff8},/*kerning  F ó : -0.031250 */
+{'[', 0x00f40046, 0xfffffff8},/*kerning  F ô : -0.031250 */
+{'[', 0x00f50046, 0xfffffff8},/*kerning  F õ : -0.031250 */
+{'[', 0x00f60046, 0xfffffff8},/*kerning  F ö : -0.031250 */
+{'[', 0x00f80046, 0xfffffff8},/*kerning  F ø : -0.031250 */
+{'[', 0x00f90046, 0xfffffff8},/*kerning  F ù : -0.031250 */
+{'[', 0x00fa0046, 0xfffffff8},/*kerning  F ú : -0.031250 */
+{'[', 0x00fb0046, 0xfffffff8},/*kerning  F û : -0.031250 */
+{'[', 0x00fc0046, 0xfffffff8},/*kerning  F ü : -0.031250 */
+{'[', 0x00fd0046, 0xfffffffd},/*kerning  F ý : -0.011719 */
+{'[', 0x00ff0046, 0xfffffffd},/*kerning  F ÿ : -0.011719 */
+{'@', 0x00000047, 0x00007200},/*        G        x-advance: 114.000000 */
+{'M', 0x426ccccc, 0x3f4ccccc},
+{'q', 0xc1333330, 0x00000000},
+{0, 0xc1a70a3c, 0xc09c28f6},
+{'q', 0xc11ae148, 0xc09c28f6},
+{0, 0xc1870a3e, 0xc151eb84},
+{'q', 0xc0e66664, 0xc103d70a},
+{0, 0xc1333332, 0xc1947ae1},
+{'q', 0xc0800000, 0xc1251eb8},
+{0, 0xc0800000, 0xc1aae148},
+{'q', 0x00000000, 0xc13851ec},
+{0, 0x40800000, 0xc1aeb852},
+{'q', 0x40800000, 0xc1251eb8},
+{0, 0x4131eb86, 0xc1928f5c},
+{'q', 0x40e3d708, 0xc1000000},
+{0, 0x41866666, 0xc148f5c0},
+{'q', 0x411ae148, 0xc091eb80},
+{0, 0x41a851ea, 0xc091eb80},
+{'q', 0x4183d70c, 0x00000000},
+{0, 0x41d99998, 0x40dc28f0},
+{'9', 0x00370055, 0x008f0081},
+{'l', 0xc130a3d8, 0x40f5c290},
+{'q', 0xc09eb850, 0xc11eb850},
+{0, 0xc1599998, 0xc16b8520},
+{'q', 0xc10a3d70, 0xc0999990},
+{0, 0xc19851ec, 0xc0999990},
+{'q', 0xc10a3d70, 0x00000000},
+{0, 0xc17ae148, 0x406b8520},
+{'q', 0xc0e147a8, 0x406b8520},
+{0, 0xc14147ac, 0x41200000},
+{'q', 0xc0a147ac, 0x40ca3d70},
+{0, 0xc0f5c290, 0x41651eb8},
+{'q', 0xc028f5c0, 0x41000000},
+{0, 0xc028f5c0, 0x41851eb6},
+{'q', 0x00000000, 0x41428f5c},
+{0, 0x40a66668, 0x41b28f5c},
+{'q', 0x40a66664, 0x41228f5c},
+{0, 0x41628f5c, 0x4181eb85},
+{'q', 0x410f5c28, 0x40c28f5c},
+{0, 0x41a147ae, 0x40c28f5c},
+{'q', 0x4111eb80, 0x00000000},
+{0, 0x418c28f4, 0xc08ccccc},
+{'9', 0xffdd0043, 0xff94007f},
+{'l', 0x00000000, 0xc17ae146},
+{'l', 0xc1c3d708, 0x00000000},
+{'l', 0x00000000, 0xc12e147c},
+{'l', 0x42128f5c, 0x00000000},
+{'4', 0x01c50000, 0x0000ff9f},
+{'l', 0x00000000, 0xc175c28f},
+{'q', 0xc16b8518, 0x418147ae},
+{0, 0xc20a3d70, 0x418147ae},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00540047, 0xfffffffe},/*kerning  G T : -0.007812 */
+{'[', 0x00560047, 0xfffffffb},/*kerning  G V : -0.019531 */
+{'[', 0x00570047, 0xfffffffb},/*kerning  G W : -0.019531 */
+{'[', 0x00590047, 0xfffffff8},/*kerning  G Y : -0.031250 */
+{'[', 0x005c0047, 0xfffffffd},/*kerning  G \ : -0.011719 */
+{'[', 0x00660047, 0xffffffff},/*kerning  G f : -0.003906 */
+{'[', 0x00740047, 0xffffffff},/*kerning  G t : -0.003906 */
+{'[', 0x00760047, 0xfffffffe},/*kerning  G v : -0.007812 */
+{'[', 0x00770047, 0xfffffffe},/*kerning  G w : -0.007812 */
+{'[', 0x00790047, 0xfffffffe},/*kerning  G y : -0.007812 */
+{'[', 0x00c60047, 0x00000002},/*kerning  G Æ : 0.007812 */
+{'[', 0x00dd0047, 0xfffffff8},/*kerning  G Ý : -0.031250 */
+{'[', 0x00fd0047, 0xfffffffe},/*kerning  G ý : -0.007812 */
+{'[', 0x00ff0047, 0xfffffffe},/*kerning  G ÿ : -0.007812 */
+{'@', 0x00000048, 0x00007600},/*        H        x-advance: 118.000000 */
+{'M', 0x42d1eb85, 0xc2e33333},
+{'l', 0x00000000, 0x42e33333},
+{'l', 0xc1666668, 0x80000000},
+{'l', 0x00000000, 0xc24eb852},
+{'l', 0xc27a3d70, 0x00000000},
+{'l', 0x00000000, 0x424eb852},
+{'l', 0xc1666667, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'l', 0x41666667, 0x00000000},
+{'l', 0x00000000, 0x42447ae2},
+{'4', 0x000001f4, 0xfe780000},
+{'l', 0x41666668, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00610048, 0xffffffff},/*kerning  H a : -0.003906 */
+{'[', 0x00630048, 0xfffffffe},/*kerning  H c : -0.007812 */
+{'[', 0x00640048, 0xfffffffe},/*kerning  H d : -0.007812 */
+{'[', 0x00650048, 0xfffffffe},/*kerning  H e : -0.007812 */
+{'[', 0x00660048, 0xffffffff},/*kerning  H f : -0.003906 */
+{'[', 0x00670048, 0xfffffffe},/*kerning  H g : -0.007812 */
+{'[', 0x006f0048, 0xfffffffe},/*kerning  H o : -0.007812 */
+{'[', 0x00710048, 0xfffffffe},/*kerning  H q : -0.007812 */
+{'[', 0x00730048, 0xffffffff},/*kerning  H s : -0.003906 */
+{'[', 0x00740048, 0xffffffff},/*kerning  H t : -0.003906 */
+{'[', 0x00e00048, 0xffffffff},/*kerning  H à : -0.003906 */
+{'[', 0x00e10048, 0xffffffff},/*kerning  H á : -0.003906 */
+{'[', 0x00e20048, 0xffffffff},/*kerning  H â : -0.003906 */
+{'[', 0x00e30048, 0xffffffff},/*kerning  H ã : -0.003906 */
+{'[', 0x00e40048, 0xffffffff},/*kerning  H ä : -0.003906 */
+{'[', 0x00e50048, 0xffffffff},/*kerning  H å : -0.003906 */
+{'[', 0x00e60048, 0xffffffff},/*kerning  H æ : -0.003906 */
+{'[', 0x00e70048, 0xfffffffe},/*kerning  H ç : -0.007812 */
+{'[', 0x00e80048, 0xfffffffe},/*kerning  H è : -0.007812 */
+{'[', 0x00e90048, 0xfffffffe},/*kerning  H é : -0.007812 */
+{'[', 0x00ea0048, 0xfffffffe},/*kerning  H ê : -0.007812 */
+{'[', 0x00eb0048, 0xfffffffe},/*kerning  H ë : -0.007812 */
+{'[', 0x00f00048, 0xfffffffe},/*kerning  H ð : -0.007812 */
+{'[', 0x00f20048, 0xfffffffe},/*kerning  H ò : -0.007812 */
+{'[', 0x00f30048, 0xfffffffe},/*kerning  H ó : -0.007812 */
+{'[', 0x00f40048, 0xfffffffe},/*kerning  H ô : -0.007812 */
+{'[', 0x00f50048, 0xfffffffe},/*kerning  H õ : -0.007812 */
+{'[', 0x00f60048, 0xfffffffe},/*kerning  H ö : -0.007812 */
+{'[', 0x00f80048, 0xfffffffe},/*kerning  H ø : -0.007812 */
+{'@', 0x00000049, 0x00002900},/*        I        x-advance: 41.000000 */
+{'M', 0x41599999, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'4', 0x00000073, 0x038c0000},
+{'l', 0xc1666667, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00610049, 0xffffffff},/*kerning  I a : -0.003906 */
+{'[', 0x00630049, 0xfffffffe},/*kerning  I c : -0.007812 */
+{'[', 0x00640049, 0xfffffffe},/*kerning  I d : -0.007812 */
+{'[', 0x00650049, 0xfffffffe},/*kerning  I e : -0.007812 */
+{'[', 0x00660049, 0xffffffff},/*kerning  I f : -0.003906 */
+{'[', 0x00670049, 0xfffffffe},/*kerning  I g : -0.007812 */
+{'[', 0x006f0049, 0xfffffffe},/*kerning  I o : -0.007812 */
+{'[', 0x00710049, 0xfffffffe},/*kerning  I q : -0.007812 */
+{'[', 0x00730049, 0xffffffff},/*kerning  I s : -0.003906 */
+{'[', 0x00740049, 0xffffffff},/*kerning  I t : -0.003906 */
+{'[', 0x00e00049, 0xffffffff},/*kerning  I à : -0.003906 */
+{'[', 0x00e10049, 0xffffffff},/*kerning  I á : -0.003906 */
+{'[', 0x00e20049, 0xffffffff},/*kerning  I â : -0.003906 */
+{'[', 0x00e30049, 0xffffffff},/*kerning  I ã : -0.003906 */
+{'[', 0x00e40049, 0xffffffff},/*kerning  I ä : -0.003906 */
+{'[', 0x00e50049, 0xffffffff},/*kerning  I å : -0.003906 */
+{'[', 0x00e60049, 0xffffffff},/*kerning  I æ : -0.003906 */
+{'[', 0x00e70049, 0xfffffffe},/*kerning  I ç : -0.007812 */
+{'[', 0x00e80049, 0xfffffffe},/*kerning  I è : -0.007812 */
+{'[', 0x00e90049, 0xfffffffe},/*kerning  I é : -0.007812 */
+{'[', 0x00ea0049, 0xfffffffe},/*kerning  I ê : -0.007812 */
+{'[', 0x00eb0049, 0xfffffffe},/*kerning  I ë : -0.007812 */
+{'[', 0x00f00049, 0xfffffffe},/*kerning  I ð : -0.007812 */
+{'[', 0x00f20049, 0xfffffffe},/*kerning  I ò : -0.007812 */
+{'[', 0x00f30049, 0xfffffffe},/*kerning  I ó : -0.007812 */
+{'[', 0x00f40049, 0xfffffffe},/*kerning  I ô : -0.007812 */
+{'[', 0x00f50049, 0xfffffffe},/*kerning  I õ : -0.007812 */
+{'[', 0x00f60049, 0xfffffffe},/*kerning  I ö : -0.007812 */
+{'[', 0x00f80049, 0xfffffffe},/*kerning  I ø : -0.007812 */
+{'@', 0x0000004a, 0x00004d00},/*        J        x-advance: 77.000000 */
+{'M', 0x40b33333, 0xc187ae14},
+{'8', 0x1f431018, 0x0e650e2a},
+{'q', 0x412147ae, 0x00000000},
+{0, 0x41747ae2, 0xc08cccce},
+{'q', 0x40a66668, 0xc08ccccc},
+{0, 0x40e147b0, 0xc15851ea},
+{'9', 0xffb8000e, 0xff44000e},
+{'4', 0xfe190000, 0x00000073},
+{'l', 0x00000000, 0x42670a3d},
+{'q', 0x00000000, 0x414a3d70},
+{0, 0xbfa3d700, 0x41b9999a},
+{'q', 0xbfa3d720, 0x4128f5c2},
+{0, 0xc0a3d710, 0x41928f5c},
+{'q', 0xc075c290, 0x40f851eb},
+{0, 0xc1370a3c, 0x413eb852},
+{'q', 0xc0f33330, 0x40851eb8},
+{0, 0xc1a1eb85, 0x40851eb8},
+{'q', 0xc1000000, 0xb4800000},
+{0, 0xc16147ae, 0xbfe147b0},
+{'9', 0xfff2ffd0, 0xffd6ffa7},
+{'l', 0x406b851e, 0xc13ae147},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002c004a, 0xfffffffe},/*kerning  J , : -0.007812 */
+{'[', 0x002e004a, 0xfffffffe},/*kerning  J . : -0.007812 */
+{'[', 0x002f004a, 0xfffffffd},/*kerning  J / : -0.011719 */
+{'[', 0x0041004a, 0xfffffffc},/*kerning  J A : -0.015625 */
+{'[', 0x004a004a, 0xfffffffe},/*kerning  J J : -0.007812 */
+{'[', 0x0061004a, 0xfffffffe},/*kerning  J a : -0.007812 */
+{'[', 0x0063004a, 0xfffffffe},/*kerning  J c : -0.007812 */
+{'[', 0x0064004a, 0xfffffffe},/*kerning  J d : -0.007812 */
+{'[', 0x0065004a, 0xfffffffe},/*kerning  J e : -0.007812 */
+{'[', 0x0066004a, 0xffffffff},/*kerning  J f : -0.003906 */
+{'[', 0x0067004a, 0xfffffffe},/*kerning  J g : -0.007812 */
+{'[', 0x006c004a, 0xffffffff},/*kerning  J l : -0.003906 */
+{'[', 0x006f004a, 0xfffffffe},/*kerning  J o : -0.007812 */
+{'[', 0x0071004a, 0xfffffffe},/*kerning  J q : -0.007812 */
+{'[', 0x0073004a, 0xfffffffe},/*kerning  J s : -0.007812 */
+{'[', 0x0074004a, 0xffffffff},/*kerning  J t : -0.003906 */
+{'[', 0x0075004a, 0xffffffff},/*kerning  J u : -0.003906 */
+{'[', 0x007a004a, 0xffffffff},/*kerning  J z : -0.003906 */
+{'[', 0x00c0004a, 0xfffffffc},/*kerning  J À : -0.015625 */
+{'[', 0x00c1004a, 0xfffffffc},/*kerning  J Á : -0.015625 */
+{'[', 0x00c2004a, 0xfffffffc},/*kerning  J Â : -0.015625 */
+{'[', 0x00c3004a, 0xfffffffc},/*kerning  J Ã : -0.015625 */
+{'[', 0x00c4004a, 0xfffffffc},/*kerning  J Ä : -0.015625 */
+{'[', 0x00c5004a, 0xfffffffc},/*kerning  J Å : -0.015625 */
+{'[', 0x00c6004a, 0xfffffffc},/*kerning  J Æ : -0.015625 */
+{'[', 0x00e0004a, 0xfffffffe},/*kerning  J à : -0.007812 */
+{'[', 0x00e1004a, 0xfffffffe},/*kerning  J á : -0.007812 */
+{'[', 0x00e2004a, 0xfffffffe},/*kerning  J â : -0.007812 */
+{'[', 0x00e3004a, 0xfffffffe},/*kerning  J ã : -0.007812 */
+{'[', 0x00e4004a, 0xfffffffe},/*kerning  J ä : -0.007812 */
+{'[', 0x00e5004a, 0xfffffffe},/*kerning  J å : -0.007812 */
+{'[', 0x00e6004a, 0xfffffffe},/*kerning  J æ : -0.007812 */
+{'[', 0x00e7004a, 0xfffffffe},/*kerning  J ç : -0.007812 */
+{'[', 0x00e8004a, 0xfffffffe},/*kerning  J è : -0.007812 */
+{'[', 0x00e9004a, 0xfffffffe},/*kerning  J é : -0.007812 */
+{'[', 0x00ea004a, 0xfffffffe},/*kerning  J ê : -0.007812 */
+{'[', 0x00eb004a, 0xfffffffe},/*kerning  J ë : -0.007812 */
+{'[', 0x00f0004a, 0xfffffffd},/*kerning  J ð : -0.011719 */
+{'[', 0x00f2004a, 0xfffffffe},/*kerning  J ò : -0.007812 */
+{'[', 0x00f3004a, 0xfffffffe},/*kerning  J ó : -0.007812 */
+{'[', 0x00f4004a, 0xfffffffe},/*kerning  J ô : -0.007812 */
+{'[', 0x00f5004a, 0xfffffffe},/*kerning  J õ : -0.007812 */
+{'[', 0x00f6004a, 0xfffffffe},/*kerning  J ö : -0.007812 */
+{'[', 0x00f8004a, 0xfffffffe},/*kerning  J ø : -0.007812 */
+{'[', 0x00f9004a, 0xffffffff},/*kerning  J ù : -0.003906 */
+{'[', 0x00fa004a, 0xffffffff},/*kerning  J ú : -0.003906 */
+{'[', 0x00fb004a, 0xffffffff},/*kerning  J û : -0.003906 */
+{'[', 0x00fc004a, 0xffffffff},/*kerning  J ü : -0.003906 */
+{'@', 0x0000004b, 0x00006800},/*        K        x-advance: 104.000000 */
+{'M', 0x41599999, 0x80000000},
+{'l', 0x00000000, 0xc2e2e147},
+{'l', 0x41666667, 0x00000000},
+{'l', 0x00000000, 0x427ae147},
+{'l', 0x426a3d70, 0xc27b851f},
+{'l', 0x417851e8, 0x00000000},
+{'l', 0xc2366665, 0x424851eb},
+{'l', 0x4240a3d7, 0x427e147b},
+{'l', 0xc18147b0, 0x80000000},
+{'l', 0xc2247ae0, 0xc25b851e},
+{'4', 0x00a1ff66, 0x01150000},
+{'l', 0xc1666667, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0020004b, 0xfffffffd},/*kerning  K   : -0.011719 */
+{'[', 0x002d004b, 0xfffffffd},/*kerning  K - : -0.011719 */
+{'[', 0x002f004b, 0x00000003},/*kerning  K / : 0.011719 */
+{'[', 0x0030004b, 0xfffffffd},/*kerning  K 0 : -0.011719 */
+{'[', 0x0043004b, 0xfffffff6},/*kerning  K C : -0.039062 */
+{'[', 0x0047004b, 0xfffffff6},/*kerning  K G : -0.039062 */
+{'[', 0x004f004b, 0xfffffff6},/*kerning  K O : -0.039062 */
+{'[', 0x0051004b, 0xfffffff6},/*kerning  K Q : -0.039062 */
+{'[', 0x0063004b, 0xfffffff8},/*kerning  K c : -0.031250 */
+{'[', 0x0064004b, 0xfffffff8},/*kerning  K d : -0.031250 */
+{'[', 0x0065004b, 0xfffffff8},/*kerning  K e : -0.031250 */
+{'[', 0x0066004b, 0xfffffffd},/*kerning  K f : -0.011719 */
+{'[', 0x0067004b, 0xfffffff8},/*kerning  K g : -0.031250 */
+{'[', 0x006f004b, 0xfffffff8},/*kerning  K o : -0.031250 */
+{'[', 0x0071004b, 0xfffffff8},/*kerning  K q : -0.031250 */
+{'[', 0x0074004b, 0xfffffffe},/*kerning  K t : -0.007812 */
+{'[', 0x0075004b, 0xfffffffc},/*kerning  K u : -0.015625 */
+{'[', 0x0076004b, 0xfffffff7},/*kerning  K v : -0.035156 */
+{'[', 0x0077004b, 0xfffffff7},/*kerning  K w : -0.035156 */
+{'[', 0x0079004b, 0xfffffff7},/*kerning  K y : -0.035156 */
+{'[', 0x00a9004b, 0xfffffffb},/*kerning  K © : -0.019531 */
+{'[', 0x00ab004b, 0xfffffffb},/*kerning  K « : -0.019531 */
+{'[', 0x00ae004b, 0xfffffffb},/*kerning  K ® : -0.019531 */
+{'[', 0x00c7004b, 0xfffffff6},/*kerning  K Ç : -0.039062 */
+{'[', 0x00d2004b, 0xfffffff6},/*kerning  K Ò : -0.039062 */
+{'[', 0x00d3004b, 0xfffffff6},/*kerning  K Ó : -0.039062 */
+{'[', 0x00d4004b, 0xfffffff6},/*kerning  K Ô : -0.039062 */
+{'[', 0x00d5004b, 0xfffffff6},/*kerning  K Õ : -0.039062 */
+{'[', 0x00d6004b, 0xfffffff6},/*kerning  K Ö : -0.039062 */
+{'[', 0x00d8004b, 0xfffffff6},/*kerning  K Ø : -0.039062 */
+{'[', 0x00e7004b, 0xfffffff8},/*kerning  K ç : -0.031250 */
+{'[', 0x00e8004b, 0xfffffff8},/*kerning  K è : -0.031250 */
+{'[', 0x00e9004b, 0xfffffff8},/*kerning  K é : -0.031250 */
+{'[', 0x00ea004b, 0xfffffff8},/*kerning  K ê : -0.031250 */
+{'[', 0x00eb004b, 0xfffffff8},/*kerning  K ë : -0.031250 */
+{'[', 0x00ef004b, 0x00000004},/*kerning  K ï : 0.015625 */
+{'[', 0x00f0004b, 0xfffffffa},/*kerning  K ð : -0.023438 */
+{'[', 0x00f2004b, 0xfffffff8},/*kerning  K ò : -0.031250 */
+{'[', 0x00f3004b, 0xfffffff8},/*kerning  K ó : -0.031250 */
+{'[', 0x00f4004b, 0xfffffff8},/*kerning  K ô : -0.031250 */
+{'[', 0x00f5004b, 0xfffffff8},/*kerning  K õ : -0.031250 */
+{'[', 0x00f6004b, 0xfffffff8},/*kerning  K ö : -0.031250 */
+{'[', 0x00f8004b, 0xfffffff8},/*kerning  K ø : -0.031250 */
+{'[', 0x00f9004b, 0xfffffffc},/*kerning  K ù : -0.015625 */
+{'[', 0x00fa004b, 0xfffffffc},/*kerning  K ú : -0.015625 */
+{'[', 0x00fb004b, 0xfffffffc},/*kerning  K û : -0.015625 */
+{'[', 0x00fc004b, 0xfffffffc},/*kerning  K ü : -0.015625 */
+{'[', 0x00fd004b, 0xfffffff7},/*kerning  K ý : -0.035156 */
+{'[', 0x00ff004b, 0xfffffff7},/*kerning  K ÿ : -0.035156 */
+{'@', 0x0000004c, 0x00005d00},/*        L        x-advance: 93.000000 */
+{'M', 0x41599999, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'l', 0x41666667, 0x00000000},
+{'l', 0x00000000, 0x42c9999a},
+{'4', 0x000001fa, 0x00660000},
+{'l', 0xc29b851f, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0020004c, 0xfffffff9},/*kerning  L   : -0.027344 */
+{'[', 0x0022004c, 0xffffffe6},/*kerning  L " : -0.101562 */
+{'[', 0x0027004c, 0xffffffe6},/*kerning  L ' : -0.101562 */
+{'[', 0x002a004c, 0xffffffe2},/*kerning  L * : -0.117188 */
+{'[', 0x002d004c, 0xfffffff1},/*kerning  L - : -0.058594 */
+{'[', 0x0037004c, 0xfffffffd},/*kerning  L 7 : -0.011719 */
+{'[', 0x003f004c, 0xfffffffb},/*kerning  L ? : -0.019531 */
+{'[', 0x0043004c, 0xfffffffb},/*kerning  L C : -0.019531 */
+{'[', 0x0047004c, 0xfffffffb},/*kerning  L G : -0.019531 */
+{'[', 0x004f004c, 0xfffffffb},/*kerning  L O : -0.019531 */
+{'[', 0x0051004c, 0xfffffffb},/*kerning  L Q : -0.019531 */
+{'[', 0x0054004c, 0xffffffe5},/*kerning  L T : -0.105469 */
+{'[', 0x0055004c, 0xfffffffa},/*kerning  L U : -0.023438 */
+{'[', 0x0056004c, 0xffffffe7},/*kerning  L V : -0.097656 */
+{'[', 0x0057004c, 0xffffffe7},/*kerning  L W : -0.097656 */
+{'[', 0x0059004c, 0xffffffe5},/*kerning  L Y : -0.105469 */
+{'[', 0x005c004c, 0xffffffe5},/*kerning  L \ : -0.105469 */
+{'[', 0x0063004c, 0xffffffff},/*kerning  L c : -0.003906 */
+{'[', 0x0064004c, 0xffffffff},/*kerning  L d : -0.003906 */
+{'[', 0x0065004c, 0xffffffff},/*kerning  L e : -0.003906 */
+{'[', 0x0066004c, 0xffffffff},/*kerning  L f : -0.003906 */
+{'[', 0x0067004c, 0xffffffff},/*kerning  L g : -0.003906 */
+{'[', 0x006f004c, 0xffffffff},/*kerning  L o : -0.003906 */
+{'[', 0x0071004c, 0xffffffff},/*kerning  L q : -0.003906 */
+{'[', 0x0074004c, 0xfffffffd},/*kerning  L t : -0.011719 */
+{'[', 0x0076004c, 0xffffffef},/*kerning  L v : -0.066406 */
+{'[', 0x0077004c, 0xffffffed},/*kerning  L w : -0.074219 */
+{'[', 0x0079004c, 0xffffffed},/*kerning  L y : -0.074219 */
+{'[', 0x00a9004c, 0xfffffffa},/*kerning  L © : -0.023438 */
+{'[', 0x00aa004c, 0xffffffe2},/*kerning  L ª : -0.117188 */
+{'[', 0x00ab004c, 0xfffffffa},/*kerning  L « : -0.023438 */
+{'[', 0x00ae004c, 0xfffffffa},/*kerning  L ® : -0.023438 */
+{'[', 0x00b7004c, 0xffffffd4},/*kerning  L · : -0.171875 */
+{'[', 0x00ba004c, 0xffffffe2},/*kerning  L º : -0.117188 */
+{'[', 0x00c6004c, 0x00000003},/*kerning  L Æ : 0.011719 */
+{'[', 0x00c7004c, 0xfffffffb},/*kerning  L Ç : -0.019531 */
+{'[', 0x00d2004c, 0xfffffffb},/*kerning  L Ò : -0.019531 */
+{'[', 0x00d3004c, 0xfffffffb},/*kerning  L Ó : -0.019531 */
+{'[', 0x00d4004c, 0xfffffffb},/*kerning  L Ô : -0.019531 */
+{'[', 0x00d5004c, 0xfffffffb},/*kerning  L Õ : -0.019531 */
+{'[', 0x00d6004c, 0xfffffffb},/*kerning  L Ö : -0.019531 */
+{'[', 0x00d8004c, 0xfffffffb},/*kerning  L Ø : -0.019531 */
+{'[', 0x00d9004c, 0xfffffffa},/*kerning  L Ù : -0.023438 */
+{'[', 0x00da004c, 0xfffffffa},/*kerning  L Ú : -0.023438 */
+{'[', 0x00db004c, 0xfffffffa},/*kerning  L Û : -0.023438 */
+{'[', 0x00dc004c, 0xfffffffa},/*kerning  L Ü : -0.023438 */
+{'[', 0x00dd004c, 0xffffffe5},/*kerning  L Ý : -0.105469 */
+{'[', 0x00e7004c, 0xffffffff},/*kerning  L ç : -0.003906 */
+{'[', 0x00e8004c, 0xffffffff},/*kerning  L è : -0.003906 */
+{'[', 0x00e9004c, 0xffffffff},/*kerning  L é : -0.003906 */
+{'[', 0x00ea004c, 0xffffffff},/*kerning  L ê : -0.003906 */
+{'[', 0x00eb004c, 0xffffffff},/*kerning  L ë : -0.003906 */
+{'[', 0x00f2004c, 0xffffffff},/*kerning  L ò : -0.003906 */
+{'[', 0x00f3004c, 0xffffffff},/*kerning  L ó : -0.003906 */
+{'[', 0x00f4004c, 0xffffffff},/*kerning  L ô : -0.003906 */
+{'[', 0x00f5004c, 0xffffffff},/*kerning  L õ : -0.003906 */
+{'[', 0x00f6004c, 0xffffffff},/*kerning  L ö : -0.003906 */
+{'[', 0x00f8004c, 0xffffffff},/*kerning  L ø : -0.003906 */
+{'[', 0x00fd004c, 0xffffffed},/*kerning  L ý : -0.074219 */
+{'[', 0x00ff004c, 0xffffffed},/*kerning  L ÿ : -0.074219 */
+{'@', 0x0000004d, 0x00008b00},/*        M        x-advance: 139.000000 */
+{'M', 0x42dfae14, 0x80000000},
+{'l', 0x00000000, 0xc2ad70a4},
+{'l', 0xc215c28e, 0x428570a4},
+{'l', 0xc10cccd0, 0x00000000},
+{'l', 0xc2166666, 0xc28570a4},
+{'l', 0x00000000, 0x42ad70a4},
+{'l', 0xc1666667, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'l', 0x41733333, 0x00000000},
+{'l', 0x42247ae1, 0x4293851e},
+{'l', 0x42251eb8, 0xc293851e},
+{'4', 0x00000078, 0x038c0000},
+{'l', 0xc1666668, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0061004d, 0xffffffff},/*kerning  M a : -0.003906 */
+{'[', 0x0063004d, 0xfffffffe},/*kerning  M c : -0.007812 */
+{'[', 0x0064004d, 0xfffffffe},/*kerning  M d : -0.007812 */
+{'[', 0x0065004d, 0xfffffffe},/*kerning  M e : -0.007812 */
+{'[', 0x0066004d, 0xffffffff},/*kerning  M f : -0.003906 */
+{'[', 0x0067004d, 0xfffffffe},/*kerning  M g : -0.007812 */
+{'[', 0x006f004d, 0xfffffffe},/*kerning  M o : -0.007812 */
+{'[', 0x0071004d, 0xfffffffe},/*kerning  M q : -0.007812 */
+{'[', 0x0073004d, 0xffffffff},/*kerning  M s : -0.003906 */
+{'[', 0x0074004d, 0xffffffff},/*kerning  M t : -0.003906 */
+{'[', 0x00e0004d, 0xffffffff},/*kerning  M à : -0.003906 */
+{'[', 0x00e1004d, 0xffffffff},/*kerning  M á : -0.003906 */
+{'[', 0x00e2004d, 0xffffffff},/*kerning  M â : -0.003906 */
+{'[', 0x00e3004d, 0xffffffff},/*kerning  M ã : -0.003906 */
+{'[', 0x00e4004d, 0xffffffff},/*kerning  M ä : -0.003906 */
+{'[', 0x00e5004d, 0xffffffff},/*kerning  M å : -0.003906 */
+{'[', 0x00e6004d, 0xffffffff},/*kerning  M æ : -0.003906 */
+{'[', 0x00e7004d, 0xfffffffe},/*kerning  M ç : -0.007812 */
+{'[', 0x00e8004d, 0xfffffffe},/*kerning  M è : -0.007812 */
+{'[', 0x00e9004d, 0xfffffffe},/*kerning  M é : -0.007812 */
+{'[', 0x00ea004d, 0xfffffffe},/*kerning  M ê : -0.007812 */
+{'[', 0x00eb004d, 0xfffffffe},/*kerning  M ë : -0.007812 */
+{'[', 0x00f0004d, 0xfffffffe},/*kerning  M ð : -0.007812 */
+{'[', 0x00f2004d, 0xfffffffe},/*kerning  M ò : -0.007812 */
+{'[', 0x00f3004d, 0xfffffffe},/*kerning  M ó : -0.007812 */
+{'[', 0x00f4004d, 0xfffffffe},/*kerning  M ô : -0.007812 */
+{'[', 0x00f5004d, 0xfffffffe},/*kerning  M õ : -0.007812 */
+{'[', 0x00f6004d, 0xfffffffe},/*kerning  M ö : -0.007812 */
+{'[', 0x00f8004d, 0xfffffffe},/*kerning  M ø : -0.007812 */
+{'@', 0x0000004e, 0x00007b00},/*        N        x-advance: 123.000000 */
+{'M', 0x41e00000, 0xc2ae147b},
+{'l', 0x00000000, 0x42ae147b},
+{'l', 0xc1666667, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'l', 0x41428f5d, 0x00000000},
+{'l', 0x428ae147, 0x42b1999a},
+{'l', 0x00000000, 0xc2b147ae},
+{'l', 0x41666668, 0x00000000},
+{'4', 0x038b0000, 0x0000ff98},
+{'l', 0xc288f5c2, 0xc2ae147b},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0061004e, 0xffffffff},/*kerning  N a : -0.003906 */
+{'[', 0x0063004e, 0xfffffffe},/*kerning  N c : -0.007812 */
+{'[', 0x0064004e, 0xfffffffe},/*kerning  N d : -0.007812 */
+{'[', 0x0065004e, 0xfffffffe},/*kerning  N e : -0.007812 */
+{'[', 0x0066004e, 0xffffffff},/*kerning  N f : -0.003906 */
+{'[', 0x0067004e, 0xfffffffe},/*kerning  N g : -0.007812 */
+{'[', 0x006f004e, 0xfffffffe},/*kerning  N o : -0.007812 */
+{'[', 0x0071004e, 0xfffffffe},/*kerning  N q : -0.007812 */
+{'[', 0x0073004e, 0xffffffff},/*kerning  N s : -0.003906 */
+{'[', 0x0074004e, 0xffffffff},/*kerning  N t : -0.003906 */
+{'[', 0x00e0004e, 0xffffffff},/*kerning  N à : -0.003906 */
+{'[', 0x00e1004e, 0xffffffff},/*kerning  N á : -0.003906 */
+{'[', 0x00e2004e, 0xffffffff},/*kerning  N â : -0.003906 */
+{'[', 0x00e3004e, 0xffffffff},/*kerning  N ã : -0.003906 */
+{'[', 0x00e4004e, 0xffffffff},/*kerning  N ä : -0.003906 */
+{'[', 0x00e5004e, 0xffffffff},/*kerning  N å : -0.003906 */
+{'[', 0x00e6004e, 0xffffffff},/*kerning  N æ : -0.003906 */
+{'[', 0x00e7004e, 0xfffffffe},/*kerning  N ç : -0.007812 */
+{'[', 0x00e8004e, 0xfffffffe},/*kerning  N è : -0.007812 */
+{'[', 0x00e9004e, 0xfffffffe},/*kerning  N é : -0.007812 */
+{'[', 0x00ea004e, 0xfffffffe},/*kerning  N ê : -0.007812 */
+{'[', 0x00eb004e, 0xfffffffe},/*kerning  N ë : -0.007812 */
+{'[', 0x00f0004e, 0xfffffffe},/*kerning  N ð : -0.007812 */
+{'[', 0x00f2004e, 0xfffffffe},/*kerning  N ò : -0.007812 */
+{'[', 0x00f3004e, 0xfffffffe},/*kerning  N ó : -0.007812 */
+{'[', 0x00f4004e, 0xfffffffe},/*kerning  N ô : -0.007812 */
+{'[', 0x00f5004e, 0xfffffffe},/*kerning  N õ : -0.007812 */
+{'[', 0x00f6004e, 0xfffffffe},/*kerning  N ö : -0.007812 */
+{'[', 0x00f8004e, 0xfffffffe},/*kerning  N ø : -0.007812 */
+{'@', 0x0000004f, 0x00007700},/*        O        x-advance: 119.000000 */
+{'M', 0x426eb852, 0x3f4ccccc},
+{'q', 0xc1400000, 0x00000000},
+{0, 0xc1ae147c, 0xc099999a},
+{'q', 0xc11c28f4, 0xc099999a},
+{0, 0xc1870a3c, 0xc150a3d6},
+{'q', 0xc0e3d70c, 0xc103d70a},
+{0, 0xc12f5c2a, 0xc1947ae1},
+{'q', 0xc075c290, 0xc1251eb8},
+{0, 0xc075c290, 0xc1a9999a},
+{'q', 0x00000000, 0xc135c28c},
+{0, 0x40828f5c, 0xc1ad70a2},
+{'q', 0x40828f5c, 0xc1251eb8},
+{0, 0x4135c290, 0xc1933334},
+{'q', 0x40e8f5c0, 0xc10147b0},
+{0, 0x418851ec, 0xc14cccc8},
+{'q', 0x411c28f4, 0xc0970a40},
+{0, 0x41aa3d70, 0xc0970a40},
+{'q', 0x41400000, 0x00000000},
+{0, 0x41ae1478, 0x409eb850},
+{'q', 0x411c28f8, 0x409eb850},
+{0, 0x41866668, 0x41547ae0},
+{'q', 0x40e147b0, 0x41051eb8},
+{0, 0x412e1480, 0x41947ae0},
+{'q', 0x4075c280, 0x4123d708},
+{0, 0x4075c280, 0x41a7ae14},
+{'q', 0x00000000, 0x4135c290},
+{0, 0xc0800000, 0x41ad70a4},
+{'q', 0xc0800000, 0x41251eb8},
+{0, 0xc1347ae0, 0x41933333},
+{'q', 0xc0e8f5c0, 0x410147ae},
+{0, 0xc18851ec, 0x414b851e},
+{'9', 0x0025ffb2, 0x0025ff56},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a66666, 0xc2633333},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x40333330, 0x4185c28e},
+{'q', 0x40333338, 0x410147b0},
+{0, 0x40fd70a8, 0x41651eba},
+{'q', 0x40a3d708, 0x40c7ae14},
+{0, 0x41451eb4, 0x411eb852},
+{'q', 0x40e66668, 0x406b8520},
+{0, 0x41800002, 0x406b8520},
+{'q', 0x4111eb84, 0x00000000},
+{0, 0x41828f5e, 0xc075c290},
+{'q', 0x40e66660, 0xc075c290},
+{0, 0x4143d700, 0xc123d70a},
+{'q', 0x40a147b0, 0xc0cccccc},
+{0, 0x40f5c2a0, 0xc1666666},
+{'q', 0x4028f5c0, 0xc1000000},
+{0, 0x4028f5c0, 0xc18147ae},
+{'q', 0x00000000, 0xc10a3d6c},
+{0, 0xc0333340, 0xc1851eb6},
+{'q', 0xc0333340, 0xc1000000},
+{0, 0xc1000000, 0xc1651eb8},
+{'q', 0xc0a66660, 0xc0ca3d70},
+{0, 0xc1451eb8, 0xc11eb850},
+{'q', 0xc0e3d710, 0xc0666680},
+{0, 0xc17c28f4, 0xc0666680},
+{'q', 0xc111eb88, 0x00000000},
+{0, 0xc1828f5e, 0x4070a3e0},
+{'q', 0xc0e66660, 0x4070a3e0},
+{0, 0xc143d708, 0x41228f58},
+{'q', 0xc0a147ac, 0x40ccccd0},
+{0, 0xc0f851e8, 0x41651ec0},
+{'q', 0xc02e1480, 0x40fd70a0},
+{0, 0xc02e1480, 0x4181eb82},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0029004f, 0xfffffffc},/*kerning  O ) : -0.015625 */
+{'[', 0x002c004f, 0xfffffffd},/*kerning  O , : -0.011719 */
+{'[', 0x002e004f, 0xfffffffd},/*kerning  O . : -0.011719 */
+{'[', 0x002f004f, 0xfffffffa},/*kerning  O / : -0.023438 */
+{'[', 0x0041004f, 0xfffffffa},/*kerning  O A : -0.023438 */
+{'[', 0x004a004f, 0xfffffffb},/*kerning  O J : -0.019531 */
+{'[', 0x0054004f, 0xfffffffb},/*kerning  O T : -0.019531 */
+{'[', 0x0056004f, 0xfffffffa},/*kerning  O V : -0.023438 */
+{'[', 0x0057004f, 0xfffffffa},/*kerning  O W : -0.023438 */
+{'[', 0x0058004f, 0xfffffff8},/*kerning  O X : -0.031250 */
+{'[', 0x0059004f, 0xfffffff4},/*kerning  O Y : -0.046875 */
+{'[', 0x005a004f, 0xfffffffd},/*kerning  O Z : -0.011719 */
+{'[', 0x005c004f, 0xfffffffb},/*kerning  O \ : -0.019531 */
+{'[', 0x0061004f, 0xffffffff},/*kerning  O a : -0.003906 */
+{'[', 0x006d004f, 0xffffffff},/*kerning  O m : -0.003906 */
+{'[', 0x006e004f, 0xffffffff},/*kerning  O n : -0.003906 */
+{'[', 0x0070004f, 0xffffffff},/*kerning  O p : -0.003906 */
+{'[', 0x0072004f, 0xffffffff},/*kerning  O r : -0.003906 */
+{'[', 0x0078004f, 0xfffffffe},/*kerning  O x : -0.007812 */
+{'[', 0x0079004f, 0xffffffff},/*kerning  O y : -0.003906 */
+{'[', 0x00c0004f, 0xfffffffa},/*kerning  O À : -0.023438 */
+{'[', 0x00c1004f, 0xfffffffa},/*kerning  O Á : -0.023438 */
+{'[', 0x00c2004f, 0xfffffffa},/*kerning  O Â : -0.023438 */
+{'[', 0x00c3004f, 0xfffffffa},/*kerning  O Ã : -0.023438 */
+{'[', 0x00c4004f, 0xfffffffa},/*kerning  O Ä : -0.023438 */
+{'[', 0x00c5004f, 0xfffffffa},/*kerning  O Å : -0.023438 */
+{'[', 0x00c6004f, 0xfffffff9},/*kerning  O Æ : -0.027344 */
+{'[', 0x00d0004f, 0xffffffff},/*kerning  O Ð : -0.003906 */
+{'[', 0x00dd004f, 0xfffffff4},/*kerning  O Ý : -0.046875 */
+{'[', 0x00e0004f, 0xffffffff},/*kerning  O à : -0.003906 */
+{'[', 0x00e1004f, 0xffffffff},/*kerning  O á : -0.003906 */
+{'[', 0x00e2004f, 0xffffffff},/*kerning  O â : -0.003906 */
+{'[', 0x00e3004f, 0xffffffff},/*kerning  O ã : -0.003906 */
+{'[', 0x00e4004f, 0xffffffff},/*kerning  O ä : -0.003906 */
+{'[', 0x00e5004f, 0xffffffff},/*kerning  O å : -0.003906 */
+{'[', 0x00e6004f, 0xffffffff},/*kerning  O æ : -0.003906 */
+{'[', 0x00f1004f, 0xffffffff},/*kerning  O ñ : -0.003906 */
+{'[', 0x00fd004f, 0xffffffff},/*kerning  O ý : -0.003906 */
+{'[', 0x00ff004f, 0xffffffff},/*kerning  O ÿ : -0.003906 */
+{'@', 0x00000050, 0x00006300},/*        P        x-advance: 99.000000 */
+{'M', 0x41599999, 0x80000000},
+{'4', 0xfc740000, 0x0000017a},
+{'8', 0x186e003c, 0x42571831},
+{'8', 0x5d392925, 0x69143314},
+{'q', 0x00000000, 0x41147ae0},
+{0, 0xc0851ec0, 0x418d70a4},
+{'q', 0xc0851eb0, 0x41066668},
+{0, 0xc13ae140, 0x41599998},
+{'9', 0x0029ffc4, 0x0029ff74},
+{'4', 0x0000fef1, 0x01460000},
+{'l', 0xc1666667, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41e00000, 0xc2566666},
+{'l', 0x42047ae1, 0x00000000},
+{'8', 0xe752002f, 0xbb37e723},
+{'8', 0xa213d513, 0xa0e9cb00},
+{'8', 0xbdc4d6e9, 0xe8afe8db},
+{'l', 0xc200a3d7, 0x00000000},
+{'l', 0x00000000, 0x423ccccc},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200050, 0xfffffffa},/*kerning  P   : -0.023438 */
+{'[', 0x002c0050, 0xffffffe8},/*kerning  P , : -0.093750 */
+{'[', 0x002e0050, 0xffffffe8},/*kerning  P . : -0.093750 */
+{'[', 0x002f0050, 0xffffffee},/*kerning  P / : -0.070312 */
+{'[', 0x00340050, 0xfffffff3},/*kerning  P 4 : -0.050781 */
+{'[', 0x00410050, 0xfffffff3},/*kerning  P A : -0.050781 */
+{'[', 0x004a0050, 0xffffffe8},/*kerning  P J : -0.093750 */
+{'[', 0x00560050, 0xfffffffe},/*kerning  P V : -0.007812 */
+{'[', 0x00570050, 0xfffffffe},/*kerning  P W : -0.007812 */
+{'[', 0x00580050, 0xfffffffc},/*kerning  P X : -0.015625 */
+{'[', 0x00590050, 0xfffffffc},/*kerning  P Y : -0.015625 */
+{'[', 0x00610050, 0xffffffff},/*kerning  P a : -0.003906 */
+{'[', 0x00630050, 0xfffffffe},/*kerning  P c : -0.007812 */
+{'[', 0x00640050, 0xfffffffe},/*kerning  P d : -0.007812 */
+{'[', 0x00650050, 0xfffffffe},/*kerning  P e : -0.007812 */
+{'[', 0x00670050, 0xfffffffe},/*kerning  P g : -0.007812 */
+{'[', 0x006f0050, 0xfffffffe},/*kerning  P o : -0.007812 */
+{'[', 0x00710050, 0xfffffffe},/*kerning  P q : -0.007812 */
+{'[', 0x00730050, 0xffffffff},/*kerning  P s : -0.003906 */
+{'[', 0x00ab0050, 0xfffffffd},/*kerning  P « : -0.011719 */
+{'[', 0x00c00050, 0xfffffff3},/*kerning  P À : -0.050781 */
+{'[', 0x00c10050, 0xfffffff3},/*kerning  P Á : -0.050781 */
+{'[', 0x00c20050, 0xfffffff3},/*kerning  P Â : -0.050781 */
+{'[', 0x00c30050, 0xfffffff3},/*kerning  P Ã : -0.050781 */
+{'[', 0x00c40050, 0xfffffff3},/*kerning  P Ä : -0.050781 */
+{'[', 0x00c50050, 0xfffffff3},/*kerning  P Å : -0.050781 */
+{'[', 0x00c60050, 0xffffffea},/*kerning  P Æ : -0.085938 */
+{'[', 0x00dd0050, 0xfffffffc},/*kerning  P Ý : -0.015625 */
+{'[', 0x00e00050, 0xffffffff},/*kerning  P à : -0.003906 */
+{'[', 0x00e10050, 0xffffffff},/*kerning  P á : -0.003906 */
+{'[', 0x00e20050, 0xffffffff},/*kerning  P â : -0.003906 */
+{'[', 0x00e30050, 0xffffffff},/*kerning  P ã : -0.003906 */
+{'[', 0x00e40050, 0xffffffff},/*kerning  P ä : -0.003906 */
+{'[', 0x00e50050, 0xffffffff},/*kerning  P å : -0.003906 */
+{'[', 0x00e60050, 0xffffffff},/*kerning  P æ : -0.003906 */
+{'[', 0x00e70050, 0xfffffffe},/*kerning  P ç : -0.007812 */
+{'[', 0x00e80050, 0xfffffffe},/*kerning  P è : -0.007812 */
+{'[', 0x00e90050, 0xfffffffe},/*kerning  P é : -0.007812 */
+{'[', 0x00ea0050, 0xfffffffe},/*kerning  P ê : -0.007812 */
+{'[', 0x00eb0050, 0xfffffffe},/*kerning  P ë : -0.007812 */
+{'[', 0x00f00050, 0xfffffffb},/*kerning  P ð : -0.019531 */
+{'[', 0x00f20050, 0xfffffffe},/*kerning  P ò : -0.007812 */
+{'[', 0x00f30050, 0xfffffffe},/*kerning  P ó : -0.007812 */
+{'[', 0x00f40050, 0xfffffffe},/*kerning  P ô : -0.007812 */
+{'[', 0x00f50050, 0xfffffffe},/*kerning  P õ : -0.007812 */
+{'[', 0x00f60050, 0xfffffffe},/*kerning  P ö : -0.007812 */
+{'[', 0x00f80050, 0xfffffffe},/*kerning  P ø : -0.007812 */
+{'@', 0x00000051, 0x00007700},/*        Q        x-advance: 119.000000 */
+{'M', 0x426eb852, 0x3f4ccccc},
+{'q', 0xc1400000, 0x00000000},
+{0, 0xc1ae147c, 0xc09c28f6},
+{'q', 0xc11c28f4, 0xc09c28f6},
+{0, 0xc1870a3c, 0xc150a3d6},
+{'q', 0xc0e3d70c, 0xc1028f5c},
+{0, 0xc12f5c2a, 0xc193d70a},
+{'q', 0xc075c290, 0xc1251eb8},
+{0, 0xc075c290, 0xc1a9999a},
+{'q', 0x00000000, 0xc135c28c},
+{0, 0x40828f5c, 0xc1ad70a2},
+{'q', 0x40828f5c, 0xc1251eb8},
+{0, 0x4135c290, 0xc1933334},
+{'q', 0x40e8f5c0, 0xc10147b0},
+{0, 0x418851ec, 0xc14cccc8},
+{'q', 0x411c28f4, 0xc0970a40},
+{0, 0x41aa3d70, 0xc0970a40},
+{'q', 0x41400000, 0x00000000},
+{0, 0x41ae1478, 0x409eb850},
+{'q', 0x411c28f8, 0x409eb850},
+{0, 0x41866668, 0x41547ae0},
+{'q', 0x40e147b0, 0x41051eb8},
+{0, 0x412e1480, 0x41947ae0},
+{'q', 0x4075c280, 0x4123d708},
+{0, 0x4075c280, 0x41a7ae14},
+{'q', 0x00000000, 0x4135c290},
+{0, 0xc0828f60, 0x41ae147c},
+{'9', 0x0053ffe0, 0x0093ffa6},
+{'4', 0x00830071, 0x0000ff90},
+{'l', 0xc1000000, 0xc1147ae1},
+{'q', 0xc0ccccc0, 0x40947ae1},
+{0, 0xc16147a8, 0x40eb851e},
+{'9', 0x0015ffc3, 0x0015ff7e},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x426f5c29, 0xc1428f5c},
+{'8', 0xf15d0031, 0xd64ff12b},
+{'4', 0xff72ff87, 0x00000070},
+{'l', 0x410a3d70, 0x412147ae},
+{'q', 0x40999990, 0xc0c7ae14},
+{0, 0x40e8f5c0, 0xc1600002},
+{'q', 0x401eb860, 0xc0f851e8},
+{0, 0x401eb860, 0xc17c28f4},
+{'q', 0x00000000, 0xc10a3d6c},
+{0, 0xc0333340, 0xc185c28e},
+{'q', 0xc0333340, 0xc10147b0},
+{0, 0xc1000000, 0xc1651eb8},
+{'q', 0xc0a66660, 0xc0c7ae10},
+{0, 0xc1451eb8, 0xc11eb850},
+{'q', 0xc0e3d710, 0xc06b8520},
+{0, 0xc17c28f4, 0xc06b8520},
+{'q', 0xc111eb88, 0x00000000},
+{0, 0xc1828f5e, 0x4075c2a0},
+{'q', 0xc0e66660, 0x4075c280},
+{0, 0xc143d708, 0x4123d700},
+{'q', 0xc0a147ac, 0x40ccccd0},
+{0, 0xc0f851e8, 0x41651ec0},
+{'q', 0xc02e1480, 0x40fd70a0},
+{0, 0xc02e1480, 0x4181eb82},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x40333330, 0x4185c28e},
+{'q', 0x40333338, 0x410147b0},
+{0, 0x40fd70a8, 0x41651eba},
+{'q', 0x40a3d708, 0x40c7ae14},
+{0, 0x41451eb4, 0x411eb852},
+{'q', 0x40e66668, 0x406b8520},
+{0, 0x41800002, 0x406b8520},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00290051, 0xfffffffc},/*kerning  Q ) : -0.015625 */
+{'[', 0x002c0051, 0xfffffffd},/*kerning  Q , : -0.011719 */
+{'[', 0x002e0051, 0xfffffffd},/*kerning  Q . : -0.011719 */
+{'[', 0x002f0051, 0xfffffffa},/*kerning  Q / : -0.023438 */
+{'[', 0x00410051, 0xfffffffc},/*kerning  Q A : -0.015625 */
+{'[', 0x004a0051, 0xfffffffb},/*kerning  Q J : -0.019531 */
+{'[', 0x00540051, 0xfffffffb},/*kerning  Q T : -0.019531 */
+{'[', 0x00560051, 0xfffffffa},/*kerning  Q V : -0.023438 */
+{'[', 0x00570051, 0xfffffffa},/*kerning  Q W : -0.023438 */
+{'[', 0x00580051, 0xfffffffb},/*kerning  Q X : -0.019531 */
+{'[', 0x00590051, 0xfffffff4},/*kerning  Q Y : -0.046875 */
+{'[', 0x005a0051, 0xfffffffd},/*kerning  Q Z : -0.011719 */
+{'[', 0x005c0051, 0xfffffffb},/*kerning  Q \ : -0.019531 */
+{'[', 0x00610051, 0xffffffff},/*kerning  Q a : -0.003906 */
+{'[', 0x006d0051, 0xffffffff},/*kerning  Q m : -0.003906 */
+{'[', 0x006e0051, 0xffffffff},/*kerning  Q n : -0.003906 */
+{'[', 0x00700051, 0xffffffff},/*kerning  Q p : -0.003906 */
+{'[', 0x00720051, 0xffffffff},/*kerning  Q r : -0.003906 */
+{'[', 0x00780051, 0xfffffffe},/*kerning  Q x : -0.007812 */
+{'[', 0x00790051, 0xffffffff},/*kerning  Q y : -0.003906 */
+{'[', 0x00c00051, 0xfffffffc},/*kerning  Q À : -0.015625 */
+{'[', 0x00c10051, 0xfffffffc},/*kerning  Q Á : -0.015625 */
+{'[', 0x00c20051, 0xfffffffc},/*kerning  Q Â : -0.015625 */
+{'[', 0x00c30051, 0xfffffffc},/*kerning  Q Ã : -0.015625 */
+{'[', 0x00c40051, 0xfffffffc},/*kerning  Q Ä : -0.015625 */
+{'[', 0x00c50051, 0xfffffffc},/*kerning  Q Å : -0.015625 */
+{'[', 0x00c60051, 0x00000004},/*kerning  Q Æ : 0.015625 */
+{'[', 0x00d00051, 0x00000000},/*kerning  Q Ð : 0.000000 */
+{'[', 0x00dd0051, 0xfffffff4},/*kerning  Q Ý : -0.046875 */
+{'[', 0x00e00051, 0xffffffff},/*kerning  Q à : -0.003906 */
+{'[', 0x00e10051, 0xffffffff},/*kerning  Q á : -0.003906 */
+{'[', 0x00e20051, 0xffffffff},/*kerning  Q â : -0.003906 */
+{'[', 0x00e30051, 0xffffffff},/*kerning  Q ã : -0.003906 */
+{'[', 0x00e40051, 0xffffffff},/*kerning  Q ä : -0.003906 */
+{'[', 0x00e50051, 0xffffffff},/*kerning  Q å : -0.003906 */
+{'[', 0x00e60051, 0xffffffff},/*kerning  Q æ : -0.003906 */
+{'[', 0x00f10051, 0xffffffff},/*kerning  Q ñ : -0.003906 */
+{'[', 0x00fd0051, 0xffffffff},/*kerning  Q ý : -0.003906 */
+{'[', 0x00ff0051, 0xffffffff},/*kerning  Q ÿ : -0.003906 */
+{'@', 0x00000052, 0x00006900},/*        R        x-advance: 105.000000 */
+{'M', 0x41599999, 0x80000000},
+{'4', 0xfc740000, 0x00000185},
+{'8', 0x186e003c, 0x42571831},
+{'8', 0x5d392925, 0x69143314},
+{'q', 0x00000000, 0x40fae150},
+{0, 0xc03d70a0, 0x416e147c},
+{'8', 0x5fbe38e9, 0x379c27d6},
+{'l', 0x41dc28f8, 0x422e147b},
+{'l', 0xc1828f5c, 0x80000000},
+{'l', 0xc1cf5c2a, 0xc2233333},
+{'4', 0x0000ff10, 0x01460000},
+{'l', 0xc1666667, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41e00000, 0xc2566666},
+{'l', 0x42099999, 0x00000000},
+{'8', 0xe652002f, 0xbb37e623},
+{'8', 0xa313d513, 0xa2e9cd00},
+{'8', 0xbcc4d6e9, 0xe7afe7db},
+{'l', 0xc205c28f, 0x00000000},
+{'l', 0x00000000, 0x423ccccc},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00540052, 0xffffffff},/*kerning  R T : -0.003906 */
+{'[', 0x00560052, 0xfffffffb},/*kerning  R V : -0.019531 */
+{'[', 0x00570052, 0xfffffffb},/*kerning  R W : -0.019531 */
+{'[', 0x00590052, 0xfffffff9},/*kerning  R Y : -0.027344 */
+{'[', 0x00610052, 0xfffffffe},/*kerning  R a : -0.007812 */
+{'[', 0x00620052, 0xffffffff},/*kerning  R b : -0.003906 */
+{'[', 0x00630052, 0xfffffffc},/*kerning  R c : -0.015625 */
+{'[', 0x00640052, 0xfffffffc},/*kerning  R d : -0.015625 */
+{'[', 0x00650052, 0xfffffffc},/*kerning  R e : -0.015625 */
+{'[', 0x00670052, 0xfffffffc},/*kerning  R g : -0.015625 */
+{'[', 0x00680052, 0xffffffff},/*kerning  R h : -0.003906 */
+{'[', 0x00690052, 0xffffffff},/*kerning  R i : -0.003906 */
+{'[', 0x006a0052, 0xffffffff},/*kerning  R j : -0.003906 */
+{'[', 0x006b0052, 0xffffffff},/*kerning  R k : -0.003906 */
+{'[', 0x006c0052, 0xffffffff},/*kerning  R l : -0.003906 */
+{'[', 0x006d0052, 0xffffffff},/*kerning  R m : -0.003906 */
+{'[', 0x006e0052, 0xffffffff},/*kerning  R n : -0.003906 */
+{'[', 0x006f0052, 0xfffffffc},/*kerning  R o : -0.015625 */
+{'[', 0x00700052, 0xffffffff},/*kerning  R p : -0.003906 */
+{'[', 0x00710052, 0xfffffffc},/*kerning  R q : -0.015625 */
+{'[', 0x00720052, 0xffffffff},/*kerning  R r : -0.003906 */
+{'[', 0x00750052, 0xfffffffe},/*kerning  R u : -0.007812 */
+{'[', 0x00ab0052, 0xfffffffe},/*kerning  R « : -0.007812 */
+{'[', 0x00dd0052, 0xfffffff9},/*kerning  R Ý : -0.027344 */
+{'[', 0x00df0052, 0xffffffff},/*kerning  R ß : -0.003906 */
+{'[', 0x00e00052, 0xfffffffe},/*kerning  R à : -0.007812 */
+{'[', 0x00e10052, 0xfffffffe},/*kerning  R á : -0.007812 */
+{'[', 0x00e20052, 0xfffffffe},/*kerning  R â : -0.007812 */
+{'[', 0x00e30052, 0xfffffffe},/*kerning  R ã : -0.007812 */
+{'[', 0x00e40052, 0xfffffffe},/*kerning  R ä : -0.007812 */
+{'[', 0x00e50052, 0xfffffffe},/*kerning  R å : -0.007812 */
+{'[', 0x00e60052, 0xfffffffe},/*kerning  R æ : -0.007812 */
+{'[', 0x00e70052, 0xfffffffc},/*kerning  R ç : -0.015625 */
+{'[', 0x00e80052, 0xfffffffc},/*kerning  R è : -0.015625 */
+{'[', 0x00e90052, 0xfffffffc},/*kerning  R é : -0.015625 */
+{'[', 0x00ea0052, 0xfffffffc},/*kerning  R ê : -0.015625 */
+{'[', 0x00eb0052, 0xfffffffc},/*kerning  R ë : -0.015625 */
+{'[', 0x00ec0052, 0xffffffff},/*kerning  R ì : -0.003906 */
+{'[', 0x00ed0052, 0xffffffff},/*kerning  R í : -0.003906 */
+{'[', 0x00ee0052, 0xffffffff},/*kerning  R î : -0.003906 */
+{'[', 0x00ef0052, 0xffffffff},/*kerning  R ï : -0.003906 */
+{'[', 0x00f00052, 0xfffffffb},/*kerning  R ð : -0.019531 */
+{'[', 0x00f10052, 0xffffffff},/*kerning  R ñ : -0.003906 */
+{'[', 0x00f20052, 0xfffffffc},/*kerning  R ò : -0.015625 */
+{'[', 0x00f30052, 0xfffffffc},/*kerning  R ó : -0.015625 */
+{'[', 0x00f40052, 0xfffffffc},/*kerning  R ô : -0.015625 */
+{'[', 0x00f50052, 0xfffffffc},/*kerning  R õ : -0.015625 */
+{'[', 0x00f60052, 0xfffffffc},/*kerning  R ö : -0.015625 */
+{'[', 0x00f80052, 0xfffffffc},/*kerning  R ø : -0.015625 */
+{'[', 0x00f90052, 0xfffffffe},/*kerning  R ù : -0.007812 */
+{'[', 0x00fa0052, 0xfffffffe},/*kerning  R ú : -0.007812 */
+{'[', 0x00fb0052, 0xfffffffe},/*kerning  R û : -0.007812 */
+{'[', 0x00fc0052, 0xfffffffe},/*kerning  R ü : -0.007812 */
+{'[', 0x00fe0052, 0xffffffff},/*kerning  R þ : -0.003906 */
+{'@', 0x00000053, 0x00006100},/*        S        x-advance: 97.000000 */
+{'M', 0x42a0a3d7, 0xc2b3851e},
+{'q', 0xc0800000, 0xc08f5c30},
+{0, 0xc1451eb8, 0xc1028f60},
+{'q', 0xc1051eb8, 0xc06b8520},
+{0, 0xc1947ae2, 0xc06b8520},
+{'q', 0xc151eb84, 0x00000000},
+{0, 0xc19ae147, 0x409eb850},
+{'8', 0x6ccf27cf, 0x4c193000},
+{'q', 0x404cccc8, 0x406147c0},
+{0, 0x411d70a4, 0x40b85200},
+{'q', 0x40d47ae0, 0x400f5c20},
+{0, 0x41870a3c, 0x40947ad8},
+{'q', 0x413d70a4, 0x4023d700},
+{0, 0x41a3d70a, 0x40c7ae10},
+{'q', 0x410a3d70, 0x406b8520},
+{0, 0x41547ae0, 0x411d70a4},
+{'q', 0x40947ae0, 0x40c51eb8},
+{0, 0x40947ae0, 0x41833333},
+{'q', 0x00000000, 0x412e147a},
+{0, 0xc0ae1470, 0x418f5c28},
+{'q', 0xc0ae1480, 0x40e147b1},
+{0, 0xc16cccd0, 0x41266668},
+{'q', 0xc115c290, 0x40570a3c},
+{0, 0xc1a851ec, 0x40570a3c},
+{'9', 0x0000ff2c, 0xff80fe8f},
+{'l', 0x40dc28f6, 0xc1428f5b},
+{'8', 0x384c1c1c, 0x2e6e1c30},
+{'q', 0x40f851e8, 0x40147ae0},
+{0, 0x41833332, 0x40147ae0},
+{'q', 0x41428f5c, 0x00000000},
+{0, 0x41970a3c, 0xc08ccccc},
+{'8', 0x9935dd35, 0xafe2cd00},
+{'q', 0xc070a3c0, 0xc075c290},
+{0, 0xc131eb80, 0xc0ccccd0},
+{'q', 0xc0eb8520, 0xc023d700},
+{0, 0xc18f5c28, 0xc0a3d700},
+{'q', 0xc13851ec, 0xc03851f0},
+{0, 0xc19ae148, 0xc0ca3d70},
+{'q', 0xc0fae148, 0xc05c2900},
+{0, 0xc13c28f6, 0xc110a3d8},
+{'q', 0xc07ae144, 0xc0b33330},
+{0, 0xc07ae144, 0xc168f5c0},
+{'q', 0x00000000, 0xc12e1480},
+{0, 0x40a8f5c2, 0xc1933334},
+{'q', 0x40a8f5c4, 0xc0f0a3e0},
+{0, 0x4168f5c2, 0xc135c290},
+{'q', 0x41147ae0, 0xc075c280},
+{0, 0x41a7ae14, 0xc075c280},
+{'q', 0x4135c290, 0x00000000},
+{0, 0x41a5c28e, 0x406147a0},
+{'9', 0x001c004a, 0x004b0084},
+{'l', 0xc0d70a40, 0x413ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00410053, 0xfffffffd},/*kerning  S A : -0.011719 */
+{'[', 0x00560053, 0xfffffffc},/*kerning  S V : -0.015625 */
+{'[', 0x00570053, 0xfffffffc},/*kerning  S W : -0.015625 */
+{'[', 0x00580053, 0xfffffffe},/*kerning  S X : -0.007812 */
+{'[', 0x00590053, 0xfffffffc},/*kerning  S Y : -0.015625 */
+{'[', 0x00660053, 0xfffffffe},/*kerning  S f : -0.007812 */
+{'[', 0x00730053, 0xffffffff},/*kerning  S s : -0.003906 */
+{'[', 0x00740053, 0xfffffffe},/*kerning  S t : -0.007812 */
+{'[', 0x00760053, 0xfffffffc},/*kerning  S v : -0.015625 */
+{'[', 0x00770053, 0xfffffffc},/*kerning  S w : -0.015625 */
+{'[', 0x00780053, 0xfffffffe},/*kerning  S x : -0.007812 */
+{'[', 0x00790053, 0xfffffffc},/*kerning  S y : -0.015625 */
+{'[', 0x00c00053, 0xfffffffd},/*kerning  S À : -0.011719 */
+{'[', 0x00c10053, 0xfffffffd},/*kerning  S Á : -0.011719 */
+{'[', 0x00c20053, 0xfffffffd},/*kerning  S Â : -0.011719 */
+{'[', 0x00c30053, 0xfffffffd},/*kerning  S Ã : -0.011719 */
+{'[', 0x00c40053, 0xfffffffd},/*kerning  S Ä : -0.011719 */
+{'[', 0x00c50053, 0xfffffffd},/*kerning  S Å : -0.011719 */
+{'[', 0x00c60053, 0xfffffffd},/*kerning  S Æ : -0.011719 */
+{'[', 0x00dd0053, 0xfffffffc},/*kerning  S Ý : -0.015625 */
+{'[', 0x00fd0053, 0xfffffffc},/*kerning  S ý : -0.015625 */
+{'[', 0x00ff0053, 0xfffffffc},/*kerning  S ÿ : -0.015625 */
+{'@', 0x00000054, 0x00006200},/*        T        x-advance: 98.000000 */
+{'M', 0x42bf0a3d, 0xc2c99999},
+{'l', 0xc21ccccc, 0x00000000},
+{'l', 0x00000000, 0x42c99999},
+{'l', 0xc1666668, 0x80000000},
+{'l', 0x00000000, 0xc2c99999},
+{'l', 0xc21ccccc, 0x00000000},
+{'4', 0xff9a0000, 0x000002e6},
+{'l', 0x00000000, 0x414cccd0},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200054, 0xfffffff9},/*kerning  T   : -0.027344 */
+{'[', 0x002c0054, 0xffffffef},/*kerning  T , : -0.066406 */
+{'[', 0x002d0054, 0xfffffff1},/*kerning  T - : -0.058594 */
+{'[', 0x002e0054, 0xffffffef},/*kerning  T . : -0.066406 */
+{'[', 0x002f0054, 0xffffffed},/*kerning  T / : -0.074219 */
+{'[', 0x00300054, 0xfffffff3},/*kerning  T 0 : -0.050781 */
+{'[', 0x00310054, 0xfffffff0},/*kerning  T 1 : -0.062500 */
+{'[', 0x00320054, 0xfffffff4},/*kerning  T 2 : -0.046875 */
+{'[', 0x00330054, 0xfffffff1},/*kerning  T 3 : -0.058594 */
+{'[', 0x00340054, 0xffffffed},/*kerning  T 4 : -0.074219 */
+{'[', 0x00350054, 0xfffffff6},/*kerning  T 5 : -0.039062 */
+{'[', 0x00360054, 0xfffffffd},/*kerning  T 6 : -0.011719 */
+{'[', 0x00390054, 0xffffffef},/*kerning  T 9 : -0.066406 */
+{'[', 0x003a0054, 0xfffffff5},/*kerning  T : : -0.042969 */
+{'[', 0x003b0054, 0xfffffff5},/*kerning  T ; : -0.042969 */
+{'[', 0x00400054, 0xffffffee},/*kerning  T @ : -0.070312 */
+{'[', 0x00410054, 0xffffffef},/*kerning  T A : -0.066406 */
+{'[', 0x00430054, 0xfffffffb},/*kerning  T C : -0.019531 */
+{'[', 0x00470054, 0xfffffffb},/*kerning  T G : -0.019531 */
+{'[', 0x004a0054, 0xffffffe8},/*kerning  T J : -0.093750 */
+{'[', 0x004f0054, 0xfffffffb},/*kerning  T O : -0.019531 */
+{'[', 0x00510054, 0xfffffffb},/*kerning  T Q : -0.019531 */
+{'[', 0x00610054, 0xffffffe6},/*kerning  T a : -0.101562 */
+{'[', 0x00630054, 0xffffffe4},/*kerning  T c : -0.109375 */
+{'[', 0x00640054, 0xffffffe4},/*kerning  T d : -0.109375 */
+{'[', 0x00650054, 0xffffffe4},/*kerning  T e : -0.109375 */
+{'[', 0x00660054, 0xfffffffa},/*kerning  T f : -0.023438 */
+{'[', 0x00670054, 0xffffffe4},/*kerning  T g : -0.109375 */
+{'[', 0x006d0054, 0xffffffec},/*kerning  T m : -0.078125 */
+{'[', 0x006e0054, 0xffffffec},/*kerning  T n : -0.078125 */
+{'[', 0x006f0054, 0xffffffe4},/*kerning  T o : -0.109375 */
+{'[', 0x00700054, 0xffffffec},/*kerning  T p : -0.078125 */
+{'[', 0x00710054, 0xffffffe4},/*kerning  T q : -0.109375 */
+{'[', 0x00720054, 0xffffffec},/*kerning  T r : -0.078125 */
+{'[', 0x00730054, 0xffffffe6},/*kerning  T s : -0.101562 */
+{'[', 0x00740054, 0xfffffffe},/*kerning  T t : -0.007812 */
+{'[', 0x00750054, 0xffffffee},/*kerning  T u : -0.070312 */
+{'[', 0x00760054, 0xffffffeb},/*kerning  T v : -0.082031 */
+{'[', 0x00770054, 0xffffffec},/*kerning  T w : -0.078125 */
+{'[', 0x00780054, 0xffffffed},/*kerning  T x : -0.074219 */
+{'[', 0x00790054, 0xffffffec},/*kerning  T y : -0.078125 */
+{'[', 0x007a0054, 0xffffffea},/*kerning  T z : -0.085938 */
+{'[', 0x00a90054, 0xfffffffb},/*kerning  T © : -0.019531 */
+{'[', 0x00ab0054, 0xffffffeb},/*kerning  T « : -0.082031 */
+{'[', 0x00ae0054, 0xfffffffb},/*kerning  T ® : -0.019531 */
+{'[', 0x00bb0054, 0xffffffec},/*kerning  T » : -0.078125 */
+{'[', 0x00c00054, 0xffffffef},/*kerning  T À : -0.066406 */
+{'[', 0x00c10054, 0xffffffef},/*kerning  T Á : -0.066406 */
+{'[', 0x00c20054, 0xffffffef},/*kerning  T Â : -0.066406 */
+{'[', 0x00c30054, 0xffffffef},/*kerning  T Ã : -0.066406 */
+{'[', 0x00c40054, 0xffffffef},/*kerning  T Ä : -0.066406 */
+{'[', 0x00c50054, 0xffffffef},/*kerning  T Å : -0.066406 */
+{'[', 0x00c60054, 0xffffffea},/*kerning  T Æ : -0.085938 */
+{'[', 0x00c70054, 0xfffffffb},/*kerning  T Ç : -0.019531 */
+{'[', 0x00d20054, 0xfffffffb},/*kerning  T Ò : -0.019531 */
+{'[', 0x00d30054, 0xfffffffb},/*kerning  T Ó : -0.019531 */
+{'[', 0x00d40054, 0xfffffffb},/*kerning  T Ô : -0.019531 */
+{'[', 0x00d50054, 0xfffffffb},/*kerning  T Õ : -0.019531 */
+{'[', 0x00d60054, 0xfffffffb},/*kerning  T Ö : -0.019531 */
+{'[', 0x00d80054, 0xfffffffb},/*kerning  T Ø : -0.019531 */
+{'[', 0x00df0054, 0xfffffffd},/*kerning  T ß : -0.011719 */
+{'[', 0x00e00054, 0xffffffe6},/*kerning  T à : -0.101562 */
+{'[', 0x00e10054, 0xffffffe6},/*kerning  T á : -0.101562 */
+{'[', 0x00e20054, 0xffffffe6},/*kerning  T â : -0.101562 */
+{'[', 0x00e30054, 0xffffffea},/*kerning  T ã : -0.085938 */
+{'[', 0x00e40054, 0xffffffe6},/*kerning  T ä : -0.101562 */
+{'[', 0x00e50054, 0xffffffe6},/*kerning  T å : -0.101562 */
+{'[', 0x00e60054, 0xffffffe6},/*kerning  T æ : -0.101562 */
+{'[', 0x00e70054, 0xffffffe4},/*kerning  T ç : -0.109375 */
+{'[', 0x00e80054, 0xffffffe4},/*kerning  T è : -0.109375 */
+{'[', 0x00e90054, 0xffffffe4},/*kerning  T é : -0.109375 */
+{'[', 0x00ea0054, 0xffffffe4},/*kerning  T ê : -0.109375 */
+{'[', 0x00eb0054, 0xffffffe4},/*kerning  T ë : -0.109375 */
+{'[', 0x00ed0054, 0xffffffff},/*kerning  T í : -0.003906 */
+{'[', 0x00ee0054, 0x00000007},/*kerning  T î : 0.027344 */
+{'[', 0x00ef0054, 0x00000004},/*kerning  T ï : 0.015625 */
+{'[', 0x00f00054, 0xffffffee},/*kerning  T ð : -0.070312 */
+{'[', 0x00f10054, 0xffffffec},/*kerning  T ñ : -0.078125 */
+{'[', 0x00f20054, 0xffffffe4},/*kerning  T ò : -0.109375 */
+{'[', 0x00f30054, 0xffffffe4},/*kerning  T ó : -0.109375 */
+{'[', 0x00f40054, 0xffffffe4},/*kerning  T ô : -0.109375 */
+{'[', 0x00f50054, 0xffffffe4},/*kerning  T õ : -0.109375 */
+{'[', 0x00f60054, 0xffffffe4},/*kerning  T ö : -0.109375 */
+{'[', 0x00f80054, 0xffffffe4},/*kerning  T ø : -0.109375 */
+{'[', 0x00f90054, 0xffffffee},/*kerning  T ù : -0.070312 */
+{'[', 0x00fa0054, 0xffffffee},/*kerning  T ú : -0.070312 */
+{'[', 0x00fb0054, 0xffffffee},/*kerning  T û : -0.070312 */
+{'[', 0x00fc0054, 0xffffffee},/*kerning  T ü : -0.070312 */
+{'[', 0x00fd0054, 0xffffffec},/*kerning  T ý : -0.078125 */
+{'[', 0x00ff0054, 0xffffffec},/*kerning  T ÿ : -0.078125 */
+{'@', 0x00000055, 0x00007800},/*        U        x-advance: 120.000000 */
+{'M', 0x4271eb85, 0x3f4ccccc},
+{'q', 0xc159999c, 0x00000000},
+{0, 0xc1b70a3e, 0xc0970a3c},
+{'q', 0xc1147ae0, 0xc0970a3e},
+{0, 0xc16e147a, 0xc14ccccd},
+{'q', 0xc0b33334, 0xc10147ae},
+{0, 0xc1028f5c, 0xc1928f5d},
+{'9', 0xffafffec, 0xff58ffec},
+{'4', 0xfe350000, 0x00000073},
+{'l', 0x00000000, 0x4265c28f},
+{'q', 0x00000000, 0x41051eb8},
+{0, 0x3fd70a40, 0x4181eb86},
+{'q', 0x3fd70a40, 0x40fd70a0},
+{0, 0x40b0a3d4, 0x41628f5a},
+{'q', 0x4075c290, 0x40c7ae14},
+{0, 0x41266668, 0x411eb852},
+{'q', 0x40d1eb80, 0x406b8520},
+{0, 0x41828f5c, 0x406b8520},
+{'q', 0x411eb850, 0x00000000},
+{0, 0x4183d70c, 0xc070a3d8},
+{'q', 0x40d1eb80, 0xc070a3d8},
+{0, 0x41266660, 0xc12147ae},
+{'q', 0x4075c2a0, 0xc0ca3d70},
+{0, 0x40b0a3e0, 0xc1628f5c},
+{'9', 0xffc2000d, 0xff80000d},
+{'4', 0xfe350000, 0x00000073},
+{'l', 0x00000000, 0x4265c28f},
+{'q', 0x00000000, 0x413851ec},
+{0, 0xc028f5c0, 0x41aeb852},
+{'q', 0xc028f5c0, 0x41251eb8},
+{0, 0xc1066668, 0x419147ae},
+{'q', 0xc0b851e0, 0x40fae148},
+{0, 0xc16f5c20, 0x41466666},
+{'q', 0xc1133338, 0x4091eb86},
+{0, 0xc1b28f5e, 0x4091eb86},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002c0055, 0xfffffffd},/*kerning  U , : -0.011719 */
+{'[', 0x002e0055, 0xfffffffd},/*kerning  U . : -0.011719 */
+{'[', 0x002f0055, 0xfffffffa},/*kerning  U / : -0.023438 */
+{'[', 0x00340055, 0xfffffffe},/*kerning  U 4 : -0.007812 */
+{'[', 0x00410055, 0xfffffff9},/*kerning  U A : -0.027344 */
+{'[', 0x004a0055, 0xfffffffa},/*kerning  U J : -0.023438 */
+{'[', 0x00610055, 0xfffffffd},/*kerning  U a : -0.011719 */
+{'[', 0x00620055, 0xffffffff},/*kerning  U b : -0.003906 */
+{'[', 0x00630055, 0xfffffffe},/*kerning  U c : -0.007812 */
+{'[', 0x00640055, 0xfffffffe},/*kerning  U d : -0.007812 */
+{'[', 0x00650055, 0xfffffffe},/*kerning  U e : -0.007812 */
+{'[', 0x00660055, 0xffffffff},/*kerning  U f : -0.003906 */
+{'[', 0x00670055, 0xfffffffe},/*kerning  U g : -0.007812 */
+{'[', 0x00680055, 0xffffffff},/*kerning  U h : -0.003906 */
+{'[', 0x00690055, 0xfffffffe},/*kerning  U i : -0.007812 */
+{'[', 0x006a0055, 0xfffffffe},/*kerning  U j : -0.007812 */
+{'[', 0x006b0055, 0xffffffff},/*kerning  U k : -0.003906 */
+{'[', 0x006c0055, 0xffffffff},/*kerning  U l : -0.003906 */
+{'[', 0x006d0055, 0xfffffffe},/*kerning  U m : -0.007812 */
+{'[', 0x006e0055, 0xfffffffe},/*kerning  U n : -0.007812 */
+{'[', 0x006f0055, 0xfffffffe},/*kerning  U o : -0.007812 */
+{'[', 0x00700055, 0xfffffffe},/*kerning  U p : -0.007812 */
+{'[', 0x00710055, 0xfffffffe},/*kerning  U q : -0.007812 */
+{'[', 0x00720055, 0xfffffffe},/*kerning  U r : -0.007812 */
+{'[', 0x00730055, 0xfffffffd},/*kerning  U s : -0.011719 */
+{'[', 0x00740055, 0xffffffff},/*kerning  U t : -0.003906 */
+{'[', 0x00750055, 0xfffffffe},/*kerning  U u : -0.007812 */
+{'[', 0x007a0055, 0xfffffffe},/*kerning  U z : -0.007812 */
+{'[', 0x00c00055, 0xfffffff9},/*kerning  U À : -0.027344 */
+{'[', 0x00c10055, 0xfffffff9},/*kerning  U Á : -0.027344 */
+{'[', 0x00c20055, 0xfffffff9},/*kerning  U Â : -0.027344 */
+{'[', 0x00c30055, 0xfffffff9},/*kerning  U Ã : -0.027344 */
+{'[', 0x00c40055, 0xfffffff9},/*kerning  U Ä : -0.027344 */
+{'[', 0x00c50055, 0xfffffff9},/*kerning  U Å : -0.027344 */
+{'[', 0x00c60055, 0xfffffff8},/*kerning  U Æ : -0.031250 */
+{'[', 0x00d00055, 0xffffffff},/*kerning  U Ð : -0.003906 */
+{'[', 0x00df0055, 0xffffffff},/*kerning  U ß : -0.003906 */
+{'[', 0x00e00055, 0xfffffffd},/*kerning  U à : -0.011719 */
+{'[', 0x00e10055, 0xfffffffd},/*kerning  U á : -0.011719 */
+{'[', 0x00e20055, 0xfffffffd},/*kerning  U â : -0.011719 */
+{'[', 0x00e30055, 0xfffffffd},/*kerning  U ã : -0.011719 */
+{'[', 0x00e40055, 0xfffffffd},/*kerning  U ä : -0.011719 */
+{'[', 0x00e50055, 0xfffffffd},/*kerning  U å : -0.011719 */
+{'[', 0x00e60055, 0xfffffffd},/*kerning  U æ : -0.011719 */
+{'[', 0x00e70055, 0xfffffffe},/*kerning  U ç : -0.007812 */
+{'[', 0x00e80055, 0xfffffffe},/*kerning  U è : -0.007812 */
+{'[', 0x00e90055, 0xfffffffe},/*kerning  U é : -0.007812 */
+{'[', 0x00ea0055, 0xfffffffe},/*kerning  U ê : -0.007812 */
+{'[', 0x00eb0055, 0xfffffffe},/*kerning  U ë : -0.007812 */
+{'[', 0x00ec0055, 0xfffffffe},/*kerning  U ì : -0.007812 */
+{'[', 0x00ed0055, 0xfffffffe},/*kerning  U í : -0.007812 */
+{'[', 0x00ee0055, 0xfffffffe},/*kerning  U î : -0.007812 */
+{'[', 0x00ef0055, 0xfffffffe},/*kerning  U ï : -0.007812 */
+{'[', 0x00f00055, 0xfffffffd},/*kerning  U ð : -0.011719 */
+{'[', 0x00f10055, 0xfffffffe},/*kerning  U ñ : -0.007812 */
+{'[', 0x00f20055, 0xfffffffe},/*kerning  U ò : -0.007812 */
+{'[', 0x00f30055, 0xfffffffe},/*kerning  U ó : -0.007812 */
+{'[', 0x00f40055, 0xfffffffe},/*kerning  U ô : -0.007812 */
+{'[', 0x00f50055, 0xfffffffe},/*kerning  U õ : -0.007812 */
+{'[', 0x00f60055, 0xfffffffe},/*kerning  U ö : -0.007812 */
+{'[', 0x00f80055, 0xfffffffe},/*kerning  U ø : -0.007812 */
+{'[', 0x00f90055, 0xfffffffe},/*kerning  U ù : -0.007812 */
+{'[', 0x00fa0055, 0xfffffffe},/*kerning  U ú : -0.007812 */
+{'[', 0x00fb0055, 0xfffffffe},/*kerning  U û : -0.007812 */
+{'[', 0x00fc0055, 0xfffffffe},/*kerning  U ü : -0.007812 */
+{'[', 0x00fe0055, 0xffffffff},/*kerning  U þ : -0.003906 */
+{'@', 0x00000056, 0x00006c00},/*        V        x-advance: 108.000000 */
+{'M', 0x41866666, 0xc2e33333},
+{'l', 0x42166666, 0x42bf0a3d},
+{'l', 0x4215c28f, 0xc2bf0a3d},
+{'l', 0x41733338, 0x00000000},
+{'l', 0xc23851ec, 0x42e33333},
+{'4', 0x0000ff98, 0xfc74fe8f},
+{'l', 0x41733334, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200056, 0xfffffff8},/*kerning  V   : -0.031250 */
+{'[', 0x00260056, 0xfffffffb},/*kerning  V & : -0.019531 */
+{'[', 0x002c0056, 0xffffffee},/*kerning  V , : -0.070312 */
+{'[', 0x002d0056, 0xfffffff8},/*kerning  V - : -0.031250 */
+{'[', 0x002e0056, 0xffffffee},/*kerning  V . : -0.070312 */
+{'[', 0x002f0056, 0xffffffec},/*kerning  V / : -0.078125 */
+{'[', 0x00300056, 0xfffffff7},/*kerning  V 0 : -0.035156 */
+{'[', 0x00310056, 0xfffffffb},/*kerning  V 1 : -0.019531 */
+{'[', 0x00320056, 0xfffffffb},/*kerning  V 2 : -0.019531 */
+{'[', 0x00330056, 0xfffffffa},/*kerning  V 3 : -0.023438 */
+{'[', 0x00340056, 0xfffffff0},/*kerning  V 4 : -0.062500 */
+{'[', 0x00350056, 0xfffffff6},/*kerning  V 5 : -0.039062 */
+{'[', 0x00360056, 0xfffffffb},/*kerning  V 6 : -0.019531 */
+{'[', 0x00380056, 0xfffffffc},/*kerning  V 8 : -0.015625 */
+{'[', 0x00390056, 0xfffffff7},/*kerning  V 9 : -0.035156 */
+{'[', 0x003a0056, 0xfffffffc},/*kerning  V : : -0.015625 */
+{'[', 0x003b0056, 0xfffffffc},/*kerning  V ; : -0.015625 */
+{'[', 0x00400056, 0xfffffff5},/*kerning  V @ : -0.042969 */
+{'[', 0x00410056, 0xfffffff2},/*kerning  V A : -0.054688 */
+{'[', 0x00430056, 0xfffffffa},/*kerning  V C : -0.023438 */
+{'[', 0x00470056, 0xfffffffa},/*kerning  V G : -0.023438 */
+{'[', 0x004a0056, 0xffffffec},/*kerning  V J : -0.078125 */
+{'[', 0x004f0056, 0xfffffffa},/*kerning  V O : -0.023438 */
+{'[', 0x00510056, 0xfffffffa},/*kerning  V Q : -0.023438 */
+{'[', 0x00530056, 0xfffffffc},/*kerning  V S : -0.015625 */
+{'[', 0x00610056, 0xfffffff3},/*kerning  V a : -0.050781 */
+{'[', 0x00630056, 0xffffffef},/*kerning  V c : -0.066406 */
+{'[', 0x00640056, 0xfffffff0},/*kerning  V d : -0.062500 */
+{'[', 0x00650056, 0xffffffef},/*kerning  V e : -0.066406 */
+{'[', 0x00660056, 0xfffffffc},/*kerning  V f : -0.015625 */
+{'[', 0x00670056, 0xfffffff0},/*kerning  V g : -0.062500 */
+{'[', 0x006d0056, 0xfffffff5},/*kerning  V m : -0.042969 */
+{'[', 0x006e0056, 0xfffffff5},/*kerning  V n : -0.042969 */
+{'[', 0x006f0056, 0xffffffef},/*kerning  V o : -0.066406 */
+{'[', 0x00700056, 0xfffffff5},/*kerning  V p : -0.042969 */
+{'[', 0x00710056, 0xfffffff0},/*kerning  V q : -0.062500 */
+{'[', 0x00720056, 0xfffffff5},/*kerning  V r : -0.042969 */
+{'[', 0x00730056, 0xfffffff2},/*kerning  V s : -0.054688 */
+{'[', 0x00740056, 0xfffffffe},/*kerning  V t : -0.007812 */
+{'[', 0x00750056, 0xfffffff5},/*kerning  V u : -0.042969 */
+{'[', 0x00760056, 0xfffffffd},/*kerning  V v : -0.011719 */
+{'[', 0x00770056, 0xfffffffe},/*kerning  V w : -0.007812 */
+{'[', 0x00780056, 0xfffffffe},/*kerning  V x : -0.007812 */
+{'[', 0x00790056, 0xfffffffe},/*kerning  V y : -0.007812 */
+{'[', 0x007a0056, 0xfffffffa},/*kerning  V z : -0.023438 */
+{'[', 0x00a90056, 0xfffffffb},/*kerning  V © : -0.019531 */
+{'[', 0x00ab0056, 0xfffffff3},/*kerning  V « : -0.050781 */
+{'[', 0x00ae0056, 0xfffffffb},/*kerning  V ® : -0.019531 */
+{'[', 0x00bb0056, 0xfffffff8},/*kerning  V » : -0.031250 */
+{'[', 0x00c00056, 0xfffffff2},/*kerning  V À : -0.054688 */
+{'[', 0x00c10056, 0xfffffff2},/*kerning  V Á : -0.054688 */
+{'[', 0x00c20056, 0xfffffff2},/*kerning  V Â : -0.054688 */
+{'[', 0x00c30056, 0xfffffff2},/*kerning  V Ã : -0.054688 */
+{'[', 0x00c40056, 0xfffffff2},/*kerning  V Ä : -0.054688 */
+{'[', 0x00c50056, 0xfffffff2},/*kerning  V Å : -0.054688 */
+{'[', 0x00c60056, 0xffffffea},/*kerning  V Æ : -0.085938 */
+{'[', 0x00c70056, 0xfffffffa},/*kerning  V Ç : -0.023438 */
+{'[', 0x00d20056, 0xfffffffa},/*kerning  V Ò : -0.023438 */
+{'[', 0x00d30056, 0xfffffffa},/*kerning  V Ó : -0.023438 */
+{'[', 0x00d40056, 0xfffffffa},/*kerning  V Ô : -0.023438 */
+{'[', 0x00d50056, 0xfffffffa},/*kerning  V Õ : -0.023438 */
+{'[', 0x00d60056, 0xfffffffa},/*kerning  V Ö : -0.023438 */
+{'[', 0x00d80056, 0xfffffffa},/*kerning  V Ø : -0.023438 */
+{'[', 0x00df0056, 0xfffffffa},/*kerning  V ß : -0.023438 */
+{'[', 0x00e00056, 0xfffffff3},/*kerning  V à : -0.050781 */
+{'[', 0x00e10056, 0xfffffff3},/*kerning  V á : -0.050781 */
+{'[', 0x00e20056, 0xfffffff3},/*kerning  V â : -0.050781 */
+{'[', 0x00e30056, 0xfffffff3},/*kerning  V ã : -0.050781 */
+{'[', 0x00e40056, 0xfffffff3},/*kerning  V ä : -0.050781 */
+{'[', 0x00e50056, 0xfffffff3},/*kerning  V å : -0.050781 */
+{'[', 0x00e60056, 0xfffffff3},/*kerning  V æ : -0.050781 */
+{'[', 0x00e70056, 0xffffffef},/*kerning  V ç : -0.066406 */
+{'[', 0x00e80056, 0xffffffef},/*kerning  V è : -0.066406 */
+{'[', 0x00e90056, 0xffffffef},/*kerning  V é : -0.066406 */
+{'[', 0x00ea0056, 0xffffffef},/*kerning  V ê : -0.066406 */
+{'[', 0x00eb0056, 0xffffffef},/*kerning  V ë : -0.066406 */
+{'[', 0x00ee0056, 0x00000002},/*kerning  V î : 0.007812 */
+{'[', 0x00ef0056, 0x00000005},/*kerning  V ï : 0.019531 */
+{'[', 0x00f00056, 0xffffffee},/*kerning  V ð : -0.070312 */
+{'[', 0x00f10056, 0xfffffff5},/*kerning  V ñ : -0.042969 */
+{'[', 0x00f20056, 0xffffffef},/*kerning  V ò : -0.066406 */
+{'[', 0x00f30056, 0xffffffef},/*kerning  V ó : -0.066406 */
+{'[', 0x00f40056, 0xffffffef},/*kerning  V ô : -0.066406 */
+{'[', 0x00f50056, 0xffffffef},/*kerning  V õ : -0.066406 */
+{'[', 0x00f60056, 0xffffffef},/*kerning  V ö : -0.066406 */
+{'[', 0x00f80056, 0xffffffef},/*kerning  V ø : -0.066406 */
+{'[', 0x00f90056, 0xfffffff5},/*kerning  V ù : -0.042969 */
+{'[', 0x00fa0056, 0xfffffff5},/*kerning  V ú : -0.042969 */
+{'[', 0x00fb0056, 0xfffffff5},/*kerning  V û : -0.042969 */
+{'[', 0x00fc0056, 0xfffffff5},/*kerning  V ü : -0.042969 */
+{'[', 0x00fd0056, 0xfffffffe},/*kerning  V ý : -0.007812 */
+{'[', 0x00ff0056, 0xfffffffe},/*kerning  V ÿ : -0.007812 */
+{'@', 0x00000057, 0x0000a700},/*        W        x-advance: 167.000000 */
+{'M', 0x425ccccc, 0xc2e1eb85},
+{'l', 0x41599998, 0x00000000},
+{'l', 0x4170a3d8, 0x421e147c},
+{'l', 0x41733338, 0xc21e147c},
+{'l', 0x41599998, 0x00000000},
+{'l', 0xc19d70a4, 0x4245c28f},
+{'l', 0x419c28f4, 0x423b851f},
+{'l', 0x42199998, 0xc2c1eb85},
+{'l', 0x417ae150, 0x00000000},
+{'l', 0xc23e147a, 0x42e33333},
+{'l', 0xc147ae18, 0x80000000},
+{'l', 0xc1b47ae0, 0xc2566666},
+{'l', 0xc1b5c290, 0x42566666},
+{'l', 0xc147ae14, 0x80000000},
+{'l', 0xc23d70a4, 0xc2e33333},
+{'l', 0x417851ec, 0x00000000},
+{'4', 0x03070134, 0xfe89009a},
+{'l', 0xc19d70a4, 0xc245c28f},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200057, 0xfffffff8},/*kerning  W   : -0.031250 */
+{'[', 0x00260057, 0xfffffffb},/*kerning  W & : -0.019531 */
+{'[', 0x002c0057, 0xffffffee},/*kerning  W , : -0.070312 */
+{'[', 0x002d0057, 0xfffffff8},/*kerning  W - : -0.031250 */
+{'[', 0x002e0057, 0xffffffee},/*kerning  W . : -0.070312 */
+{'[', 0x002f0057, 0xffffffec},/*kerning  W / : -0.078125 */
+{'[', 0x00300057, 0xfffffff7},/*kerning  W 0 : -0.035156 */
+{'[', 0x00310057, 0xfffffffb},/*kerning  W 1 : -0.019531 */
+{'[', 0x00320057, 0xfffffffb},/*kerning  W 2 : -0.019531 */
+{'[', 0x00330057, 0xfffffffa},/*kerning  W 3 : -0.023438 */
+{'[', 0x00340057, 0xffffffef},/*kerning  W 4 : -0.066406 */
+{'[', 0x00350057, 0xfffffff6},/*kerning  W 5 : -0.039062 */
+{'[', 0x00360057, 0xfffffffb},/*kerning  W 6 : -0.019531 */
+{'[', 0x00380057, 0xfffffffc},/*kerning  W 8 : -0.015625 */
+{'[', 0x00390057, 0xfffffff8},/*kerning  W 9 : -0.031250 */
+{'[', 0x003a0057, 0xfffffffc},/*kerning  W : : -0.015625 */
+{'[', 0x003b0057, 0xfffffffc},/*kerning  W ; : -0.015625 */
+{'[', 0x00400057, 0xfffffff5},/*kerning  W @ : -0.042969 */
+{'[', 0x00410057, 0xfffffff1},/*kerning  W A : -0.058594 */
+{'[', 0x00430057, 0xfffffffa},/*kerning  W C : -0.023438 */
+{'[', 0x00470057, 0xfffffffa},/*kerning  W G : -0.023438 */
+{'[', 0x004a0057, 0xffffffec},/*kerning  W J : -0.078125 */
+{'[', 0x004f0057, 0xfffffffa},/*kerning  W O : -0.023438 */
+{'[', 0x00510057, 0xfffffffa},/*kerning  W Q : -0.023438 */
+{'[', 0x00530057, 0xfffffffc},/*kerning  W S : -0.015625 */
+{'[', 0x00610057, 0xfffffff3},/*kerning  W a : -0.050781 */
+{'[', 0x00630057, 0xffffffef},/*kerning  W c : -0.066406 */
+{'[', 0x00640057, 0xffffffef},/*kerning  W d : -0.066406 */
+{'[', 0x00650057, 0xffffffef},/*kerning  W e : -0.066406 */
+{'[', 0x00660057, 0xfffffffc},/*kerning  W f : -0.015625 */
+{'[', 0x00670057, 0xffffffef},/*kerning  W g : -0.066406 */
+{'[', 0x006d0057, 0xfffffff5},/*kerning  W m : -0.042969 */
+{'[', 0x006e0057, 0xfffffff5},/*kerning  W n : -0.042969 */
+{'[', 0x006f0057, 0xffffffef},/*kerning  W o : -0.066406 */
+{'[', 0x00700057, 0xfffffff5},/*kerning  W p : -0.042969 */
+{'[', 0x00710057, 0xffffffef},/*kerning  W q : -0.066406 */
+{'[', 0x00720057, 0xfffffff5},/*kerning  W r : -0.042969 */
+{'[', 0x00730057, 0xfffffff2},/*kerning  W s : -0.054688 */
+{'[', 0x00740057, 0xfffffffe},/*kerning  W t : -0.007812 */
+{'[', 0x00750057, 0xfffffff6},/*kerning  W u : -0.039062 */
+{'[', 0x00760057, 0xfffffffd},/*kerning  W v : -0.011719 */
+{'[', 0x00770057, 0xfffffffe},/*kerning  W w : -0.007812 */
+{'[', 0x00780057, 0xfffffffd},/*kerning  W x : -0.011719 */
+{'[', 0x00790057, 0xfffffffd},/*kerning  W y : -0.011719 */
+{'[', 0x007a0057, 0xfffffffa},/*kerning  W z : -0.023438 */
+{'[', 0x00a90057, 0xfffffffb},/*kerning  W © : -0.019531 */
+{'[', 0x00ab0057, 0xfffffff3},/*kerning  W « : -0.050781 */
+{'[', 0x00ae0057, 0xfffffffb},/*kerning  W ® : -0.019531 */
+{'[', 0x00bb0057, 0xfffffff8},/*kerning  W » : -0.031250 */
+{'[', 0x00c00057, 0xfffffff1},/*kerning  W À : -0.058594 */
+{'[', 0x00c10057, 0xfffffff1},/*kerning  W Á : -0.058594 */
+{'[', 0x00c20057, 0xfffffff1},/*kerning  W Â : -0.058594 */
+{'[', 0x00c30057, 0xfffffff1},/*kerning  W Ã : -0.058594 */
+{'[', 0x00c40057, 0xfffffff1},/*kerning  W Ä : -0.058594 */
+{'[', 0x00c50057, 0xfffffff1},/*kerning  W Å : -0.058594 */
+{'[', 0x00c60057, 0xffffffea},/*kerning  W Æ : -0.085938 */
+{'[', 0x00c70057, 0xfffffffa},/*kerning  W Ç : -0.023438 */
+{'[', 0x00d20057, 0xfffffffa},/*kerning  W Ò : -0.023438 */
+{'[', 0x00d30057, 0xfffffffa},/*kerning  W Ó : -0.023438 */
+{'[', 0x00d40057, 0xfffffffa},/*kerning  W Ô : -0.023438 */
+{'[', 0x00d50057, 0xfffffffa},/*kerning  W Õ : -0.023438 */
+{'[', 0x00d60057, 0xfffffffa},/*kerning  W Ö : -0.023438 */
+{'[', 0x00d80057, 0xfffffffa},/*kerning  W Ø : -0.023438 */
+{'[', 0x00df0057, 0xfffffffa},/*kerning  W ß : -0.023438 */
+{'[', 0x00e00057, 0xfffffff3},/*kerning  W à : -0.050781 */
+{'[', 0x00e10057, 0xfffffff3},/*kerning  W á : -0.050781 */
+{'[', 0x00e20057, 0xfffffff3},/*kerning  W â : -0.050781 */
+{'[', 0x00e30057, 0xfffffff3},/*kerning  W ã : -0.050781 */
+{'[', 0x00e40057, 0xfffffff3},/*kerning  W ä : -0.050781 */
+{'[', 0x00e50057, 0xfffffff3},/*kerning  W å : -0.050781 */
+{'[', 0x00e60057, 0xfffffff3},/*kerning  W æ : -0.050781 */
+{'[', 0x00e70057, 0xffffffef},/*kerning  W ç : -0.066406 */
+{'[', 0x00e80057, 0xffffffef},/*kerning  W è : -0.066406 */
+{'[', 0x00e90057, 0xffffffef},/*kerning  W é : -0.066406 */
+{'[', 0x00ea0057, 0xffffffef},/*kerning  W ê : -0.066406 */
+{'[', 0x00eb0057, 0xffffffef},/*kerning  W ë : -0.066406 */
+{'[', 0x00ee0057, 0x00000002},/*kerning  W î : 0.007812 */
+{'[', 0x00ef0057, 0x00000005},/*kerning  W ï : 0.019531 */
+{'[', 0x00f00057, 0xffffffee},/*kerning  W ð : -0.070312 */
+{'[', 0x00f10057, 0xfffffff5},/*kerning  W ñ : -0.042969 */
+{'[', 0x00f20057, 0xffffffef},/*kerning  W ò : -0.066406 */
+{'[', 0x00f30057, 0xffffffef},/*kerning  W ó : -0.066406 */
+{'[', 0x00f40057, 0xffffffef},/*kerning  W ô : -0.066406 */
+{'[', 0x00f50057, 0xffffffef},/*kerning  W õ : -0.066406 */
+{'[', 0x00f60057, 0xffffffef},/*kerning  W ö : -0.066406 */
+{'[', 0x00f80057, 0xffffffef},/*kerning  W ø : -0.066406 */
+{'[', 0x00f90057, 0xfffffff6},/*kerning  W ù : -0.039062 */
+{'[', 0x00fa0057, 0xfffffff6},/*kerning  W ú : -0.039062 */
+{'[', 0x00fb0057, 0xfffffff6},/*kerning  W û : -0.039062 */
+{'[', 0x00fc0057, 0xfffffff6},/*kerning  W ü : -0.039062 */
+{'[', 0x00fd0057, 0xfffffffd},/*kerning  W ý : -0.011719 */
+{'[', 0x00ff0057, 0xfffffffd},/*kerning  W ÿ : -0.011719 */
+{'@', 0x00000058, 0x00006500},/*        X        x-advance: 101.000000 */
+{'M', 0x41866666, 0xc2e33333},
+{'l', 0x4208f5c2, 0x423c28f6},
+{'l', 0x4208f5c3, 0xc23c28f6},
+{'l', 0x418147ac, 0x00000000},
+{'l', 0xc2299999, 0x42666666},
+{'l', 0x42247ae1, 0x42600000},
+{'l', 0xc18147ac, 0x80000000},
+{'l', 0xc203d70b, 0xc235c28f},
+{'l', 0xc203d70a, 0x4235c28f},
+{'l', 0xc1828f5b, 0x80000000},
+{'4', 0xfe400148, 0xfe34fead},
+{'l', 0x41828f5c, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200058, 0xfffffffe},/*kerning  X   : -0.007812 */
+{'[', 0x002d0058, 0xfffffffc},/*kerning  X - : -0.015625 */
+{'[', 0x00300058, 0xfffffffd},/*kerning  X 0 : -0.011719 */
+{'[', 0x00430058, 0xfffffff8},/*kerning  X C : -0.031250 */
+{'[', 0x00470058, 0xfffffff8},/*kerning  X G : -0.031250 */
+{'[', 0x004f0058, 0xfffffff8},/*kerning  X O : -0.031250 */
+{'[', 0x00510058, 0xfffffff8},/*kerning  X Q : -0.031250 */
+{'[', 0x00530058, 0xffffffff},/*kerning  X S : -0.003906 */
+{'[', 0x005c0058, 0x00000001},/*kerning  X \ : 0.003906 */
+{'[', 0x00610058, 0xffffffff},/*kerning  X a : -0.003906 */
+{'[', 0x00630058, 0xfffffff7},/*kerning  X c : -0.035156 */
+{'[', 0x00640058, 0xfffffff7},/*kerning  X d : -0.035156 */
+{'[', 0x00650058, 0xfffffff7},/*kerning  X e : -0.035156 */
+{'[', 0x00660058, 0xfffffffe},/*kerning  X f : -0.007812 */
+{'[', 0x00670058, 0xfffffff7},/*kerning  X g : -0.035156 */
+{'[', 0x006d0058, 0xfffffffe},/*kerning  X m : -0.007812 */
+{'[', 0x006e0058, 0xfffffffe},/*kerning  X n : -0.007812 */
+{'[', 0x006f0058, 0xfffffff7},/*kerning  X o : -0.035156 */
+{'[', 0x00700058, 0xfffffffe},/*kerning  X p : -0.007812 */
+{'[', 0x00710058, 0xfffffff7},/*kerning  X q : -0.035156 */
+{'[', 0x00720058, 0xfffffffe},/*kerning  X r : -0.007812 */
+{'[', 0x00740058, 0xfffffffe},/*kerning  X t : -0.007812 */
+{'[', 0x00750058, 0xfffffffb},/*kerning  X u : -0.019531 */
+{'[', 0x00760058, 0xfffffff9},/*kerning  X v : -0.027344 */
+{'[', 0x00770058, 0xfffffffa},/*kerning  X w : -0.023438 */
+{'[', 0x00790058, 0xfffffffa},/*kerning  X y : -0.023438 */
+{'[', 0x00a90058, 0xfffffffc},/*kerning  X © : -0.015625 */
+{'[', 0x00ab0058, 0xfffffffa},/*kerning  X « : -0.023438 */
+{'[', 0x00ae0058, 0xfffffffc},/*kerning  X ® : -0.015625 */
+{'[', 0x00c70058, 0xfffffff8},/*kerning  X Ç : -0.031250 */
+{'[', 0x00d20058, 0xfffffff8},/*kerning  X Ò : -0.031250 */
+{'[', 0x00d30058, 0xfffffff8},/*kerning  X Ó : -0.031250 */
+{'[', 0x00d40058, 0xfffffff8},/*kerning  X Ô : -0.031250 */
+{'[', 0x00d50058, 0xfffffff8},/*kerning  X Õ : -0.031250 */
+{'[', 0x00d60058, 0xfffffff8},/*kerning  X Ö : -0.031250 */
+{'[', 0x00d80058, 0xfffffff8},/*kerning  X Ø : -0.031250 */
+{'[', 0x00df0058, 0xfffffffe},/*kerning  X ß : -0.007812 */
+{'[', 0x00e00058, 0xffffffff},/*kerning  X à : -0.003906 */
+{'[', 0x00e10058, 0xffffffff},/*kerning  X á : -0.003906 */
+{'[', 0x00e20058, 0xffffffff},/*kerning  X â : -0.003906 */
+{'[', 0x00e30058, 0xffffffff},/*kerning  X ã : -0.003906 */
+{'[', 0x00e40058, 0xffffffff},/*kerning  X ä : -0.003906 */
+{'[', 0x00e50058, 0xffffffff},/*kerning  X å : -0.003906 */
+{'[', 0x00e60058, 0xffffffff},/*kerning  X æ : -0.003906 */
+{'[', 0x00e70058, 0xfffffff7},/*kerning  X ç : -0.035156 */
+{'[', 0x00e80058, 0xfffffff7},/*kerning  X è : -0.035156 */
+{'[', 0x00e90058, 0xfffffff7},/*kerning  X é : -0.035156 */
+{'[', 0x00ea0058, 0xfffffff7},/*kerning  X ê : -0.035156 */
+{'[', 0x00eb0058, 0xfffffff7},/*kerning  X ë : -0.035156 */
+{'[', 0x00ef0058, 0x00000007},/*kerning  X ï : 0.027344 */
+{'[', 0x00f00058, 0xfffffff8},/*kerning  X ð : -0.031250 */
+{'[', 0x00f10058, 0xfffffffe},/*kerning  X ñ : -0.007812 */
+{'[', 0x00f20058, 0xfffffff7},/*kerning  X ò : -0.035156 */
+{'[', 0x00f30058, 0xfffffff7},/*kerning  X ó : -0.035156 */
+{'[', 0x00f40058, 0xfffffff7},/*kerning  X ô : -0.035156 */
+{'[', 0x00f50058, 0xfffffff7},/*kerning  X õ : -0.035156 */
+{'[', 0x00f60058, 0xfffffff7},/*kerning  X ö : -0.035156 */
+{'[', 0x00f80058, 0xfffffff7},/*kerning  X ø : -0.035156 */
+{'[', 0x00f90058, 0xfffffffb},/*kerning  X ù : -0.019531 */
+{'[', 0x00fa0058, 0xfffffffb},/*kerning  X ú : -0.019531 */
+{'[', 0x00fb0058, 0xfffffffb},/*kerning  X û : -0.019531 */
+{'[', 0x00fc0058, 0xfffffffb},/*kerning  X ü : -0.019531 */
+{'[', 0x00fd0058, 0xfffffffa},/*kerning  X ý : -0.023438 */
+{'[', 0x00ff0058, 0xfffffffa},/*kerning  X ÿ : -0.023438 */
+{'@', 0x00000059, 0x00006800},/*        Y        x-advance: 104.000000 */
+{'M', 0x418f5c29, 0xc2e33333},
+{'l', 0x4209999a, 0x426ccccd},
+{'l', 0x420ae148, 0xc26ccccd},
+{'l', 0x417ae148, 0x00000000},
+{'l', 0xc22ccccd, 0x429051ec},
+{'l', 0x00000000, 0x4225c28e},
+{'l', 0xc1666668, 0x80000000},
+{'4', 0xfeb20000, 0xfdc2fea8},
+{'l', 0x417d70a6, 0xb7000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200059, 0xfffffff7},/*kerning  Y   : -0.035156 */
+{'[', 0x00260059, 0xfffffff9},/*kerning  Y & : -0.027344 */
+{'[', 0x002c0059, 0xffffffeb},/*kerning  Y , : -0.082031 */
+{'[', 0x002d0059, 0xfffffff0},/*kerning  Y - : -0.062500 */
+{'[', 0x002e0059, 0xffffffeb},/*kerning  Y . : -0.082031 */
+{'[', 0x002f0059, 0xffffffeb},/*kerning  Y / : -0.082031 */
+{'[', 0x00300059, 0xfffffff1},/*kerning  Y 0 : -0.058594 */
+{'[', 0x00310059, 0xfffffff5},/*kerning  Y 1 : -0.042969 */
+{'[', 0x00320059, 0xfffffff6},/*kerning  Y 2 : -0.039062 */
+{'[', 0x00330059, 0xfffffff6},/*kerning  Y 3 : -0.039062 */
+{'[', 0x00340059, 0xffffffec},/*kerning  Y 4 : -0.078125 */
+{'[', 0x00350059, 0xfffffff3},/*kerning  Y 5 : -0.050781 */
+{'[', 0x00360059, 0xfffffff8},/*kerning  Y 6 : -0.031250 */
+{'[', 0x00380059, 0xfffffffa},/*kerning  Y 8 : -0.023438 */
+{'[', 0x00390059, 0xfffffff2},/*kerning  Y 9 : -0.054688 */
+{'[', 0x003a0059, 0xfffffff9},/*kerning  Y : : -0.027344 */
+{'[', 0x003b0059, 0xfffffff9},/*kerning  Y ; : -0.027344 */
+{'[', 0x00400059, 0xffffffef},/*kerning  Y @ : -0.066406 */
+{'[', 0x00410059, 0xffffffed},/*kerning  Y A : -0.074219 */
+{'[', 0x00430059, 0xfffffff5},/*kerning  Y C : -0.042969 */
+{'[', 0x00470059, 0xfffffff5},/*kerning  Y G : -0.042969 */
+{'[', 0x004a0059, 0xffffffea},/*kerning  Y J : -0.085938 */
+{'[', 0x004f0059, 0xfffffff5},/*kerning  Y O : -0.042969 */
+{'[', 0x00510059, 0xfffffff5},/*kerning  Y Q : -0.042969 */
+{'[', 0x00530059, 0xfffffffa},/*kerning  Y S : -0.023438 */
+{'[', 0x00610059, 0xffffffe9},/*kerning  Y a : -0.089844 */
+{'[', 0x00630059, 0xffffffe9},/*kerning  Y c : -0.089844 */
+{'[', 0x00640059, 0xffffffea},/*kerning  Y d : -0.085938 */
+{'[', 0x00650059, 0xffffffe9},/*kerning  Y e : -0.089844 */
+{'[', 0x00660059, 0xfffffff8},/*kerning  Y f : -0.031250 */
+{'[', 0x00670059, 0xffffffea},/*kerning  Y g : -0.085938 */
+{'[', 0x006d0059, 0xfffffff0},/*kerning  Y m : -0.062500 */
+{'[', 0x006e0059, 0xfffffff0},/*kerning  Y n : -0.062500 */
+{'[', 0x006f0059, 0xffffffe9},/*kerning  Y o : -0.089844 */
+{'[', 0x00700059, 0xfffffff0},/*kerning  Y p : -0.062500 */
+{'[', 0x00710059, 0xffffffea},/*kerning  Y q : -0.085938 */
+{'[', 0x00720059, 0xfffffff0},/*kerning  Y r : -0.062500 */
+{'[', 0x00730059, 0xffffffe8},/*kerning  Y s : -0.093750 */
+{'[', 0x00740059, 0xfffffffb},/*kerning  Y t : -0.019531 */
+{'[', 0x00750059, 0xfffffff1},/*kerning  Y u : -0.058594 */
+{'[', 0x00760059, 0xfffffff7},/*kerning  Y v : -0.035156 */
+{'[', 0x00770059, 0xfffffff8},/*kerning  Y w : -0.031250 */
+{'[', 0x00780059, 0xfffffff9},/*kerning  Y x : -0.027344 */
+{'[', 0x00790059, 0xfffffff8},/*kerning  Y y : -0.031250 */
+{'[', 0x007a0059, 0xfffffff5},/*kerning  Y z : -0.042969 */
+{'[', 0x00a90059, 0xfffffff6},/*kerning  Y © : -0.039062 */
+{'[', 0x00ab0059, 0xffffffec},/*kerning  Y « : -0.078125 */
+{'[', 0x00ae0059, 0xfffffff6},/*kerning  Y ® : -0.039062 */
+{'[', 0x00bb0059, 0xfffffff2},/*kerning  Y » : -0.054688 */
+{'[', 0x00c00059, 0xffffffed},/*kerning  Y À : -0.074219 */
+{'[', 0x00c10059, 0xffffffed},/*kerning  Y Á : -0.074219 */
+{'[', 0x00c20059, 0xffffffed},/*kerning  Y Â : -0.074219 */
+{'[', 0x00c30059, 0xffffffed},/*kerning  Y Ã : -0.074219 */
+{'[', 0x00c40059, 0xffffffed},/*kerning  Y Ä : -0.074219 */
+{'[', 0x00c50059, 0xffffffed},/*kerning  Y Å : -0.074219 */
+{'[', 0x00c60059, 0xffffffe5},/*kerning  Y Æ : -0.105469 */
+{'[', 0x00c70059, 0xfffffff5},/*kerning  Y Ç : -0.042969 */
+{'[', 0x00d00059, 0xfffffffe},/*kerning  Y Ð : -0.007812 */
+{'[', 0x00d20059, 0xfffffff5},/*kerning  Y Ò : -0.042969 */
+{'[', 0x00d30059, 0xfffffff5},/*kerning  Y Ó : -0.042969 */
+{'[', 0x00d40059, 0xfffffff5},/*kerning  Y Ô : -0.042969 */
+{'[', 0x00d50059, 0xfffffff5},/*kerning  Y Õ : -0.042969 */
+{'[', 0x00d60059, 0xfffffff5},/*kerning  Y Ö : -0.042969 */
+{'[', 0x00d80059, 0xfffffff5},/*kerning  Y Ø : -0.042969 */
+{'[', 0x00df0059, 0xfffffff6},/*kerning  Y ß : -0.039062 */
+{'[', 0x00e00059, 0xffffffe9},/*kerning  Y à : -0.089844 */
+{'[', 0x00e10059, 0xffffffe9},/*kerning  Y á : -0.089844 */
+{'[', 0x00e20059, 0xffffffe9},/*kerning  Y â : -0.089844 */
+{'[', 0x00e30059, 0xffffffe9},/*kerning  Y ã : -0.089844 */
+{'[', 0x00e40059, 0xffffffe9},/*kerning  Y ä : -0.089844 */
+{'[', 0x00e50059, 0xffffffe9},/*kerning  Y å : -0.089844 */
+{'[', 0x00e60059, 0xffffffe9},/*kerning  Y æ : -0.089844 */
+{'[', 0x00e70059, 0xffffffe9},/*kerning  Y ç : -0.089844 */
+{'[', 0x00e80059, 0xffffffe9},/*kerning  Y è : -0.089844 */
+{'[', 0x00e90059, 0xffffffe9},/*kerning  Y é : -0.089844 */
+{'[', 0x00ea0059, 0xffffffe9},/*kerning  Y ê : -0.089844 */
+{'[', 0x00eb0059, 0xffffffe9},/*kerning  Y ë : -0.089844 */
+{'[', 0x00ed0059, 0xfffffffd},/*kerning  Y í : -0.011719 */
+{'[', 0x00ef0059, 0x00000004},/*kerning  Y ï : 0.015625 */
+{'[', 0x00f00059, 0xffffffe8},/*kerning  Y ð : -0.093750 */
+{'[', 0x00f10059, 0xfffffff0},/*kerning  Y ñ : -0.062500 */
+{'[', 0x00f20059, 0xffffffe9},/*kerning  Y ò : -0.089844 */
+{'[', 0x00f30059, 0xffffffe9},/*kerning  Y ó : -0.089844 */
+{'[', 0x00f40059, 0xffffffe9},/*kerning  Y ô : -0.089844 */
+{'[', 0x00f50059, 0xffffffe9},/*kerning  Y õ : -0.089844 */
+{'[', 0x00f60059, 0xffffffe9},/*kerning  Y ö : -0.089844 */
+{'[', 0x00f80059, 0xffffffe9},/*kerning  Y ø : -0.089844 */
+{'[', 0x00f90059, 0xfffffff1},/*kerning  Y ù : -0.058594 */
+{'[', 0x00fa0059, 0xfffffff1},/*kerning  Y ú : -0.058594 */
+{'[', 0x00fb0059, 0xfffffff1},/*kerning  Y û : -0.058594 */
+{'[', 0x00fc0059, 0xfffffff1},/*kerning  Y ü : -0.058594 */
+{'[', 0x00fd0059, 0xfffffff8},/*kerning  Y ý : -0.031250 */
+{'[', 0x00ff0059, 0xfffffff8},/*kerning  Y ÿ : -0.031250 */
+{'@', 0x0000005a, 0x00006400},/*        Z        x-advance: 100.000000 */
+{'M', 0x40a3d70a, 0xc1333333},
+{'l', 0x42928f5c, 0xc2b33333},
+{'l', 0xc28fae15, 0x00000000},
+{'l', 0x36200000, 0xc14cccd0},
+{'l', 0x42b147ae, 0x00000000},
+{'l', 0x00000000, 0x41333338},
+{'l', 0xc2900000, 0x42b33332},
+{'l', 0x42900000, 0x36800000},
+{'4', 0x00660000, 0x0000fd30},
+{'l', 0xb6400000, 0xc1333333},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0043005a, 0xfffffffd},/*kerning  Z C : -0.011719 */
+{'[', 0x0047005a, 0xfffffffd},/*kerning  Z G : -0.011719 */
+{'[', 0x004f005a, 0xfffffffd},/*kerning  Z O : -0.011719 */
+{'[', 0x0051005a, 0xfffffffd},/*kerning  Z Q : -0.011719 */
+{'[', 0x0063005a, 0xfffffffd},/*kerning  Z c : -0.011719 */
+{'[', 0x0064005a, 0xfffffffd},/*kerning  Z d : -0.011719 */
+{'[', 0x0065005a, 0xfffffffd},/*kerning  Z e : -0.011719 */
+{'[', 0x0066005a, 0xfffffffe},/*kerning  Z f : -0.007812 */
+{'[', 0x0067005a, 0xfffffffd},/*kerning  Z g : -0.011719 */
+{'[', 0x006d005a, 0xfffffffe},/*kerning  Z m : -0.007812 */
+{'[', 0x006e005a, 0xfffffffe},/*kerning  Z n : -0.007812 */
+{'[', 0x006f005a, 0xfffffffd},/*kerning  Z o : -0.011719 */
+{'[', 0x0070005a, 0xfffffffe},/*kerning  Z p : -0.007812 */
+{'[', 0x0071005a, 0xfffffffd},/*kerning  Z q : -0.011719 */
+{'[', 0x0072005a, 0xfffffffe},/*kerning  Z r : -0.007812 */
+{'[', 0x0074005a, 0xfffffffe},/*kerning  Z t : -0.007812 */
+{'[', 0x0075005a, 0xfffffffd},/*kerning  Z u : -0.011719 */
+{'[', 0x0076005a, 0xfffffffc},/*kerning  Z v : -0.015625 */
+{'[', 0x0077005a, 0xfffffffc},/*kerning  Z w : -0.015625 */
+{'[', 0x0079005a, 0xfffffffc},/*kerning  Z y : -0.015625 */
+{'[', 0x00a9005a, 0xfffffffd},/*kerning  Z © : -0.011719 */
+{'[', 0x00ae005a, 0xfffffffd},/*kerning  Z ® : -0.011719 */
+{'[', 0x00c7005a, 0xfffffffd},/*kerning  Z Ç : -0.011719 */
+{'[', 0x00d2005a, 0xfffffffd},/*kerning  Z Ò : -0.011719 */
+{'[', 0x00d3005a, 0xfffffffd},/*kerning  Z Ó : -0.011719 */
+{'[', 0x00d4005a, 0xfffffffd},/*kerning  Z Ô : -0.011719 */
+{'[', 0x00d5005a, 0xfffffffd},/*kerning  Z Õ : -0.011719 */
+{'[', 0x00d6005a, 0xfffffffd},/*kerning  Z Ö : -0.011719 */
+{'[', 0x00d8005a, 0xfffffffd},/*kerning  Z Ø : -0.011719 */
+{'[', 0x00e7005a, 0xfffffffd},/*kerning  Z ç : -0.011719 */
+{'[', 0x00e8005a, 0xfffffffd},/*kerning  Z è : -0.011719 */
+{'[', 0x00e9005a, 0xfffffffd},/*kerning  Z é : -0.011719 */
+{'[', 0x00ea005a, 0xfffffffd},/*kerning  Z ê : -0.011719 */
+{'[', 0x00eb005a, 0xfffffffd},/*kerning  Z ë : -0.011719 */
+{'[', 0x00ee005a, 0x00000002},/*kerning  Z î : 0.007812 */
+{'[', 0x00f0005a, 0xfffffffd},/*kerning  Z ð : -0.011719 */
+{'[', 0x00f1005a, 0xfffffffe},/*kerning  Z ñ : -0.007812 */
+{'[', 0x00f2005a, 0xfffffffd},/*kerning  Z ò : -0.011719 */
+{'[', 0x00f3005a, 0xfffffffd},/*kerning  Z ó : -0.011719 */
+{'[', 0x00f4005a, 0xfffffffd},/*kerning  Z ô : -0.011719 */
+{'[', 0x00f5005a, 0xfffffffd},/*kerning  Z õ : -0.011719 */
+{'[', 0x00f6005a, 0xfffffffd},/*kerning  Z ö : -0.011719 */
+{'[', 0x00f8005a, 0xfffffffd},/*kerning  Z ø : -0.011719 */
+{'[', 0x00f9005a, 0xfffffffd},/*kerning  Z ù : -0.011719 */
+{'[', 0x00fa005a, 0xfffffffd},/*kerning  Z ú : -0.011719 */
+{'[', 0x00fb005a, 0xfffffffd},/*kerning  Z û : -0.011719 */
+{'[', 0x00fc005a, 0xfffffffd},/*kerning  Z ü : -0.011719 */
+{'[', 0x00fd005a, 0xfffffffc},/*kerning  Z ý : -0.015625 */
+{'[', 0x00ff005a, 0xfffffffc},/*kerning  Z ÿ : -0.015625 */
+{'@', 0x0000005b, 0x00002b00},/*        [        x-advance: 43.000000 */
+{'M', 0x41570a3d, 0x40cccccc},
+{'l', 0x00000000, 0xc2f99999},
+{'l', 0x41b33334, 0x00000000},
+{'l', 0x00000000, 0x413851e8},
+{'l', 0xc1147ae2, 0x00000000},
+{'l', 0x00000000, 0x42cb851e},
+{'4', 0x0000004a, 0x005c0000},
+{'l', 0xc1b33334, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0064005b, 0xfffffffe},/*kerning  [ d : -0.007812 */
+{'[', 0x0067005b, 0xfffffffe},/*kerning  [ g : -0.007812 */
+{'[', 0x0071005b, 0xfffffffe},/*kerning  [ q : -0.007812 */
+{'[', 0x00c6005b, 0x00000003},/*kerning  [ Æ : 0.011719 */
+{'@', 0x0000005c, 0x00005e00},/*       \         x-advance: 94.000000 */
+{'M', 0x41a28f5c, 0xc2e33333},
+{'l', 0x428b3333, 0x42e33333},
+{'4', 0x0000ff83, 0xfc74fdd2},
+{'l', 0x417d70a0, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0022005c, 0xffffffed},/*kerning  \ " : -0.074219 */
+{'[', 0x0027005c, 0xffffffed},/*kerning  \ ' : -0.074219 */
+{'[', 0x0043005c, 0xfffffffb},/*kerning  \ C : -0.019531 */
+{'[', 0x0047005c, 0xfffffffb},/*kerning  \ G : -0.019531 */
+{'[', 0x004f005c, 0xfffffffb},/*kerning  \ O : -0.019531 */
+{'[', 0x0051005c, 0xfffffffb},/*kerning  \ Q : -0.019531 */
+{'[', 0x0054005c, 0xffffffed},/*kerning  \ T : -0.074219 */
+{'[', 0x0055005c, 0xfffffffb},/*kerning  \ U : -0.019531 */
+{'[', 0x0056005c, 0xffffffed},/*kerning  \ V : -0.074219 */
+{'[', 0x0057005c, 0xffffffed},/*kerning  \ W : -0.074219 */
+{'[', 0x0059005c, 0xffffffec},/*kerning  \ Y : -0.078125 */
+{'[', 0x0074005c, 0xfffffffe},/*kerning  \ t : -0.007812 */
+{'[', 0x0076005c, 0xfffffff6},/*kerning  \ v : -0.039062 */
+{'[', 0x0077005c, 0xfffffff5},/*kerning  \ w : -0.042969 */
+{'[', 0x0079005c, 0xfffffff5},/*kerning  \ y : -0.042969 */
+{'[', 0x00c6005c, 0x00000008},/*kerning  \ Æ : 0.031250 */
+{'[', 0x00c7005c, 0xfffffffb},/*kerning  \ Ç : -0.019531 */
+{'[', 0x00d2005c, 0xfffffffb},/*kerning  \ Ò : -0.019531 */
+{'[', 0x00d3005c, 0xfffffffb},/*kerning  \ Ó : -0.019531 */
+{'[', 0x00d4005c, 0xfffffffb},/*kerning  \ Ô : -0.019531 */
+{'[', 0x00d5005c, 0xfffffffb},/*kerning  \ Õ : -0.019531 */
+{'[', 0x00d6005c, 0xfffffffb},/*kerning  \ Ö : -0.019531 */
+{'[', 0x00d8005c, 0xfffffffb},/*kerning  \ Ø : -0.019531 */
+{'[', 0x00d9005c, 0xfffffffb},/*kerning  \ Ù : -0.019531 */
+{'[', 0x00da005c, 0xfffffffb},/*kerning  \ Ú : -0.019531 */
+{'[', 0x00db005c, 0xfffffffb},/*kerning  \ Û : -0.019531 */
+{'[', 0x00dc005c, 0xfffffffb},/*kerning  \ Ü : -0.019531 */
+{'[', 0x00dd005c, 0xffffffec},/*kerning  \ Ý : -0.078125 */
+{'[', 0x00fd005c, 0xfffffff5},/*kerning  \ ý : -0.042969 */
+{'[', 0x00ff005c, 0xfffffff5},/*kerning  \ ÿ : -0.042969 */
+{'@', 0x0000005d, 0x00002b00},/*        ]        x-advance: 43.000000 */
+{'M', 0x40eb851e, 0x40cccccc},
+{'l', 0x00000000, 0xc13851eb},
+{'l', 0x41147ae1, 0x00000000},
+{'l', 0x00000000, 0xc2cb851e},
+{'l', 0xc1147ae1, 0x00000000},
+{'l', 0x00000000, 0xc13851e8},
+{'4', 0x000000b3, 0x03e60000},
+{'l', 0xc1b33334, 0xb6000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x0000005e, 0x00005800},/*        ^        x-advance: 88.000000 */
+{'M', 0x40d70a3d, 0xc241eb85},
+{'l', 0x41fd70a3, 0xc2823d70},
+{'l', 0x413d70a4, 0xb7000000},
+{'l', 0x41fc28f4, 0x42823d70},
+{'l', 0xc13ffff8, 0x36800000},
+{'4', 0xfe5dff35, 0x01a3ff31},
+{'l', 0xc13ae148, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x0000005f, 0x00005000},/*        _        x-advance: 80.000000 */
+{'M', 0x412147ae, 0x414ccccc},
+{'l', 0x00000000, 0xc14ccccc},
+{'4', 0x000001e2, 0x00660000},
+{'l', 0xc27147ae, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00000060, 0x00002500},/*        `        x-advance: 37.000000 */
+{'M', 0x40f5c28f, 0xc2e99999},
+{'l', 0x415eb852, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d70a, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00000061, 0x00005800},/*        a        x-advance: 88.000000 */
+{'M', 0x40999999, 0xc1c147ae},
+{'8', 0x9224c000, 0xb864d224},
+{'q', 0x41000000, 0xc04cccc0},
+{0, 0x41947ae1, 0xc04cccc0},
+{'8', 0x075e002c, 0x15580731},
+{'l', 0x00000000, 0xc0c28f60},
+{'q', 0x00000000, 0xc1199998},
+{0, 0xc0b851e8, 0xc171eb84},
+{'q', 0xc0b851e8, 0xc0b0a3d0},
+{0, 0xc1828f5c, 0xc0b0a3d0},
+{'8', 0x139700c9, 0x389613ce},
+{'l', 0xc0a3d70a, 0xc11eb854},
+{'q', 0x41028f5d, 0xc0b33330},
+{0, 0x41828f5c, 0xc1066668},
+{'q', 0x41028f5c, 0xc0333320},
+{0, 0x4187ae14, 0xc0333320},
+{'q', 0x41800000, 0x00000000},
+{0, 0x41ca3d70, 0x410e1478},
+{'9', 0x0047004a, 0x00c5004a},
+{'l', 0x00000000, 0x420d70a4},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e402f0, 0x01ed01f4},
+{'8', 0xebc500d9, 0xd2eaebed},
+{'l', 0xbea3d700, 0xc0a8f5c3},
+{'q', 0xc0ae1478, 0x40e147ae},
+{0, 0xc163d708, 0x412e147b},
+{'q', 0xc10cccd0, 0x4075c28e},
+{0, 0xc18b8520, 0x4075c28e},
+{'q', 0xc1051eb8, 0x00000000},
+{0, 0xc16e147a, 0xc05c28f5},
+{'8', 0xb6afe5cc, 0x98e3d2e3},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x426ccccc, 0xc191eb85},
+{'8', 0xdc18ef0f, 0xe108ee08},
+{'l', 0x00000000, 0xc1266666},
+{'q', 0xc123d708, 0xc0800000},
+{0, 0xc1a8f5c2, 0xc0800000},
+{'q', 0xc12b851e, 0x00000000},
+{0, 0xc18ae147, 0x4087ae18},
+{'8', 0x5ccb21cb, 0x3e112000},
+{'8', 0x31331e11, 0x13531321},
+{'8', 0xeb630034, 0xcb4beb2f},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00220061, 0xfffffffd},/*kerning  a " : -0.011719 */
+{'[', 0x00270061, 0xfffffffd},/*kerning  a ' : -0.011719 */
+{'[', 0x002a0061, 0xfffffffb},/*kerning  a * : -0.019531 */
+{'[', 0x003f0061, 0xfffffffb},/*kerning  a ? : -0.019531 */
+{'[', 0x00540061, 0xffffffe4},/*kerning  a T : -0.109375 */
+{'[', 0x00550061, 0xfffffffe},/*kerning  a U : -0.007812 */
+{'[', 0x00560061, 0xfffffff2},/*kerning  a V : -0.054688 */
+{'[', 0x00570061, 0xfffffff2},/*kerning  a W : -0.054688 */
+{'[', 0x00590061, 0xffffffe9},/*kerning  a Y : -0.089844 */
+{'[', 0x005c0061, 0xfffffff2},/*kerning  a \ : -0.054688 */
+{'[', 0x00660061, 0xffffffff},/*kerning  a f : -0.003906 */
+{'[', 0x00740061, 0xffffffff},/*kerning  a t : -0.003906 */
+{'[', 0x00760061, 0xfffffffc},/*kerning  a v : -0.015625 */
+{'[', 0x00770061, 0xfffffffc},/*kerning  a w : -0.015625 */
+{'[', 0x00790061, 0xfffffffc},/*kerning  a y : -0.015625 */
+{'[', 0x00ba0061, 0xfffffffe},/*kerning  a º : -0.007812 */
+{'[', 0x00d00061, 0xfffffffe},/*kerning  a Ð : -0.007812 */
+{'[', 0x00d90061, 0xfffffffe},/*kerning  a Ù : -0.007812 */
+{'[', 0x00da0061, 0xfffffffe},/*kerning  a Ú : -0.007812 */
+{'[', 0x00db0061, 0xfffffffe},/*kerning  a Û : -0.007812 */
+{'[', 0x00dc0061, 0xfffffffe},/*kerning  a Ü : -0.007812 */
+{'[', 0x00dd0061, 0xffffffe9},/*kerning  a Ý : -0.089844 */
+{'[', 0x00fd0061, 0xfffffffc},/*kerning  a ý : -0.015625 */
+{'[', 0x00ff0061, 0xfffffffc},/*kerning  a ÿ : -0.015625 */
+{'@', 0x00000062, 0x00006300},/*        b        x-advance: 99.000000 */
+{'M', 0x4258f5c2, 0x3fcccccc},
+{'q', 0xc11c28f4, 0x00000000},
+{0, 0xc18e147a, 0xc099999a},
+{'9', 0xffdaffc0, 0xff9dff9b},
+{'l', 0x00000000, 0x417ae148},
+{'l', 0xc147ae15, 0x80000000},
+{'4', 0xfc5a0000, 0x00000070},
+{'l', 0x00000000, 0x4247ae14},
+{'q', 0x40a8f5c4, 0xc1028f60},
+{0, 0x414f5c28, 0xc151eb88},
+{'q', 0x40f5c290, 0xc09eb850},
+{0, 0x418f5c2a, 0xc09eb850},
+{'q', 0x410a3d70, 0x00000000},
+{0, 0x417851e8, 0x40666660},
+{'8', 0x4e5e1c37, 0x6f3c3127},
+{'q', 0x4028f5c0, 0x40f851e8},
+{0, 0x4028f5c0, 0x4181eb84},
+{'q', 0x00000000, 0x413ae146},
+{0, 0xc0a66660, 0x41ac28f5},
+{'q', 0xc0a66660, 0x411d70a4},
+{0, 0xc1628f60, 0x417ae148},
+{'9', 0x002effb9, 0x002eff5f},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x424ae147, 0xc128f5c2},
+{'q', 0x4107ae14, 0x00000000},
+{0, 0x416e147c, 0xc08ccccc},
+{'q', 0x40ccccd0, 0xc08ccccc},
+{0, 0x412147b0, 0xc1370a3c},
+{'q', 0x406b8520, 0xc0e147b0},
+{0, 0x406b8520, 0xc170a3d8},
+{'q', 0x00000000, 0xc1028f5c},
+{0, 0xc05c2900, 0xc175c290},
+{'q', 0xc05c2900, 0xc0e66668},
+{0, 0xc1199998, 0xc1399994},
+{'q', 0xc0c51eb8, 0xc08cccd0},
+{0, 0xc1651eb8, 0xc08cccd0},
+{'q', 0xc10f5c28, 0x00000000},
+{0, 0xc17eb850, 0x40b851f0},
+{'9', 0x002effc9, 0x006effab},
+{'l', 0x00000000, 0x41c147ae},
+{'8', 0x4c292a08, 0x354c2120},
+{'q', 0x40b0a3d8, 0x40199998},
+{0, 0x4127ae14, 0x40199998},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00220062, 0xfffffffc},/*kerning  b " : -0.015625 */
+{'[', 0x00270062, 0xfffffffc},/*kerning  b ' : -0.015625 */
+{'[', 0x00290062, 0xfffffffb},/*kerning  b ) : -0.019531 */
+{'[', 0x002a0062, 0xfffffffa},/*kerning  b * : -0.023438 */
+{'[', 0x002f0062, 0xfffffffe},/*kerning  b / : -0.007812 */
+{'[', 0x003f0062, 0xfffffffb},/*kerning  b ? : -0.019531 */
+{'[', 0x00410062, 0xfffffffc},/*kerning  b A : -0.015625 */
+{'[', 0x00420062, 0xfffffffe},/*kerning  b B : -0.007812 */
+{'[', 0x00440062, 0xfffffffe},/*kerning  b D : -0.007812 */
+{'[', 0x00450062, 0xfffffffe},/*kerning  b E : -0.007812 */
+{'[', 0x00460062, 0xfffffffe},/*kerning  b F : -0.007812 */
+{'[', 0x00480062, 0xfffffffe},/*kerning  b H : -0.007812 */
+{'[', 0x00490062, 0xfffffffe},/*kerning  b I : -0.007812 */
+{'[', 0x004a0062, 0xfffffffe},/*kerning  b J : -0.007812 */
+{'[', 0x004b0062, 0xfffffffe},/*kerning  b K : -0.007812 */
+{'[', 0x004c0062, 0xfffffffe},/*kerning  b L : -0.007812 */
+{'[', 0x004d0062, 0xfffffffe},/*kerning  b M : -0.007812 */
+{'[', 0x004e0062, 0xfffffffe},/*kerning  b N : -0.007812 */
+{'[', 0x00500062, 0xfffffffe},/*kerning  b P : -0.007812 */
+{'[', 0x00520062, 0xfffffffe},/*kerning  b R : -0.007812 */
+{'[', 0x00530062, 0xffffffff},/*kerning  b S : -0.003906 */
+{'[', 0x00540062, 0xffffffe4},/*kerning  b T : -0.109375 */
+{'[', 0x00550062, 0xfffffffe},/*kerning  b U : -0.007812 */
+{'[', 0x00560062, 0xffffffef},/*kerning  b V : -0.066406 */
+{'[', 0x00570062, 0xffffffef},/*kerning  b W : -0.066406 */
+{'[', 0x00580062, 0xfffffff7},/*kerning  b X : -0.035156 */
+{'[', 0x00590062, 0xffffffea},/*kerning  b Y : -0.085938 */
+{'[', 0x005a0062, 0xfffffffc},/*kerning  b Z : -0.015625 */
+{'[', 0x005c0062, 0xfffffff4},/*kerning  b \ : -0.046875 */
+{'[', 0x005d0062, 0xfffffffe},/*kerning  b ] : -0.007812 */
+{'[', 0x00660062, 0xfffffffe},/*kerning  b f : -0.007812 */
+{'[', 0x00740062, 0xfffffffe},/*kerning  b t : -0.007812 */
+{'[', 0x00760062, 0xfffffffc},/*kerning  b v : -0.015625 */
+{'[', 0x00770062, 0xfffffffc},/*kerning  b w : -0.015625 */
+{'[', 0x00780062, 0xfffffffb},/*kerning  b x : -0.019531 */
+{'[', 0x00790062, 0xfffffffc},/*kerning  b y : -0.015625 */
+{'[', 0x007a0062, 0xfffffffe},/*kerning  b z : -0.007812 */
+{'[', 0x007d0062, 0xfffffffe},/*kerning  b } : -0.007812 */
+{'[', 0x00ba0062, 0xfffffffe},/*kerning  b º : -0.007812 */
+{'[', 0x00c00062, 0xfffffffc},/*kerning  b À : -0.015625 */
+{'[', 0x00c10062, 0xfffffffc},/*kerning  b Á : -0.015625 */
+{'[', 0x00c20062, 0xfffffffc},/*kerning  b Â : -0.015625 */
+{'[', 0x00c30062, 0xfffffffc},/*kerning  b Ã : -0.015625 */
+{'[', 0x00c40062, 0xfffffffc},/*kerning  b Ä : -0.015625 */
+{'[', 0x00c50062, 0xfffffffc},/*kerning  b Å : -0.015625 */
+{'[', 0x00c60062, 0xfffffffd},/*kerning  b Æ : -0.011719 */
+{'[', 0x00c80062, 0xfffffffe},/*kerning  b È : -0.007812 */
+{'[', 0x00c90062, 0xfffffffe},/*kerning  b É : -0.007812 */
+{'[', 0x00ca0062, 0xfffffffe},/*kerning  b Ê : -0.007812 */
+{'[', 0x00cb0062, 0xfffffffe},/*kerning  b Ë : -0.007812 */
+{'[', 0x00cc0062, 0xfffffffe},/*kerning  b Ì : -0.007812 */
+{'[', 0x00cd0062, 0xfffffffe},/*kerning  b Í : -0.007812 */
+{'[', 0x00ce0062, 0xfffffffe},/*kerning  b Î : -0.007812 */
+{'[', 0x00cf0062, 0xfffffffe},/*kerning  b Ï : -0.007812 */
+{'[', 0x00d00062, 0xfffffffc},/*kerning  b Ð : -0.015625 */
+{'[', 0x00d10062, 0xfffffffe},/*kerning  b Ñ : -0.007812 */
+{'[', 0x00d90062, 0xfffffffe},/*kerning  b Ù : -0.007812 */
+{'[', 0x00da0062, 0xfffffffe},/*kerning  b Ú : -0.007812 */
+{'[', 0x00db0062, 0xfffffffe},/*kerning  b Û : -0.007812 */
+{'[', 0x00dc0062, 0xfffffffe},/*kerning  b Ü : -0.007812 */
+{'[', 0x00dd0062, 0xffffffea},/*kerning  b Ý : -0.085938 */
+{'[', 0x00de0062, 0xfffffffe},/*kerning  b Þ : -0.007812 */
+{'[', 0x00fd0062, 0xfffffffc},/*kerning  b ý : -0.015625 */
+{'[', 0x00ff0062, 0xfffffffc},/*kerning  b ÿ : -0.015625 */
+{'@', 0x00000063, 0x00005800},/*        c        x-advance: 88.000000 */
+{'M', 0x424147ae, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b0a3d7, 0xc0bfffff},
+{'q', 0xc119999a, 0xc0c00000},
+{0, 0xc170a3d7, 0xc17eb852},
+{'q', 0xc0ae147b, 0xc11eb852},
+{0, 0xc0ae147b, 0xc1accccc},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x40a8f5c3, 0xc1accccc},
+{'q', 0x40a8f5c2, 0xc11c28f8},
+{0, 0x416e147b, 0xc1799998},
+{'q', 0x4119999a, 0xc0bae150},
+{0, 0x41b1eb85, 0xc0bae150},
+{'q', 0x41451eb8, 0x00000000},
+{0, 0x41ac28f6, 0x40b0a3d0},
+{'9', 0x002c0049, 0x0076006d},
+{'l', 0xc15c28f8, 0x408a3d70},
+{'8', 0xb7b9d1e7, 0xe69ae6d2},
+{'q', 0xc0f5c290, 0x00000000},
+{0, 0xc1600000, 0x40800000},
+{'q', 0xc0ca3d74, 0x40800000},
+{0, 0xc1200000, 0x412f5c28},
+{'q', 0xc06b8520, 0x40deb850},
+{0, 0xc06b8520, 0x417eb850},
+{'q', 0x00000000, 0x410ccccc},
+{0, 0x4070a3d8, 0x417eb850},
+{'q', 0x4070a3d8, 0x40e3d70c},
+{0, 0x412147ae, 0x41347ae2},
+{'q', 0x40ca3d70, 0x40851eb8},
+{0, 0x41600000, 0x40851eb8},
+{'8', 0xf24c0027, 0xdb40f224},
+{'9', 0xffe9001b, 0xffcd0025},
+{'l', 0x415c28f8, 0x40851eb8},
+{'q', 0xc06b8520, 0x4111eb84},
+{0, 0xc155c290, 0x4170a3d6},
+{'q', 0xc11ae148, 0x40bd70a3},
+{0, 0xc1b28f5c, 0x40bd70a3},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002a0063, 0xfffffffd},/*kerning  c * : -0.011719 */
+{'[', 0x00410063, 0xffffffff},/*kerning  c A : -0.003906 */
+{'[', 0x00430063, 0xffffffff},/*kerning  c C : -0.003906 */
+{'[', 0x00470063, 0xffffffff},/*kerning  c G : -0.003906 */
+{'[', 0x004f0063, 0xffffffff},/*kerning  c O : -0.003906 */
+{'[', 0x00510063, 0xffffffff},/*kerning  c Q : -0.003906 */
+{'[', 0x00540063, 0xffffffe7},/*kerning  c T : -0.097656 */
+{'[', 0x00550063, 0xfffffffe},/*kerning  c U : -0.007812 */
+{'[', 0x00560063, 0xfffffff2},/*kerning  c V : -0.054688 */
+{'[', 0x00570063, 0xfffffff1},/*kerning  c W : -0.058594 */
+{'[', 0x00580063, 0xffffffff},/*kerning  c X : -0.003906 */
+{'[', 0x00590063, 0xffffffeb},/*kerning  c Y : -0.082031 */
+{'[', 0x005c0063, 0xfffffff7},/*kerning  c \ : -0.035156 */
+{'[', 0x00630063, 0xffffffff},/*kerning  c c : -0.003906 */
+{'[', 0x00640063, 0xffffffff},/*kerning  c d : -0.003906 */
+{'[', 0x00650063, 0xffffffff},/*kerning  c e : -0.003906 */
+{'[', 0x00670063, 0xffffffff},/*kerning  c g : -0.003906 */
+{'[', 0x006f0063, 0xffffffff},/*kerning  c o : -0.003906 */
+{'[', 0x00710063, 0xffffffff},/*kerning  c q : -0.003906 */
+{'[', 0x00760063, 0xfffffffe},/*kerning  c v : -0.007812 */
+{'[', 0x00770063, 0xffffffff},/*kerning  c w : -0.003906 */
+{'[', 0x00790063, 0xfffffffe},/*kerning  c y : -0.007812 */
+{'[', 0x00ab0063, 0xfffffffe},/*kerning  c « : -0.007812 */
+{'[', 0x00c00063, 0xffffffff},/*kerning  c À : -0.003906 */
+{'[', 0x00c10063, 0xffffffff},/*kerning  c Á : -0.003906 */
+{'[', 0x00c20063, 0xffffffff},/*kerning  c Â : -0.003906 */
+{'[', 0x00c30063, 0xffffffff},/*kerning  c Ã : -0.003906 */
+{'[', 0x00c40063, 0xffffffff},/*kerning  c Ä : -0.003906 */
+{'[', 0x00c50063, 0xffffffff},/*kerning  c Å : -0.003906 */
+{'[', 0x00c60063, 0xffffffff},/*kerning  c Æ : -0.003906 */
+{'[', 0x00c70063, 0xffffffff},/*kerning  c Ç : -0.003906 */
+{'[', 0x00d00063, 0xfffffffe},/*kerning  c Ð : -0.007812 */
+{'[', 0x00d20063, 0xffffffff},/*kerning  c Ò : -0.003906 */
+{'[', 0x00d30063, 0xffffffff},/*kerning  c Ó : -0.003906 */
+{'[', 0x00d40063, 0xffffffff},/*kerning  c Ô : -0.003906 */
+{'[', 0x00d50063, 0xffffffff},/*kerning  c Õ : -0.003906 */
+{'[', 0x00d60063, 0xffffffff},/*kerning  c Ö : -0.003906 */
+{'[', 0x00d80063, 0xffffffff},/*kerning  c Ø : -0.003906 */
+{'[', 0x00d90063, 0xfffffffe},/*kerning  c Ù : -0.007812 */
+{'[', 0x00da0063, 0xfffffffe},/*kerning  c Ú : -0.007812 */
+{'[', 0x00db0063, 0xfffffffe},/*kerning  c Û : -0.007812 */
+{'[', 0x00dc0063, 0xfffffffe},/*kerning  c Ü : -0.007812 */
+{'[', 0x00dd0063, 0xffffffeb},/*kerning  c Ý : -0.082031 */
+{'[', 0x00e70063, 0xffffffff},/*kerning  c ç : -0.003906 */
+{'[', 0x00e80063, 0xffffffff},/*kerning  c è : -0.003906 */
+{'[', 0x00e90063, 0xffffffff},/*kerning  c é : -0.003906 */
+{'[', 0x00ea0063, 0xffffffff},/*kerning  c ê : -0.003906 */
+{'[', 0x00eb0063, 0xffffffff},/*kerning  c ë : -0.003906 */
+{'[', 0x00f00063, 0xffffffff},/*kerning  c ð : -0.003906 */
+{'[', 0x00f20063, 0xffffffff},/*kerning  c ò : -0.003906 */
+{'[', 0x00f30063, 0xffffffff},/*kerning  c ó : -0.003906 */
+{'[', 0x00f40063, 0xffffffff},/*kerning  c ô : -0.003906 */
+{'[', 0x00f50063, 0xffffffff},/*kerning  c õ : -0.003906 */
+{'[', 0x00f60063, 0xffffffff},/*kerning  c ö : -0.003906 */
+{'[', 0x00f80063, 0xffffffff},/*kerning  c ø : -0.003906 */
+{'[', 0x00fd0063, 0xfffffffe},/*kerning  c ý : -0.007812 */
+{'[', 0x00ff0063, 0xfffffffe},/*kerning  c ÿ : -0.007812 */
+{'@', 0x00000064, 0x00006400},/*        d        x-advance: 100.000000 */
+{'M', 0x40bd70a4, 0xc2266666},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x409c28f4, 0xc1ad70a4},
+{'q', 0x409c28f6, 0xc11d70a0},
+{0, 0x41570a3e, 0xc17c28f0},
+{'q', 0x4108f5c2, 0xc0bd70b0},
+{0, 0x419ccccd, 0xc0bd70b0},
+{'q', 0x412147ac, 0x00000000},
+{0, 0x4190a3d6, 0x40a8f5c0},
+{'9', 0x002a0040, 0x00660063},
+{'4', 0xfe710000, 0x00000070},
+{'l', 0x00000000, 0x42c99999},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x05cf05e0, 0xe9c600df},
+{'9', 0xffe9ffe8, 0xffcdffe8},
+{'l', 0x00000000, 0xc0e147ae},
+{'q', 0xc09eb850, 0x40ffffff},
+{0, 0xc1547ae0, 0x414a3d70},
+{'q', 0xc1051ebc, 0x40947ae1},
+{0, 0xc18a3d72, 0x40947ae1},
+{'q', 0xc13851ec, 0x00000000},
+{0, 0xc1a47ae1, 0xc0bfffff},
+{'q', 0xc110a3d6, 0xc0c00000},
+{0, 0xc1628f5b, 0xc17d70a4},
+{'9', 0xffb2ffd8, 0xff56ffd8},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4294cccd, 0xc1ea3d70},
+{'l', 0x00000000, 0xc1c00000},
+{'8', 0xb2cfd5f1, 0xc8b3ddde},
+{'q', 0xc0ab8520, 0xc028f5c0},
+{0, 0xc12a3d70, 0xc028f5c0},
+{'q', 0xc1028f5c, 0x00000000},
+{0, 0xc1651eb8, 0x408f5c20},
+{'q', 0xc0c51ebc, 0x408f5c28},
+{0, 0xc119999c, 0x413ae148},
+{'q', 0xc05c28f0, 0x40e66668},
+{0, 0xc05c28f0, 0x41733334},
+{'q', 0x00000000, 0x41051eb8},
+{0, 0x4070a3d8, 0x4175c290},
+{'q', 0x4070a3d8, 0x40e147ac},
+{0, 0x41251eb6, 0x41347ae0},
+{'q', 0x40d1eb88, 0x4087ae14},
+{0, 0x4168f5c4, 0x4087ae14},
+{'8', 0xed540028, 0xca4ced2b},
+{'q', 0x40851eb0, 0xc08a3d70},
+{0, 0x40a3d710, 0xc1170a3c},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00430064, 0xffffffff},/*kerning  d C : -0.003906 */
+{'[', 0x00470064, 0xffffffff},/*kerning  d G : -0.003906 */
+{'[', 0x004f0064, 0xffffffff},/*kerning  d O : -0.003906 */
+{'[', 0x00510064, 0xffffffff},/*kerning  d Q : -0.003906 */
+{'[', 0x00550064, 0xfffffffe},/*kerning  d U : -0.007812 */
+{'[', 0x00590064, 0xffffffff},/*kerning  d Y : -0.003906 */
+{'[', 0x00c70064, 0xffffffff},/*kerning  d Ç : -0.003906 */
+{'[', 0x00d00064, 0xfffffffe},/*kerning  d Ð : -0.007812 */
+{'[', 0x00d20064, 0xffffffff},/*kerning  d Ò : -0.003906 */
+{'[', 0x00d30064, 0xffffffff},/*kerning  d Ó : -0.003906 */
+{'[', 0x00d40064, 0xffffffff},/*kerning  d Ô : -0.003906 */
+{'[', 0x00d50064, 0xffffffff},/*kerning  d Õ : -0.003906 */
+{'[', 0x00d60064, 0xffffffff},/*kerning  d Ö : -0.003906 */
+{'[', 0x00d80064, 0xffffffff},/*kerning  d Ø : -0.003906 */
+{'[', 0x00d90064, 0xfffffffe},/*kerning  d Ù : -0.007812 */
+{'[', 0x00da0064, 0xfffffffe},/*kerning  d Ú : -0.007812 */
+{'[', 0x00db0064, 0xfffffffe},/*kerning  d Û : -0.007812 */
+{'[', 0x00dc0064, 0xfffffffe},/*kerning  d Ü : -0.007812 */
+{'[', 0x00dd0064, 0xffffffff},/*kerning  d Ý : -0.003906 */
+{'@', 0x00000065, 0x00005e00},/*        e        x-advance: 94.000000 */
+{'M', 0x424147ae, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b0a3d7, 0xc0bd70a3},
+{'q', 0xc119999a, 0xc0bd70a4},
+{0, 0xc170a3d7, 0xc17d70a4},
+{'q', 0xc0ae147b, 0xc11eb852},
+{0, 0xc0ae147b, 0xc1accccc},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x40ae147b, 0xc1accccc},
+{'q', 0x40ae147a, 0xc11c28f4},
+{0, 0x4171eb85, 0xc17ae144},
+{'q', 0x411ae148, 0xc0bd70b0},
+{0, 0x41b147ae, 0xc0bd70b0},
+{'q', 0x414a3d70, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x4115c290, 0x40c00000},
+{0, 0x4168f5c0, 0x417ae148},
+{'q', 0x40a66670, 0x411ae148},
+{0, 0x40a66670, 0x41a70a3e},
+{'9', 0x001c0000, 0x002bfffe},
+{'l', 0xc28a8f5c, 0x00000000},
+{'q', 0x3f23d700, 0x41028f5c},
+{0, 0x4091eb84, 0x4167ae14},
+{'8', 0x4f51321f, 0x1c6b1c31},
+{'q', 0x40f5c290, 0x00000000},
+{0, 0x4167ae14, 0xc075c28c},
+{'9', 0xffe20036, 0xffb0004a},
+{'l', 0x41428f58, 0x40570a38},
+{'q', 0xc0800000, 0x41147ae2},
+{0, 0xc15eb850, 0x41733334},
+{'9', 0x002fffb1, 0x002fff4c},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc23ae147},
+{'l', 0x4263d709, 0x00000000},
+{'q', 0xbf23d700, 0xc1028f5c},
+{0, 0xc0947ae0, 0xc1666668},
+{'8', 0xb2afcfe0, 0xe492e4cf},
+{'8', 0x1c9400c6, 0x4eaf1ccf},
+{'q', 0xc07ae148, 0x40c7ae18},
+{0, 0xc091eb84, 0x41666668},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00220065, 0xfffffffd},/*kerning  e " : -0.011719 */
+{'[', 0x00270065, 0xfffffffd},/*kerning  e ' : -0.011719 */
+{'[', 0x00290065, 0xfffffffc},/*kerning  e ) : -0.015625 */
+{'[', 0x002a0065, 0xfffffffc},/*kerning  e * : -0.015625 */
+{'[', 0x003f0065, 0xfffffffd},/*kerning  e ? : -0.011719 */
+{'[', 0x00410065, 0xfffffffd},/*kerning  e A : -0.011719 */
+{'[', 0x00420065, 0xffffffff},/*kerning  e B : -0.003906 */
+{'[', 0x00440065, 0xffffffff},/*kerning  e D : -0.003906 */
+{'[', 0x00450065, 0xffffffff},/*kerning  e E : -0.003906 */
+{'[', 0x00460065, 0xffffffff},/*kerning  e F : -0.003906 */
+{'[', 0x00480065, 0xffffffff},/*kerning  e H : -0.003906 */
+{'[', 0x00490065, 0xffffffff},/*kerning  e I : -0.003906 */
+{'[', 0x004a0065, 0xfffffffe},/*kerning  e J : -0.007812 */
+{'[', 0x004b0065, 0xffffffff},/*kerning  e K : -0.003906 */
+{'[', 0x004c0065, 0xffffffff},/*kerning  e L : -0.003906 */
+{'[', 0x004d0065, 0xffffffff},/*kerning  e M : -0.003906 */
+{'[', 0x004e0065, 0xffffffff},/*kerning  e N : -0.003906 */
+{'[', 0x00500065, 0xffffffff},/*kerning  e P : -0.003906 */
+{'[', 0x00520065, 0xffffffff},/*kerning  e R : -0.003906 */
+{'[', 0x00530065, 0xffffffff},/*kerning  e S : -0.003906 */
+{'[', 0x00540065, 0xffffffe6},/*kerning  e T : -0.101562 */
+{'[', 0x00550065, 0xffffffff},/*kerning  e U : -0.003906 */
+{'[', 0x00560065, 0xfffffff2},/*kerning  e V : -0.054688 */
+{'[', 0x00570065, 0xfffffff2},/*kerning  e W : -0.054688 */
+{'[', 0x00580065, 0xfffffffb},/*kerning  e X : -0.019531 */
+{'[', 0x00590065, 0xffffffe6},/*kerning  e Y : -0.101562 */
+{'[', 0x005a0065, 0xfffffffd},/*kerning  e Z : -0.011719 */
+{'[', 0x005c0065, 0xfffffff5},/*kerning  e \ : -0.042969 */
+{'[', 0x00660065, 0xffffffff},/*kerning  e f : -0.003906 */
+{'[', 0x00740065, 0xffffffff},/*kerning  e t : -0.003906 */
+{'[', 0x00760065, 0xfffffffd},/*kerning  e v : -0.011719 */
+{'[', 0x00770065, 0xfffffffd},/*kerning  e w : -0.011719 */
+{'[', 0x00780065, 0xfffffffb},/*kerning  e x : -0.019531 */
+{'[', 0x00790065, 0xfffffffd},/*kerning  e y : -0.011719 */
+{'[', 0x007a0065, 0xffffffff},/*kerning  e z : -0.003906 */
+{'[', 0x00c00065, 0xfffffffd},/*kerning  e À : -0.011719 */
+{'[', 0x00c10065, 0xfffffffd},/*kerning  e Á : -0.011719 */
+{'[', 0x00c20065, 0xfffffffd},/*kerning  e Â : -0.011719 */
+{'[', 0x00c30065, 0xfffffffd},/*kerning  e Ã : -0.011719 */
+{'[', 0x00c40065, 0xfffffffd},/*kerning  e Ä : -0.011719 */
+{'[', 0x00c50065, 0xfffffffd},/*kerning  e Å : -0.011719 */
+{'[', 0x00c60065, 0xfffffffd},/*kerning  e Æ : -0.011719 */
+{'[', 0x00c80065, 0xffffffff},/*kerning  e È : -0.003906 */
+{'[', 0x00c90065, 0xffffffff},/*kerning  e É : -0.003906 */
+{'[', 0x00ca0065, 0xffffffff},/*kerning  e Ê : -0.003906 */
+{'[', 0x00cb0065, 0xffffffff},/*kerning  e Ë : -0.003906 */
+{'[', 0x00cc0065, 0xffffffff},/*kerning  e Ì : -0.003906 */
+{'[', 0x00cd0065, 0xffffffff},/*kerning  e Í : -0.003906 */
+{'[', 0x00ce0065, 0xffffffff},/*kerning  e Î : -0.003906 */
+{'[', 0x00cf0065, 0xffffffff},/*kerning  e Ï : -0.003906 */
+{'[', 0x00d00065, 0xfffffffe},/*kerning  e Ð : -0.007812 */
+{'[', 0x00d10065, 0xffffffff},/*kerning  e Ñ : -0.003906 */
+{'[', 0x00d90065, 0xffffffff},/*kerning  e Ù : -0.003906 */
+{'[', 0x00da0065, 0xffffffff},/*kerning  e Ú : -0.003906 */
+{'[', 0x00db0065, 0xffffffff},/*kerning  e Û : -0.003906 */
+{'[', 0x00dc0065, 0xffffffff},/*kerning  e Ü : -0.003906 */
+{'[', 0x00dd0065, 0xffffffe6},/*kerning  e Ý : -0.101562 */
+{'[', 0x00de0065, 0xffffffff},/*kerning  e Þ : -0.003906 */
+{'[', 0x00fd0065, 0xfffffffd},/*kerning  e ý : -0.011719 */
+{'[', 0x00ff0065, 0xfffffffd},/*kerning  e ÿ : -0.011719 */
+{'@', 0x00000066, 0x00003600},/*        f        x-advance: 54.000000 */
+{'M', 0x417d70a3, 0x80000000},
+{'l', 0x00000000, 0xc290f5c2},
+{'0', 0xa80000a6, 0xf200005a},
+{'q', 0x00000000, 0xc175c290},
+{0, 0x40deb852, 0xc1c1eb84},
+{'q', 0x40deb854, 0xc10e1478},
+{0, 0x41951eb8, 0xc10e1478},
+{'9', 0x00000051, 0x00280093},
+{'l', 0xc06147b0, 0x41266668},
+{'8', 0xe4a0e4d8, 0x2aab00c9},
+{'9', 0x002affe2, 0x007affe2},
+{'l', 0x00000000, 0x400f5c20},
+{'l', 0x41b1eb85, 0x00000000},
+{'l', 0x00000000, 0x4130a3d8},
+{'4', 0x0000ff4f, 0x02430000},
+{'l', 0xc16147af, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200066, 0xfffffffb},/*kerning  f   : -0.019531 */
+{'[', 0x00220066, 0x00000007},/*kerning  f " : 0.027344 */
+{'[', 0x00270066, 0x00000007},/*kerning  f ' : 0.027344 */
+{'[', 0x00290066, 0x00000008},/*kerning  f ) : 0.031250 */
+{'[', 0x002a0066, 0x00000002},/*kerning  f * : 0.007812 */
+{'[', 0x002c0066, 0xfffffff7},/*kerning  f , : -0.035156 */
+{'[', 0x002d0066, 0xfffffffb},/*kerning  f - : -0.019531 */
+{'[', 0x002e0066, 0xfffffff7},/*kerning  f . : -0.035156 */
+{'[', 0x002f0066, 0xfffffff9},/*kerning  f / : -0.027344 */
+{'[', 0x00410066, 0xfffffff7},/*kerning  f A : -0.035156 */
+{'[', 0x004a0066, 0xfffffff5},/*kerning  f J : -0.042969 */
+{'[', 0x00540066, 0x0000000b},/*kerning  f T : 0.042969 */
+{'[', 0x00560066, 0x0000000c},/*kerning  f V : 0.046875 */
+{'[', 0x00570066, 0x0000000c},/*kerning  f W : 0.046875 */
+{'[', 0x00580066, 0x0000000e},/*kerning  f X : 0.054688 */
+{'[', 0x00590066, 0x0000000b},/*kerning  f Y : 0.042969 */
+{'[', 0x005a0066, 0x00000004},/*kerning  f Z : 0.015625 */
+{'[', 0x005c0066, 0x00000008},/*kerning  f \ : 0.031250 */
+{'[', 0x005d0066, 0x00000004},/*kerning  f ] : 0.015625 */
+{'[', 0x00630066, 0xfffffffd},/*kerning  f c : -0.011719 */
+{'[', 0x00640066, 0xfffffffe},/*kerning  f d : -0.007812 */
+{'[', 0x00650066, 0xfffffffd},/*kerning  f e : -0.011719 */
+{'[', 0x00670066, 0xfffffffe},/*kerning  f g : -0.007812 */
+{'[', 0x006f0066, 0xfffffffd},/*kerning  f o : -0.011719 */
+{'[', 0x00710066, 0xfffffffe},/*kerning  f q : -0.007812 */
+{'[', 0x007d0066, 0x00000003},/*kerning  f } : 0.011719 */
+{'[', 0x00ab0066, 0xfffffff8},/*kerning  f « : -0.031250 */
+{'[', 0x00c00066, 0xfffffff7},/*kerning  f À : -0.035156 */
+{'[', 0x00c10066, 0xfffffff7},/*kerning  f Á : -0.035156 */
+{'[', 0x00c20066, 0xfffffff7},/*kerning  f Â : -0.035156 */
+{'[', 0x00c30066, 0xfffffff7},/*kerning  f Ã : -0.035156 */
+{'[', 0x00c40066, 0xfffffff7},/*kerning  f Ä : -0.035156 */
+{'[', 0x00c50066, 0xfffffff7},/*kerning  f Å : -0.035156 */
+{'[', 0x00c60066, 0xfffffff6},/*kerning  f Æ : -0.039062 */
+{'[', 0x00dd0066, 0x0000000b},/*kerning  f Ý : 0.042969 */
+{'[', 0x00e70066, 0xfffffffd},/*kerning  f ç : -0.011719 */
+{'[', 0x00e80066, 0xfffffffd},/*kerning  f è : -0.011719 */
+{'[', 0x00e90066, 0xfffffffd},/*kerning  f é : -0.011719 */
+{'[', 0x00ea0066, 0xfffffffd},/*kerning  f ê : -0.011719 */
+{'[', 0x00eb0066, 0xfffffffd},/*kerning  f ë : -0.011719 */
+{'[', 0x00ec0066, 0x00000006},/*kerning  f ì : 0.023438 */
+{'[', 0x00ee0066, 0x0000000d},/*kerning  f î : 0.050781 */
+{'[', 0x00ef0066, 0x0000000f},/*kerning  f ï : 0.058594 */
+{'[', 0x00f00066, 0xfffffff8},/*kerning  f ð : -0.031250 */
+{'[', 0x00f20066, 0xfffffffd},/*kerning  f ò : -0.011719 */
+{'[', 0x00f30066, 0xfffffffd},/*kerning  f ó : -0.011719 */
+{'[', 0x00f40066, 0xfffffffd},/*kerning  f ô : -0.011719 */
+{'[', 0x00f50066, 0xfffffffd},/*kerning  f õ : -0.011719 */
+{'[', 0x00f60066, 0xfffffffd},/*kerning  f ö : -0.011719 */
+{'[', 0x00f80066, 0xfffffffd},/*kerning  f ø : -0.011719 */
+{'@', 0x00000067, 0x00006300},/*        g        x-advance: 99.000000 */
+{'M', 0x42328f5c, 0x3f75c28f},
+{'q', 0xc135c290, 0x00000000},
+{0, 0xc1a0a3d7, 0xc0c00000},
+{'q', 0xc10b851f, 0xc0c00000},
+{0, 0xc159999a, 0xc17c28f5},
+{'q', 0xc09c28f4, 0xc11c28f6},
+{0, 0xc09c28f4, 0xc1a66666},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x409c28f4, 0xc1ad70a4},
+{'q', 0x409c28f6, 0xc11d70a0},
+{0, 0x415ae148, 0xc17c28f0},
+{'q', 0x410ccccc, 0xc0bd70b0},
+{0, 0x41a147ae, 0xc0bd70b0},
+{'q', 0x41266664, 0x00000000},
+{0, 0x419147ae, 0x40a3d710},
+{'9', 0x0028003e, 0x00670068},
+{'4', 0xff7b0000, 0x00000063},
+{'l', 0x00000000, 0x42a51eb8},
+{'q', 0x00000000, 0x413d70a3},
+{0, 0xc0b5c290, 0x419fffff},
+{'q', 0xc0b5c290, 0x41028f5c},
+{0, 0xc175c290, 0x41466666},
+{'q', 0xc11ae144, 0x4087ae18},
+{0, 0xc1ac28f4, 0x4087ae18},
+{'q', 0xc16147ac, 0x00000000},
+{0, 0xc1b851ea, 0xc09eb850},
+{'9', 0xffd9ffb9, 0xff95ff89},
+{'l', 0x41028f5c, 0xc0e66664},
+{'q', 0x409eb850, 0x40eb8520},
+{0, 0x414e147a, 0x4130a3d6},
+{'q', 0x40fd70a4, 0x406b8520},
+{0, 0x41870a3d, 0x406b8520},
+{'q', 0x40f5c290, 0x00000000},
+{0, 0x41628f5c, 0xc0333330},
+{'q', 0x40cf5c28, 0xc0333338},
+{0, 0x41266664, 0xc108f5c3},
+{'9', 0xffd2001f, 0xff8d001f},
+{'l', 0x00000000, 0xc16b851e},
+{'q', 0xc0947ae0, 0x40f5c28e},
+{0, 0xc14b8520, 0x41428f5c},
+{'9', 0x0023ffc0, 0x0023ff78},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4243d70a, 0xc128f5c2},
+{'8', 0xeb5a002f, 0xc849eb2b},
+{'9', 0xffde001e, 0xffb90027},
+{'l', 0x00000000, 0xc1c00000},
+{'q', 0xc0570a40, 0xc107ae14},
+{0, 0xc12e147c, 0xc1600000},
+{'q', 0xc0f0a3d8, 0xc0b0a3d0},
+{0, 0xc17d70a4, 0xc0b0a3d0},
+{'q', 0xc107ae14, 0x00000000},
+{0, 0xc16a3d70, 0x40947ae0},
+{'q', 0xc0c51ebc, 0x40947ad8},
+{0, 0xc1170a40, 0x413d70a0},
+{'q', 0xc051eb80, 0x40e66668},
+{0, 0xc051eb80, 0x4170a3d8},
+{'q', 0x00000000, 0x41051eb8},
+{0, 0x4075c290, 0x41747ae0},
+{'q', 0x4075c290, 0x40deb854},
+{0, 0x41251eb8, 0x41333334},
+{'q', 0x40cf5c28, 0x4087ae14},
+{0, 0x4167ae14, 0x4087ae14},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00540067, 0xffffffea},/*kerning  g T : -0.085938 */
+{'[', 0x00550067, 0xfffffffe},/*kerning  g U : -0.007812 */
+{'[', 0x00560067, 0xfffffff5},/*kerning  g V : -0.042969 */
+{'[', 0x00570067, 0xfffffff5},/*kerning  g W : -0.042969 */
+{'[', 0x00580067, 0xfffffffe},/*kerning  g X : -0.007812 */
+{'[', 0x00590067, 0xffffffee},/*kerning  g Y : -0.070312 */
+{'[', 0x005a0067, 0xfffffffe},/*kerning  g Z : -0.007812 */
+{'[', 0x005c0067, 0xfffffff9},/*kerning  g \ : -0.027344 */
+{'[', 0x006a0067, 0x00000005},/*kerning  g j : 0.019531 */
+{'[', 0x00d90067, 0xfffffffe},/*kerning  g Ù : -0.007812 */
+{'[', 0x00da0067, 0xfffffffe},/*kerning  g Ú : -0.007812 */
+{'[', 0x00db0067, 0xfffffffe},/*kerning  g Û : -0.007812 */
+{'[', 0x00dc0067, 0xfffffffe},/*kerning  g Ü : -0.007812 */
+{'[', 0x00dd0067, 0xffffffee},/*kerning  g Ý : -0.070312 */
+{'@', 0x00000068, 0x00005e00},/*        h        x-advance: 94.000000 */
+{'M', 0x42a7ae14, 0x80000000},
+{'4', 0x0000ff90, 0xfe8b0000},
+{'q', 0x00000000, 0xc14cccd0},
+{0, 0xc091eb90, 0xc199999a},
+{'8', 0xcd98cddc, 0x17a900d5},
+{'8', 0x3eb317d4, 0x5ad027df},
+{'l', 0x00000000, 0x42499999},
+{'l', 0xc16147ad, 0x80000000},
+{'4', 0xfc5a0000, 0x00000070},
+{'l', 0x00000000, 0x424ccccc},
+{'q', 0x409eb854, 0xc10f5c28},
+{0, 0x415851ec, 0xc1628f58},
+{'q', 0x4108f5c4, 0xc0a66670},
+{0, 0x4193d70a, 0xc0a66670},
+{'q', 0x411eb854, 0x00000000},
+{0, 0x417ae144, 0x40947ae0},
+{'q', 0x40b851f0, 0x40947ae0},
+{0, 0x4103d710, 0x4148f5c0},
+{'9', 0x003f0013, 0x008e0013},
+{'l', 0x00000000, 0x4247ae14},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00220068, 0xfffffffd},/*kerning  h " : -0.011719 */
+{'[', 0x00270068, 0xfffffffd},/*kerning  h ' : -0.011719 */
+{'[', 0x002a0068, 0xfffffffc},/*kerning  h * : -0.015625 */
+{'[', 0x003f0068, 0xfffffffc},/*kerning  h ? : -0.015625 */
+{'[', 0x00430068, 0xffffffff},/*kerning  h C : -0.003906 */
+{'[', 0x00470068, 0xffffffff},/*kerning  h G : -0.003906 */
+{'[', 0x004f0068, 0xffffffff},/*kerning  h O : -0.003906 */
+{'[', 0x00510068, 0xffffffff},/*kerning  h Q : -0.003906 */
+{'[', 0x00540068, 0xffffffe4},/*kerning  h T : -0.109375 */
+{'[', 0x00550068, 0xfffffffe},/*kerning  h U : -0.007812 */
+{'[', 0x00560068, 0xfffffff2},/*kerning  h V : -0.054688 */
+{'[', 0x00570068, 0xfffffff2},/*kerning  h W : -0.054688 */
+{'[', 0x00580068, 0xffffffff},/*kerning  h X : -0.003906 */
+{'[', 0x00590068, 0xffffffeb},/*kerning  h Y : -0.082031 */
+{'[', 0x005a0068, 0xfffffffe},/*kerning  h Z : -0.007812 */
+{'[', 0x005c0068, 0xfffffff5},/*kerning  h \ : -0.042969 */
+{'[', 0x00660068, 0xffffffff},/*kerning  h f : -0.003906 */
+{'[', 0x00740068, 0xffffffff},/*kerning  h t : -0.003906 */
+{'[', 0x00760068, 0xfffffffe},/*kerning  h v : -0.007812 */
+{'[', 0x00770068, 0xfffffffe},/*kerning  h w : -0.007812 */
+{'[', 0x00790068, 0xfffffffd},/*kerning  h y : -0.011719 */
+{'[', 0x00c70068, 0xffffffff},/*kerning  h Ç : -0.003906 */
+{'[', 0x00d00068, 0xfffffffe},/*kerning  h Ð : -0.007812 */
+{'[', 0x00d20068, 0xffffffff},/*kerning  h Ò : -0.003906 */
+{'[', 0x00d30068, 0xffffffff},/*kerning  h Ó : -0.003906 */
+{'[', 0x00d40068, 0xffffffff},/*kerning  h Ô : -0.003906 */
+{'[', 0x00d50068, 0xffffffff},/*kerning  h Õ : -0.003906 */
+{'[', 0x00d60068, 0xffffffff},/*kerning  h Ö : -0.003906 */
+{'[', 0x00d80068, 0xffffffff},/*kerning  h Ø : -0.003906 */
+{'[', 0x00d90068, 0xfffffffe},/*kerning  h Ù : -0.007812 */
+{'[', 0x00da0068, 0xfffffffe},/*kerning  h Ú : -0.007812 */
+{'[', 0x00db0068, 0xfffffffe},/*kerning  h Û : -0.007812 */
+{'[', 0x00dc0068, 0xfffffffe},/*kerning  h Ü : -0.007812 */
+{'[', 0x00dd0068, 0xffffffeb},/*kerning  h Ý : -0.082031 */
+{'[', 0x00fd0068, 0xfffffffd},/*kerning  h ý : -0.011719 */
+{'[', 0x00ff0068, 0xfffffffd},/*kerning  h ÿ : -0.011719 */
+{'@', 0x00000069, 0x00002400},/*        i        x-advance: 36.000000 */
+{'M', 0x4135c28f, 0xc2c66666},
+{'l', 0x00000000, 0xc18ccccc},
+{'4', 0x00000070, 0x008c0000},
+{'l', 0xc16147ad, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4135c28f, 0x80000000},
+{'l', 0x00000000, 0xc2a70a3d},
+{'4', 0x00000070, 0x029c0000},
+{'l', 0xc16147ad, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00550069, 0xfffffffe},/*kerning  i U : -0.007812 */
+{'[', 0x005a0069, 0xfffffffe},/*kerning  i Z : -0.007812 */
+{'[', 0x00d90069, 0xfffffffe},/*kerning  i Ù : -0.007812 */
+{'[', 0x00da0069, 0xfffffffe},/*kerning  i Ú : -0.007812 */
+{'[', 0x00db0069, 0xfffffffe},/*kerning  i Û : -0.007812 */
+{'[', 0x00dc0069, 0xfffffffe},/*kerning  i Ü : -0.007812 */
+{'@', 0x0000006a, 0x00002500},/*        j        x-advance: 37.000000 */
+{'M', 0x4147ae14, 0xc2c66666},
+{'l', 0x00000000, 0xc18ccccc},
+{'4', 0x00000070, 0x008c0000},
+{'l', 0xc16147ae, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x3f23d70a, 0x41ee147b},
+{'8', 0xf4ad00d5, 0xd8baf4d9},
+{'l', 0x40d1eb84, 0xc1170a3d},
+{'8', 0x17291011, 0x062e0617},
+{'8', 0xe24a0028, 0xb221e221},
+{'4', 0xfd470000, 0x00000070},
+{'l', 0x00000000, 0x42ac7ae1},
+{'8', 0x6fe33e00, 0x4cb431e3},
+{'q', 0xc0bae147, 0x405c28f8},
+{0, 0xc14b851e, 0x405c28f8},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0055006a, 0xfffffffe},/*kerning  j U : -0.007812 */
+{'[', 0x005a006a, 0xfffffffe},/*kerning  j Z : -0.007812 */
+{'[', 0x006a006a, 0x00000005},/*kerning  j j : 0.019531 */
+{'[', 0x00d9006a, 0xfffffffe},/*kerning  j Ù : -0.007812 */
+{'[', 0x00da006a, 0xfffffffe},/*kerning  j Ú : -0.007812 */
+{'[', 0x00db006a, 0xfffffffe},/*kerning  j Û : -0.007812 */
+{'[', 0x00dc006a, 0xfffffffe},/*kerning  j Ü : -0.007812 */
+{'@', 0x0000006b, 0x00005600},/*        k        x-advance: 86.000000 */
+{'M', 0x428c7ae1, 0x80000000},
+{'l', 0xc1e7ae14, 0xc2228f5c},
+{'l', 0xc17d70a4, 0x416e147a},
+{'l', 0x00000000, 0x41ce147b},
+{'l', 0xc16147ad, 0x80000000},
+{'l', 0x00000000, 0xc2e99999},
+{'l', 0x416147ad, 0x00000000},
+{'l', 0x00000000, 0x4298a3d6},
+{'l', 0x422ccccd, 0xc22b851e},
+{'l', 0x41733330, 0x00000000},
+{'4', 0x0114fef6, 0x01860117},
+{'l', 0xc1733330, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002d006b, 0xfffffff4},/*kerning  k - : -0.046875 */
+{'[', 0x0043006b, 0xfffffffd},/*kerning  k C : -0.011719 */
+{'[', 0x0047006b, 0xfffffffd},/*kerning  k G : -0.011719 */
+{'[', 0x004f006b, 0xfffffffd},/*kerning  k O : -0.011719 */
+{'[', 0x0051006b, 0xfffffffd},/*kerning  k Q : -0.011719 */
+{'[', 0x0054006b, 0xffffffed},/*kerning  k T : -0.074219 */
+{'[', 0x0056006b, 0xfffffffc},/*kerning  k V : -0.015625 */
+{'[', 0x0057006b, 0xfffffffc},/*kerning  k W : -0.015625 */
+{'[', 0x0059006b, 0xfffffff6},/*kerning  k Y : -0.039062 */
+{'[', 0x005c006b, 0xfffffffd},/*kerning  k \ : -0.011719 */
+{'[', 0x0063006b, 0xfffffffa},/*kerning  k c : -0.023438 */
+{'[', 0x0064006b, 0xfffffffa},/*kerning  k d : -0.023438 */
+{'[', 0x0065006b, 0xfffffffa},/*kerning  k e : -0.023438 */
+{'[', 0x0067006b, 0xfffffffa},/*kerning  k g : -0.023438 */
+{'[', 0x006f006b, 0xfffffffa},/*kerning  k o : -0.023438 */
+{'[', 0x0071006b, 0xfffffffa},/*kerning  k q : -0.023438 */
+{'[', 0x00ab006b, 0xfffffff8},/*kerning  k « : -0.031250 */
+{'[', 0x00c7006b, 0xfffffffd},/*kerning  k Ç : -0.011719 */
+{'[', 0x00d2006b, 0xfffffffd},/*kerning  k Ò : -0.011719 */
+{'[', 0x00d3006b, 0xfffffffd},/*kerning  k Ó : -0.011719 */
+{'[', 0x00d4006b, 0xfffffffd},/*kerning  k Ô : -0.011719 */
+{'[', 0x00d5006b, 0xfffffffd},/*kerning  k Õ : -0.011719 */
+{'[', 0x00d6006b, 0xfffffffd},/*kerning  k Ö : -0.011719 */
+{'[', 0x00d8006b, 0xfffffffd},/*kerning  k Ø : -0.011719 */
+{'[', 0x00dd006b, 0xfffffff6},/*kerning  k Ý : -0.039062 */
+{'[', 0x00e7006b, 0xfffffffa},/*kerning  k ç : -0.023438 */
+{'[', 0x00e8006b, 0xfffffffa},/*kerning  k è : -0.023438 */
+{'[', 0x00e9006b, 0xfffffffa},/*kerning  k é : -0.023438 */
+{'[', 0x00ea006b, 0xfffffffa},/*kerning  k ê : -0.023438 */
+{'[', 0x00eb006b, 0xfffffffa},/*kerning  k ë : -0.023438 */
+{'[', 0x00f0006b, 0xfffffff8},/*kerning  k ð : -0.031250 */
+{'[', 0x00f2006b, 0xfffffffa},/*kerning  k ò : -0.023438 */
+{'[', 0x00f3006b, 0xfffffffa},/*kerning  k ó : -0.023438 */
+{'[', 0x00f4006b, 0xfffffffa},/*kerning  k ô : -0.023438 */
+{'[', 0x00f5006b, 0xfffffffa},/*kerning  k õ : -0.023438 */
+{'[', 0x00f6006b, 0xfffffffa},/*kerning  k ö : -0.023438 */
+{'[', 0x00f8006b, 0xfffffffa},/*kerning  k ø : -0.023438 */
+{'@', 0x0000006c, 0x00002d00},/*        l        x-advance: 45.000000 */
+{'M', 0x413ae147, 0xc2e99999},
+{'4', 0x00000070, 0x02f90000},
+{'8', 0x430f3700, 0x0c250c0f},
+{'8', 0xfb33001a, 0xf428fb18},
+{'l', 0x400f5c20, 0x413851eb},
+{'8', 0x13be0be4, 0x07bd07da},
+{'8', 0xdb9900bf, 0x99dbdbdb},
+{'l', 0x00000000, 0xc2c8a3d6},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0020006c, 0xfffffff9},/*kerning  l   : -0.027344 */
+{'[', 0x0022006c, 0xfffffffc},/*kerning  l " : -0.015625 */
+{'[', 0x0027006c, 0xfffffffc},/*kerning  l ' : -0.015625 */
+{'[', 0x002a006c, 0xfffffffc},/*kerning  l * : -0.015625 */
+{'[', 0x002d006c, 0xfffffffc},/*kerning  l - : -0.015625 */
+{'[', 0x003f006c, 0xfffffffd},/*kerning  l ? : -0.011719 */
+{'[', 0x0043006c, 0xfffffffd},/*kerning  l C : -0.011719 */
+{'[', 0x0047006c, 0xfffffffd},/*kerning  l G : -0.011719 */
+{'[', 0x004f006c, 0xfffffffd},/*kerning  l O : -0.011719 */
+{'[', 0x0051006c, 0xfffffffd},/*kerning  l Q : -0.011719 */
+{'[', 0x0054006c, 0xfffffffa},/*kerning  l T : -0.023438 */
+{'[', 0x0055006c, 0xfffffffd},/*kerning  l U : -0.011719 */
+{'[', 0x0056006c, 0xfffffffb},/*kerning  l V : -0.019531 */
+{'[', 0x0057006c, 0xfffffffb},/*kerning  l W : -0.019531 */
+{'[', 0x0059006c, 0xfffffffa},/*kerning  l Y : -0.023438 */
+{'[', 0x005c006c, 0xfffffffa},/*kerning  l \ : -0.023438 */
+{'[', 0x0076006c, 0xfffffffb},/*kerning  l v : -0.019531 */
+{'[', 0x0077006c, 0xfffffffc},/*kerning  l w : -0.015625 */
+{'[', 0x0079006c, 0xfffffffc},/*kerning  l y : -0.015625 */
+{'[', 0x00a9006c, 0xfffffffb},/*kerning  l © : -0.019531 */
+{'[', 0x00aa006c, 0xfffffffd},/*kerning  l ª : -0.011719 */
+{'[', 0x00ab006c, 0xfffffff9},/*kerning  l « : -0.027344 */
+{'[', 0x00ae006c, 0xfffffffb},/*kerning  l ® : -0.019531 */
+{'[', 0x00b7006c, 0xffffffec},/*kerning  l · : -0.078125 */
+{'[', 0x00ba006c, 0xfffffffd},/*kerning  l º : -0.011719 */
+{'[', 0x00c7006c, 0xfffffffd},/*kerning  l Ç : -0.011719 */
+{'[', 0x00d2006c, 0xfffffffd},/*kerning  l Ò : -0.011719 */
+{'[', 0x00d3006c, 0xfffffffd},/*kerning  l Ó : -0.011719 */
+{'[', 0x00d4006c, 0xfffffffd},/*kerning  l Ô : -0.011719 */
+{'[', 0x00d5006c, 0xfffffffd},/*kerning  l Õ : -0.011719 */
+{'[', 0x00d6006c, 0xfffffffd},/*kerning  l Ö : -0.011719 */
+{'[', 0x00d8006c, 0xfffffffd},/*kerning  l Ø : -0.011719 */
+{'[', 0x00d9006c, 0xfffffffd},/*kerning  l Ù : -0.011719 */
+{'[', 0x00da006c, 0xfffffffd},/*kerning  l Ú : -0.011719 */
+{'[', 0x00db006c, 0xfffffffd},/*kerning  l Û : -0.011719 */
+{'[', 0x00dc006c, 0xfffffffd},/*kerning  l Ü : -0.011719 */
+{'[', 0x00dd006c, 0xfffffffa},/*kerning  l Ý : -0.023438 */
+{'[', 0x00fd006c, 0xfffffffc},/*kerning  l ý : -0.015625 */
+{'[', 0x00ff006c, 0xfffffffc},/*kerning  l ÿ : -0.015625 */
+{'@', 0x0000006d, 0x00009300},/*        m        x-advance: 147.000000 */
+{'M', 0x430947ae, 0x80000000},
+{'4', 0x0000ff90, 0xfe8b0000},
+{'q', 0x00000000, 0xc151eb88},
+{0, 0xc087ae10, 0xc19ae14a},
+{'q', 0xc087ae10, 0xc0c7ae10},
+{0, 0xc148f5c8, 0xc0c7ae10},
+{'q', 0xc107ae10, 0x00000000},
+{0, 0xc175c290, 0x40c51eb0},
+{'9', 0x0031ffc9, 0x007fffb2},
+{'4', 0x01910000, 0x0000ff90},
+{'l', 0x00000000, 0xc23ae147},
+{'q', 0x00000000, 0xc1547ae4},
+{0, 0xc0851eb8, 0xc19b8522},
+{'q', 0xc0851eb8, 0xc0c51eb0},
+{0, 0xc147ae14, 0xc0c51eb0},
+{'q', 0xc1051eb8, 0x00000000},
+{0, 0xc1747ae0, 0x40c00000},
+{'9', 0x0030ffc9, 0x007fffb2},
+{'l', 0x00000000, 0x42499999},
+{'l', 0xc16147ad, 0x80000000},
+{'4', 0xfd640000, 0x00000066},
+{'l', 0x00000000, 0x418f5c28},
+{'q', 0x40a3d708, 0xc1147ae0},
+{0, 0x41547ae0, 0xc1651eb8},
+{'q', 0x41028f5c, 0xc0a147b0},
+{0, 0x41933334, 0xc0a147b0},
+{'q', 0x41266664, 0x00000000},
+{0, 0x41851eb6, 0x40b5c290},
+{'q', 0x40c7ae20, 0x40b5c290},
+{0, 0x40f5c290, 0x416a3d70},
+{'q', 0x41333338, 0xc1a28f5c},
+{0, 0x41feb854, 0xc1a28f5c},
+{'q', 0x41199998, 0x00000000},
+{0, 0x4171eb80, 0x4091eb90},
+{'q', 0x40b0a3e0, 0x4091eb80},
+{0, 0x40fae140, 0x4147ae10},
+{'9', 0x003f0012, 0x00900012},
+{'l', 0x00000000, 0x4247ae14},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0022006d, 0xfffffffe},/*kerning  m " : -0.007812 */
+{'[', 0x0027006d, 0xfffffffe},/*kerning  m ' : -0.007812 */
+{'[', 0x002a006d, 0xfffffffd},/*kerning  m * : -0.011719 */
+{'[', 0x003f006d, 0xfffffffc},/*kerning  m ? : -0.015625 */
+{'[', 0x0043006d, 0xffffffff},/*kerning  m C : -0.003906 */
+{'[', 0x0047006d, 0xffffffff},/*kerning  m G : -0.003906 */
+{'[', 0x004f006d, 0xffffffff},/*kerning  m O : -0.003906 */
+{'[', 0x0051006d, 0xffffffff},/*kerning  m Q : -0.003906 */
+{'[', 0x0054006d, 0xffffffe4},/*kerning  m T : -0.109375 */
+{'[', 0x0055006d, 0xfffffffe},/*kerning  m U : -0.007812 */
+{'[', 0x0056006d, 0xfffffff2},/*kerning  m V : -0.054688 */
+{'[', 0x0057006d, 0xfffffff2},/*kerning  m W : -0.054688 */
+{'[', 0x0058006d, 0xffffffff},/*kerning  m X : -0.003906 */
+{'[', 0x0059006d, 0xffffffec},/*kerning  m Y : -0.078125 */
+{'[', 0x005a006d, 0xfffffffe},/*kerning  m Z : -0.007812 */
+{'[', 0x005c006d, 0xfffffff5},/*kerning  m \ : -0.042969 */
+{'[', 0x0066006d, 0xffffffff},/*kerning  m f : -0.003906 */
+{'[', 0x0074006d, 0xffffffff},/*kerning  m t : -0.003906 */
+{'[', 0x0076006d, 0xfffffffe},/*kerning  m v : -0.007812 */
+{'[', 0x0077006d, 0xfffffffe},/*kerning  m w : -0.007812 */
+{'[', 0x0079006d, 0xfffffffe},/*kerning  m y : -0.007812 */
+{'[', 0x00c7006d, 0xffffffff},/*kerning  m Ç : -0.003906 */
+{'[', 0x00d0006d, 0xfffffffe},/*kerning  m Ð : -0.007812 */
+{'[', 0x00d2006d, 0xffffffff},/*kerning  m Ò : -0.003906 */
+{'[', 0x00d3006d, 0xffffffff},/*kerning  m Ó : -0.003906 */
+{'[', 0x00d4006d, 0xffffffff},/*kerning  m Ô : -0.003906 */
+{'[', 0x00d5006d, 0xffffffff},/*kerning  m Õ : -0.003906 */
+{'[', 0x00d6006d, 0xffffffff},/*kerning  m Ö : -0.003906 */
+{'[', 0x00d8006d, 0xffffffff},/*kerning  m Ø : -0.003906 */
+{'[', 0x00d9006d, 0xfffffffe},/*kerning  m Ù : -0.007812 */
+{'[', 0x00da006d, 0xfffffffe},/*kerning  m Ú : -0.007812 */
+{'[', 0x00db006d, 0xfffffffe},/*kerning  m Û : -0.007812 */
+{'[', 0x00dc006d, 0xfffffffe},/*kerning  m Ü : -0.007812 */
+{'[', 0x00dd006d, 0xffffffec},/*kerning  m Ý : -0.078125 */
+{'[', 0x00fd006d, 0xfffffffe},/*kerning  m ý : -0.007812 */
+{'[', 0x00ff006d, 0xfffffffe},/*kerning  m ÿ : -0.007812 */
+{'@', 0x0000006e, 0x00005e00},/*        n        x-advance: 94.000000 */
+{'M', 0x42a7ae14, 0x80000000},
+{'4', 0x0000ff90, 0xfe8b0000},
+{'q', 0x00000000, 0xc1547ae4},
+{0, 0xc0828f60, 0xc19b8522},
+{'8', 0xcf9dcfe0, 0x17a500d2},
+{'8', 0x3eb017d3, 0x5ace27dd},
+{'l', 0x00000000, 0x42499999},
+{'l', 0xc16147ad, 0x80000000},
+{'4', 0xfd640000, 0x00000066},
+{'l', 0x00000000, 0x418f5c28},
+{'q', 0x409eb850, 0xc10cccd0},
+{0, 0x41651eb8, 0xc16147b0},
+{'q', 0x4115c290, 0xc0a8f5c0},
+{0, 0x41a33332, 0xc0a8f5c0},
+{'q', 0x411c28f8, 0x00000000},
+{0, 0x4171eb88, 0x4091eb90},
+{'q', 0x40ab8520, 0x4091eb80},
+{0, 0x40f33330, 0x4147ae10},
+{'9', 0x003f0011, 0x00900011},
+{'l', 0x00000000, 0x4247ae14},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0022006e, 0xfffffffe},/*kerning  n " : -0.007812 */
+{'[', 0x0027006e, 0xfffffffe},/*kerning  n ' : -0.007812 */
+{'[', 0x002a006e, 0xfffffffd},/*kerning  n * : -0.011719 */
+{'[', 0x003f006e, 0xfffffffc},/*kerning  n ? : -0.015625 */
+{'[', 0x0043006e, 0xffffffff},/*kerning  n C : -0.003906 */
+{'[', 0x0047006e, 0xffffffff},/*kerning  n G : -0.003906 */
+{'[', 0x004f006e, 0xffffffff},/*kerning  n O : -0.003906 */
+{'[', 0x0051006e, 0xffffffff},/*kerning  n Q : -0.003906 */
+{'[', 0x0054006e, 0xffffffe4},/*kerning  n T : -0.109375 */
+{'[', 0x0055006e, 0xfffffffe},/*kerning  n U : -0.007812 */
+{'[', 0x0056006e, 0xfffffff2},/*kerning  n V : -0.054688 */
+{'[', 0x0057006e, 0xfffffff2},/*kerning  n W : -0.054688 */
+{'[', 0x0058006e, 0xffffffff},/*kerning  n X : -0.003906 */
+{'[', 0x0059006e, 0xffffffec},/*kerning  n Y : -0.078125 */
+{'[', 0x005a006e, 0xfffffffe},/*kerning  n Z : -0.007812 */
+{'[', 0x005c006e, 0xfffffff5},/*kerning  n \ : -0.042969 */
+{'[', 0x0066006e, 0xffffffff},/*kerning  n f : -0.003906 */
+{'[', 0x0074006e, 0xffffffff},/*kerning  n t : -0.003906 */
+{'[', 0x0076006e, 0xfffffffe},/*kerning  n v : -0.007812 */
+{'[', 0x0077006e, 0xfffffffe},/*kerning  n w : -0.007812 */
+{'[', 0x0079006e, 0xfffffffe},/*kerning  n y : -0.007812 */
+{'[', 0x00c7006e, 0xffffffff},/*kerning  n Ç : -0.003906 */
+{'[', 0x00d0006e, 0xfffffffe},/*kerning  n Ð : -0.007812 */
+{'[', 0x00d2006e, 0xffffffff},/*kerning  n Ò : -0.003906 */
+{'[', 0x00d3006e, 0xffffffff},/*kerning  n Ó : -0.003906 */
+{'[', 0x00d4006e, 0xffffffff},/*kerning  n Ô : -0.003906 */
+{'[', 0x00d5006e, 0xffffffff},/*kerning  n Õ : -0.003906 */
+{'[', 0x00d6006e, 0xffffffff},/*kerning  n Ö : -0.003906 */
+{'[', 0x00d8006e, 0xffffffff},/*kerning  n Ø : -0.003906 */
+{'[', 0x00d9006e, 0xfffffffe},/*kerning  n Ù : -0.007812 */
+{'[', 0x00da006e, 0xfffffffe},/*kerning  n Ú : -0.007812 */
+{'[', 0x00db006e, 0xfffffffe},/*kerning  n Û : -0.007812 */
+{'[', 0x00dc006e, 0xfffffffe},/*kerning  n Ü : -0.007812 */
+{'[', 0x00dd006e, 0xffffffec},/*kerning  n Ý : -0.078125 */
+{'[', 0x00fd006e, 0xfffffffe},/*kerning  n ý : -0.007812 */
+{'[', 0x00ff006e, 0xfffffffe},/*kerning  n ÿ : -0.007812 */
+{'@', 0x0000006f, 0x00005f00},/*        o        x-advance: 95.000000 */
+{'M', 0x423f5c29, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b00000, 0xc0bfffff},
+{'q', 0xc11851ec, 0xc0c00000},
+{0, 0xc16ccccd, 0xc17d70a4},
+{'q', 0xc0a8f5c3, 0xc11d70a4},
+{0, 0xc0a8f5c3, 0xc1aae147},
+{'q', 0x00000000, 0xc13ae148},
+{0, 0x40ab851f, 0xc1ac28f6},
+{'q', 0x40ab851e, 0xc11d70a4},
+{0, 0x416e147b, 0xc17d70a4},
+{'q', 0x411851ec, 0xc0c00000},
+{0, 0x41aeb852, 0xc0c00000},
+{'q', 0x4147ae14, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x411851f0, 0x40c00000},
+{0, 0x416e1480, 0x417d70a4},
+{'q', 0x40ab8510, 0x411d70a4},
+{0, 0x40ab8510, 0x41ac28f6},
+{'q', 0x00000000, 0x413851ea},
+{0, 0xc0ab8510, 0x41aae147},
+{'q', 0xc0ab8520, 0x411d70a4},
+{0, 0xc16cccd0, 0x417d70a4},
+{'9', 0x002fffb5, 0x002fff50},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc225c28f},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x4070a3d8, 0x417ae148},
+{'8', 0x584f381e, 0x206f2031},
+{'8', 0xdf6f003d, 0xa650df32},
+{'q', 0x4070a3e0, 0xc0e3d708},
+{0, 0x4070a3e0, 0xc17c28f4},
+{'q', 0x00000000, 0xc10a3d70},
+{0, 0xc070a3e0, 0xc17ae144},
+{'8', 0xa7b0c8e2, 0xdf91dfce},
+{'8', 0x219100c3, 0x5ab121cf},
+{'q', 0xc070a3d8, 0x40e147b0},
+{0, 0xc070a3d8, 0x417d70a4},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x0022006f, 0xfffffffc},/*kerning  o " : -0.015625 */
+{'[', 0x0027006f, 0xfffffffc},/*kerning  o ' : -0.015625 */
+{'[', 0x0029006f, 0xfffffffb},/*kerning  o ) : -0.019531 */
+{'[', 0x002a006f, 0xfffffffb},/*kerning  o * : -0.019531 */
+{'[', 0x002c006f, 0xfffffffb},/*kerning  o , : -0.019531 */
+{'[', 0x002e006f, 0xfffffffb},/*kerning  o . : -0.019531 */
+{'[', 0x003f006f, 0xfffffffb},/*kerning  o ? : -0.019531 */
+{'[', 0x0041006f, 0xfffffffc},/*kerning  o A : -0.015625 */
+{'[', 0x0042006f, 0xfffffffe},/*kerning  o B : -0.007812 */
+{'[', 0x0044006f, 0xfffffffe},/*kerning  o D : -0.007812 */
+{'[', 0x0045006f, 0xfffffffe},/*kerning  o E : -0.007812 */
+{'[', 0x0046006f, 0xfffffffe},/*kerning  o F : -0.007812 */
+{'[', 0x0048006f, 0xfffffffe},/*kerning  o H : -0.007812 */
+{'[', 0x0049006f, 0xfffffffe},/*kerning  o I : -0.007812 */
+{'[', 0x004a006f, 0xfffffffe},/*kerning  o J : -0.007812 */
+{'[', 0x004b006f, 0xfffffffe},/*kerning  o K : -0.007812 */
+{'[', 0x004c006f, 0xfffffffe},/*kerning  o L : -0.007812 */
+{'[', 0x004d006f, 0xfffffffe},/*kerning  o M : -0.007812 */
+{'[', 0x004e006f, 0xfffffffe},/*kerning  o N : -0.007812 */
+{'[', 0x0050006f, 0xfffffffe},/*kerning  o P : -0.007812 */
+{'[', 0x0052006f, 0xfffffffe},/*kerning  o R : -0.007812 */
+{'[', 0x0053006f, 0xffffffff},/*kerning  o S : -0.003906 */
+{'[', 0x0054006f, 0xffffffe4},/*kerning  o T : -0.109375 */
+{'[', 0x0055006f, 0xfffffffe},/*kerning  o U : -0.007812 */
+{'[', 0x0056006f, 0xffffffef},/*kerning  o V : -0.066406 */
+{'[', 0x0057006f, 0xffffffef},/*kerning  o W : -0.066406 */
+{'[', 0x0058006f, 0xfffffff7},/*kerning  o X : -0.035156 */
+{'[', 0x0059006f, 0xffffffe9},/*kerning  o Y : -0.089844 */
+{'[', 0x005a006f, 0xfffffffb},/*kerning  o Z : -0.019531 */
+{'[', 0x005c006f, 0xfffffff4},/*kerning  o \ : -0.046875 */
+{'[', 0x0066006f, 0xfffffffe},/*kerning  o f : -0.007812 */
+{'[', 0x0074006f, 0xfffffffe},/*kerning  o t : -0.007812 */
+{'[', 0x0076006f, 0xfffffffc},/*kerning  o v : -0.015625 */
+{'[', 0x0077006f, 0xfffffffc},/*kerning  o w : -0.015625 */
+{'[', 0x0078006f, 0xfffffffa},/*kerning  o x : -0.023438 */
+{'[', 0x0079006f, 0xfffffffc},/*kerning  o y : -0.015625 */
+{'[', 0x007a006f, 0xfffffffe},/*kerning  o z : -0.007812 */
+{'[', 0x00c0006f, 0xfffffffc},/*kerning  o À : -0.015625 */
+{'[', 0x00c1006f, 0xfffffffc},/*kerning  o Á : -0.015625 */
+{'[', 0x00c2006f, 0xfffffffc},/*kerning  o Â : -0.015625 */
+{'[', 0x00c3006f, 0xfffffffc},/*kerning  o Ã : -0.015625 */
+{'[', 0x00c4006f, 0xfffffffc},/*kerning  o Ä : -0.015625 */
+{'[', 0x00c5006f, 0xfffffffc},/*kerning  o Å : -0.015625 */
+{'[', 0x00c6006f, 0xfffffffd},/*kerning  o Æ : -0.011719 */
+{'[', 0x00c8006f, 0xfffffffe},/*kerning  o È : -0.007812 */
+{'[', 0x00c9006f, 0xfffffffe},/*kerning  o É : -0.007812 */
+{'[', 0x00ca006f, 0xfffffffe},/*kerning  o Ê : -0.007812 */
+{'[', 0x00cb006f, 0xfffffffe},/*kerning  o Ë : -0.007812 */
+{'[', 0x00cc006f, 0xfffffffe},/*kerning  o Ì : -0.007812 */
+{'[', 0x00cd006f, 0xfffffffe},/*kerning  o Í : -0.007812 */
+{'[', 0x00ce006f, 0xfffffffe},/*kerning  o Î : -0.007812 */
+{'[', 0x00cf006f, 0xfffffffe},/*kerning  o Ï : -0.007812 */
+{'[', 0x00d0006f, 0xfffffffc},/*kerning  o Ð : -0.015625 */
+{'[', 0x00d1006f, 0xfffffffe},/*kerning  o Ñ : -0.007812 */
+{'[', 0x00d9006f, 0xfffffffe},/*kerning  o Ù : -0.007812 */
+{'[', 0x00da006f, 0xfffffffe},/*kerning  o Ú : -0.007812 */
+{'[', 0x00db006f, 0xfffffffe},/*kerning  o Û : -0.007812 */
+{'[', 0x00dc006f, 0xfffffffe},/*kerning  o Ü : -0.007812 */
+{'[', 0x00dd006f, 0xffffffe9},/*kerning  o Ý : -0.089844 */
+{'[', 0x00de006f, 0xfffffffe},/*kerning  o Þ : -0.007812 */
+{'[', 0x00fd006f, 0xfffffffc},/*kerning  o ý : -0.015625 */
+{'[', 0x00ff006f, 0xfffffffc},/*kerning  o ÿ : -0.015625 */
+{'@', 0x00000070, 0x00006300},/*        p        x-advance: 99.000000 */
+{'M', 0x426147ae, 0x3fcccccc},
+{'q', 0xc123d70c, 0x00000000},
+{0, 0xc191eb86, 0xc0a3d70a},
+{'9', 0xffd8ffc1, 0xff99ff9b},
+{'l', 0x00000000, 0x424a3d70},
+{'l', 0xc16147ad, 0x00000000},
+{'4', 0xfc540000, 0x00000063},
+{'l', 0x00000000, 0x417ae148},
+{'q', 0x409eb850, 0xc0f5c290},
+{0, 0x414f5c28, 0xc1466668},
+{'q', 0x41000000, 0xc0970a40},
+{0, 0x418b851e, 0xc0970a40},
+{'q', 0x410a3d70, 0x00000000},
+{0, 0x417d70a8, 0x406147a0},
+{'8', 0x4c631c39, 0x6e41302a},
+{'q', 0x403d70a0, 0x40f851f0},
+{0, 0x403d70a0, 0x4181eb86},
+{'q', 0x00000000, 0x413d70a2},
+{0, 0xc0970a40, 0x41ae147a},
+{'q', 0xc0970a30, 0x411eb852},
+{0, 0xc1533330, 0x417c28f6},
+{'9', 0x002effbd, 0x002eff64},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42500000, 0xc128f5c2},
+{'q', 0x41051eb8, 0x00000000},
+{0, 0x41666660, 0xc08f5c2a},
+{'q', 0x40c28f60, 0xc08f5c2a},
+{0, 0x411851f0, 0xc13ae147},
+{'q', 0x405c2900, 0xc0e66664},
+{0, 0x405c2900, 0xc170a3d6},
+{'q', 0x00000000, 0xc107ae14},
+{0, 0xc070a3e0, 0xc17851ec},
+{'q', 0xc070a3e0, 0xc0e147b0},
+{0, 0xc123d708, 0xc1347ae0},
+{'q', 0xc0cf5c30, 0xc087ae10},
+{0, 0xc16a3d74, 0xc087ae10},
+{'8', 0x14ad00d9, 0x36b414d4},
+{'9', 0x0021ffe0, 0x004affd7},
+{'l', 0x00000000, 0x41beb851},
+{'q', 0x406147b0, 0x41051eb8},
+{0, 0x412ccccc, 0x41600000},
+{'q', 0x40e8f5c8, 0x40b5c290},
+{0, 0x417c28f8, 0x40b5c290},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00220070, 0xfffffffc},/*kerning  p " : -0.015625 */
+{'[', 0x00270070, 0xfffffffc},/*kerning  p ' : -0.015625 */
+{'[', 0x00290070, 0xfffffffb},/*kerning  p ) : -0.019531 */
+{'[', 0x002a0070, 0xfffffffa},/*kerning  p * : -0.023438 */
+{'[', 0x002f0070, 0xfffffffe},/*kerning  p / : -0.007812 */
+{'[', 0x003f0070, 0xfffffffb},/*kerning  p ? : -0.019531 */
+{'[', 0x00410070, 0xfffffffc},/*kerning  p A : -0.015625 */
+{'[', 0x00420070, 0xfffffffe},/*kerning  p B : -0.007812 */
+{'[', 0x00440070, 0xfffffffe},/*kerning  p D : -0.007812 */
+{'[', 0x00450070, 0xfffffffe},/*kerning  p E : -0.007812 */
+{'[', 0x00460070, 0xfffffffe},/*kerning  p F : -0.007812 */
+{'[', 0x00480070, 0xfffffffe},/*kerning  p H : -0.007812 */
+{'[', 0x00490070, 0xfffffffe},/*kerning  p I : -0.007812 */
+{'[', 0x004a0070, 0xfffffffe},/*kerning  p J : -0.007812 */
+{'[', 0x004b0070, 0xfffffffe},/*kerning  p K : -0.007812 */
+{'[', 0x004c0070, 0xfffffffe},/*kerning  p L : -0.007812 */
+{'[', 0x004d0070, 0xfffffffe},/*kerning  p M : -0.007812 */
+{'[', 0x004e0070, 0xfffffffe},/*kerning  p N : -0.007812 */
+{'[', 0x00500070, 0xfffffffe},/*kerning  p P : -0.007812 */
+{'[', 0x00520070, 0xfffffffe},/*kerning  p R : -0.007812 */
+{'[', 0x00530070, 0xffffffff},/*kerning  p S : -0.003906 */
+{'[', 0x00540070, 0xffffffe4},/*kerning  p T : -0.109375 */
+{'[', 0x00550070, 0xfffffffe},/*kerning  p U : -0.007812 */
+{'[', 0x00560070, 0xffffffef},/*kerning  p V : -0.066406 */
+{'[', 0x00570070, 0xffffffef},/*kerning  p W : -0.066406 */
+{'[', 0x00580070, 0xfffffff7},/*kerning  p X : -0.035156 */
+{'[', 0x00590070, 0xffffffea},/*kerning  p Y : -0.085938 */
+{'[', 0x005a0070, 0xfffffffc},/*kerning  p Z : -0.015625 */
+{'[', 0x005c0070, 0xfffffff4},/*kerning  p \ : -0.046875 */
+{'[', 0x005d0070, 0xfffffffe},/*kerning  p ] : -0.007812 */
+{'[', 0x00660070, 0xfffffffe},/*kerning  p f : -0.007812 */
+{'[', 0x00740070, 0xfffffffe},/*kerning  p t : -0.007812 */
+{'[', 0x00760070, 0xfffffffc},/*kerning  p v : -0.015625 */
+{'[', 0x00770070, 0xfffffffc},/*kerning  p w : -0.015625 */
+{'[', 0x00780070, 0xfffffffb},/*kerning  p x : -0.019531 */
+{'[', 0x00790070, 0xfffffffc},/*kerning  p y : -0.015625 */
+{'[', 0x007a0070, 0xfffffffe},/*kerning  p z : -0.007812 */
+{'[', 0x007d0070, 0xfffffffe},/*kerning  p } : -0.007812 */
+{'[', 0x00ba0070, 0xfffffffe},/*kerning  p º : -0.007812 */
+{'[', 0x00c00070, 0xfffffffc},/*kerning  p À : -0.015625 */
+{'[', 0x00c10070, 0xfffffffc},/*kerning  p Á : -0.015625 */
+{'[', 0x00c20070, 0xfffffffc},/*kerning  p Â : -0.015625 */
+{'[', 0x00c30070, 0xfffffffc},/*kerning  p Ã : -0.015625 */
+{'[', 0x00c40070, 0xfffffffc},/*kerning  p Ä : -0.015625 */
+{'[', 0x00c50070, 0xfffffffc},/*kerning  p Å : -0.015625 */
+{'[', 0x00c60070, 0xfffffffd},/*kerning  p Æ : -0.011719 */
+{'[', 0x00c80070, 0xfffffffe},/*kerning  p È : -0.007812 */
+{'[', 0x00c90070, 0xfffffffe},/*kerning  p É : -0.007812 */
+{'[', 0x00ca0070, 0xfffffffe},/*kerning  p Ê : -0.007812 */
+{'[', 0x00cb0070, 0xfffffffe},/*kerning  p Ë : -0.007812 */
+{'[', 0x00cc0070, 0xfffffffe},/*kerning  p Ì : -0.007812 */
+{'[', 0x00cd0070, 0xfffffffe},/*kerning  p Í : -0.007812 */
+{'[', 0x00ce0070, 0xfffffffe},/*kerning  p Î : -0.007812 */
+{'[', 0x00cf0070, 0xfffffffe},/*kerning  p Ï : -0.007812 */
+{'[', 0x00d00070, 0xfffffffc},/*kerning  p Ð : -0.015625 */
+{'[', 0x00d10070, 0xfffffffe},/*kerning  p Ñ : -0.007812 */
+{'[', 0x00d90070, 0xfffffffe},/*kerning  p Ù : -0.007812 */
+{'[', 0x00da0070, 0xfffffffe},/*kerning  p Ú : -0.007812 */
+{'[', 0x00db0070, 0xfffffffe},/*kerning  p Û : -0.007812 */
+{'[', 0x00dc0070, 0xfffffffe},/*kerning  p Ü : -0.007812 */
+{'[', 0x00dd0070, 0xffffffea},/*kerning  p Ý : -0.085938 */
+{'[', 0x00de0070, 0xfffffffe},/*kerning  p Þ : -0.007812 */
+{'[', 0x00fd0070, 0xfffffffc},/*kerning  p ý : -0.015625 */
+{'[', 0x00ff0070, 0xfffffffc},/*kerning  p ÿ : -0.015625 */
+{'@', 0x00000071, 0x00006300},/*        q        x-advance: 99.000000 */
+{'M', 0x422d70a4, 0x3fcccccc},
+{'q', 0xc130a3d8, 0x00000000},
+{0, 0xc19c28f6, 0xc0c28f5b},
+{'q', 0xc107ae15, 0xc0c28f5c},
+{0, 0xc1533334, 0xc17eb852},
+{'q', 0xc0970a3c, 0xc11d70a4},
+{0, 0xc0970a3c, 0xc1aae147},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x40a8f5c2, 0xc1accccc},
+{'q', 0x40a8f5c2, 0xc11c28f4},
+{0, 0x4163d709, 0xc17ae144},
+{'q', 0x410f5c28, 0xc0bd70b0},
+{0, 0x41a00000, 0xc0bd70b0},
+{'q', 0x411c28f4, 0x00000000},
+{0, 0x418e147a, 0x409c28f0},
+{'9', 0x00270040, 0x00630065},
+{'l', 0x00000000, 0xc17d70a0},
+{'l', 0x4147ae18, 0x00000000},
+{'4', 0x03ac0000, 0x0000ff90},
+{'l', 0x00000000, 0xc24a3d70},
+{'9', 0x0090ffa4, 0x0090ff09},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4240a3d7, 0xc128f5c2},
+{'q', 0x410f5c28, 0x00000000},
+{0, 0x417851ec, 0xc0a8f5c2},
+{'9', 0xffd60034, 0xff9b0054},
+{'l', 0x00000000, 0xc1c00000},
+{'8', 0xb0d8d5f9, 0xc5b4dbe0},
+{'q', 0xc0b0a3d8, 0xc0333320},
+{0, 0xc131eb84, 0xc0333320},
+{'q', 0xc1028f5c, 0x00000000},
+{0, 0xc168f5c4, 0x4091eb80},
+{'q', 0xc0cccccc, 0x4091eb80},
+{0, 0xc1200000, 0x413ae148},
+{'q', 0xc0666660, 0x40e3d708},
+{0, 0xc0666660, 0x4171eb84},
+{'q', 0x00000000, 0x41051eb8},
+{0, 0x40666660, 0x4175c290},
+{'q', 0x40666668, 0x40e147ac},
+{0, 0x411d70a4, 0x41347ae0},
+{'q', 0x40c7ae18, 0x4087ae14},
+{0, 0x41666668, 0x4087ae14},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00540071, 0xffffffea},/*kerning  q T : -0.085938 */
+{'[', 0x00550071, 0xfffffffe},/*kerning  q U : -0.007812 */
+{'[', 0x00560071, 0xfffffff5},/*kerning  q V : -0.042969 */
+{'[', 0x00580071, 0xfffffffe},/*kerning  q X : -0.007812 */
+{'[', 0x00590071, 0xffffffee},/*kerning  q Y : -0.070312 */
+{'[', 0x005a0071, 0xfffffffe},/*kerning  q Z : -0.007812 */
+{'[', 0x005c0071, 0xfffffff9},/*kerning  q \ : -0.027344 */
+{'[', 0x006a0071, 0x00000012},/*kerning  q j : 0.070312 */
+{'[', 0x00d90071, 0xfffffffe},/*kerning  q Ù : -0.007812 */
+{'[', 0x00da0071, 0xfffffffe},/*kerning  q Ú : -0.007812 */
+{'[', 0x00db0071, 0xfffffffe},/*kerning  q Û : -0.007812 */
+{'[', 0x00dc0071, 0xfffffffe},/*kerning  q Ü : -0.007812 */
+{'[', 0x00dd0071, 0xffffffee},/*kerning  q Ý : -0.070312 */
+{'@', 0x00000072, 0x00003a00},/*        r        x-advance: 58.000000 */
+{'M', 0x425e147b, 0xc28e6666},
+{'q', 0xc128f5c4, 0x3e23d600},
+{0, 0xc1951eba, 0x40ab8520},
+{'9', 0x0029ffc0, 0x0072ffa5},
+{'l', 0x00000000, 0x424e147b},
+{'l', 0xc16147ad, 0x80000000},
+{'4', 0xfd640000, 0x00000068},
+{'l', 0x00000000, 0x419ae148},
+{'q', 0x408a3d70, 0xc10a3d70},
+{0, 0x41370a3c, 0xc1600000},
+{'q', 0x40e3d710, 0xc0ab8520},
+{0, 0x416f5c28, 0xc0c00000},
+{'8', 0x0015000c, 0x010f0008},
+{'l', 0x00000000, 0x414cccd0},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200072, 0xfffffffb},/*kerning  r   : -0.019531 */
+{'[', 0x00290072, 0xfffffffd},/*kerning  r ) : -0.011719 */
+{'[', 0x002c0072, 0xffffffe5},/*kerning  r , : -0.105469 */
+{'[', 0x002d0072, 0xfffffff8},/*kerning  r - : -0.031250 */
+{'[', 0x002e0072, 0xffffffe5},/*kerning  r . : -0.105469 */
+{'[', 0x002f0072, 0xfffffff4},/*kerning  r / : -0.046875 */
+{'[', 0x00410072, 0xfffffff5},/*kerning  r A : -0.042969 */
+{'[', 0x004a0072, 0xffffffed},/*kerning  r J : -0.074219 */
+{'[', 0x00540072, 0xffffffed},/*kerning  r T : -0.074219 */
+{'[', 0x00560072, 0xfffffffe},/*kerning  r V : -0.007812 */
+{'[', 0x00570072, 0xfffffffe},/*kerning  r W : -0.007812 */
+{'[', 0x00580072, 0xfffffff9},/*kerning  r X : -0.027344 */
+{'[', 0x00590072, 0xfffffff9},/*kerning  r Y : -0.027344 */
+{'[', 0x005a0072, 0xfffffffc},/*kerning  r Z : -0.015625 */
+{'[', 0x00630072, 0xfffffffd},/*kerning  r c : -0.011719 */
+{'[', 0x00640072, 0xfffffffe},/*kerning  r d : -0.007812 */
+{'[', 0x00650072, 0xfffffffd},/*kerning  r e : -0.011719 */
+{'[', 0x00670072, 0xfffffffe},/*kerning  r g : -0.007812 */
+{'[', 0x006f0072, 0xfffffffd},/*kerning  r o : -0.011719 */
+{'[', 0x00710072, 0xfffffffe},/*kerning  r q : -0.007812 */
+{'[', 0x00ab0072, 0xfffffff5},/*kerning  r « : -0.042969 */
+{'[', 0x00c00072, 0xfffffff5},/*kerning  r À : -0.042969 */
+{'[', 0x00c10072, 0xfffffff5},/*kerning  r Á : -0.042969 */
+{'[', 0x00c20072, 0xfffffff5},/*kerning  r Â : -0.042969 */
+{'[', 0x00c30072, 0xfffffff5},/*kerning  r Ã : -0.042969 */
+{'[', 0x00c40072, 0xfffffff5},/*kerning  r Ä : -0.042969 */
+{'[', 0x00c50072, 0xfffffff5},/*kerning  r Å : -0.042969 */
+{'[', 0x00c60072, 0xfffffff2},/*kerning  r Æ : -0.054688 */
+{'[', 0x00d00072, 0xffffffff},/*kerning  r Ð : -0.003906 */
+{'[', 0x00dd0072, 0xfffffff9},/*kerning  r Ý : -0.027344 */
+{'[', 0x00e70072, 0xfffffffd},/*kerning  r ç : -0.011719 */
+{'[', 0x00e80072, 0xfffffffd},/*kerning  r è : -0.011719 */
+{'[', 0x00e90072, 0xfffffffd},/*kerning  r é : -0.011719 */
+{'[', 0x00ea0072, 0xfffffffd},/*kerning  r ê : -0.011719 */
+{'[', 0x00eb0072, 0xfffffffd},/*kerning  r ë : -0.011719 */
+{'[', 0x00f00072, 0xfffffff8},/*kerning  r ð : -0.031250 */
+{'[', 0x00f20072, 0xfffffffd},/*kerning  r ò : -0.011719 */
+{'[', 0x00f30072, 0xfffffffd},/*kerning  r ó : -0.011719 */
+{'[', 0x00f40072, 0xfffffffd},/*kerning  r ô : -0.011719 */
+{'[', 0x00f50072, 0xfffffffd},/*kerning  r õ : -0.011719 */
+{'[', 0x00f60072, 0xfffffffd},/*kerning  r ö : -0.011719 */
+{'[', 0x00f80072, 0xfffffffd},/*kerning  r ø : -0.011719 */
+{'@', 0x00000073, 0x00004e00},/*        s        x-advance: 78.000000 */
+{'M', 0x42200000, 0x3fcccccc},
+{'q', 0xc1266668, 0x00000000},
+{0, 0xc19c28f6, 0xc05c28f5},
+{'9', 0xffe5ffb8, 0xffaeff83},
+{'l', 0x40ae147c, 0xc11eb852},
+{'q', 0x40e66668, 0x40d70a3e},
+{0, 0x41666666, 0x4119999a},
+{'q', 0x40e66668, 0x403851ec},
+{0, 0x416b8520, 0x403851ec},
+{'q', 0x410a3d70, 0x00000000},
+{0, 0x416147ac, 0xc051eb84},
+{'8', 0xb32be62b, 0xc9eadb00},
+{'8', 0xe2c1efea, 0xe59ff4d8},
+{'q', 0xc14f5c2a, 0xc06b8520},
+{0, 0xc19e147b, 0xc10b8520},
+{'q', 0xc0d9999a, 0xc0a147a8},
+{0, 0xc0d9999a, 0xc16ccccc},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x4110a3d7, 0xc1928f5a},
+{'q', 0x4110a3d6, 0xc0cf5c30},
+{0, 0x41b8f5c2, 0xc0cf5c30},
+{'9', 0x00000097, 0x005a00ee},
+{'l', 0xc0ccccd0, 0x411c28f4},
+{'q', 0xc11c28f8, 0xc12147ac},
+{0, 0xc1c147ae, 0xc12147ac},
+{'8', 0x08bd00de, 0x1dc908df},
+{'8', 0x3beb15eb, 0x43262f00},
+{'q', 0x40999998, 0x4023d710},
+{0, 0x416147ac, 0x40a8f5c0},
+{'q', 0x41170a3c, 0x402e1480},
+{0, 0x41833334, 0x40ae1480},
+{'8', 0x38561537, 0x601e221e},
+{'q', 0x00000000, 0x413d70a3},
+{0, 0xc10f5c28, 0x4193d70a},
+{'q', 0xc10f5c2c, 0x40d47adf},
+{0, 0xc1bd70a4, 0x40d47adf},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002a0073, 0xfffffffe},/*kerning  s * : -0.007812 */
+{'[', 0x00410073, 0xfffffffe},/*kerning  s A : -0.007812 */
+{'[', 0x00420073, 0xffffffff},/*kerning  s B : -0.003906 */
+{'[', 0x00440073, 0xffffffff},/*kerning  s D : -0.003906 */
+{'[', 0x00450073, 0xffffffff},/*kerning  s E : -0.003906 */
+{'[', 0x00460073, 0xffffffff},/*kerning  s F : -0.003906 */
+{'[', 0x00480073, 0xffffffff},/*kerning  s H : -0.003906 */
+{'[', 0x00490073, 0xffffffff},/*kerning  s I : -0.003906 */
+{'[', 0x004b0073, 0xffffffff},/*kerning  s K : -0.003906 */
+{'[', 0x004c0073, 0xffffffff},/*kerning  s L : -0.003906 */
+{'[', 0x004d0073, 0xffffffff},/*kerning  s M : -0.003906 */
+{'[', 0x004e0073, 0xffffffff},/*kerning  s N : -0.003906 */
+{'[', 0x00500073, 0xffffffff},/*kerning  s P : -0.003906 */
+{'[', 0x00520073, 0xffffffff},/*kerning  s R : -0.003906 */
+{'[', 0x00540073, 0xffffffe7},/*kerning  s T : -0.097656 */
+{'[', 0x00550073, 0xfffffffe},/*kerning  s U : -0.007812 */
+{'[', 0x00560073, 0xfffffff4},/*kerning  s V : -0.046875 */
+{'[', 0x00570073, 0xfffffff4},/*kerning  s W : -0.046875 */
+{'[', 0x00580073, 0xffffffff},/*kerning  s X : -0.003906 */
+{'[', 0x00590073, 0xffffffed},/*kerning  s Y : -0.074219 */
+{'[', 0x005c0073, 0xfffffff8},/*kerning  s \ : -0.031250 */
+{'[', 0x00760073, 0xfffffffe},/*kerning  s v : -0.007812 */
+{'[', 0x00770073, 0xfffffffe},/*kerning  s w : -0.007812 */
+{'[', 0x00790073, 0xfffffffe},/*kerning  s y : -0.007812 */
+{'[', 0x00c00073, 0xfffffffe},/*kerning  s À : -0.007812 */
+{'[', 0x00c10073, 0xfffffffe},/*kerning  s Á : -0.007812 */
+{'[', 0x00c20073, 0xfffffffe},/*kerning  s Â : -0.007812 */
+{'[', 0x00c30073, 0xfffffffe},/*kerning  s Ã : -0.007812 */
+{'[', 0x00c40073, 0xfffffffe},/*kerning  s Ä : -0.007812 */
+{'[', 0x00c50073, 0xfffffffe},/*kerning  s Å : -0.007812 */
+{'[', 0x00c60073, 0xffffffff},/*kerning  s Æ : -0.003906 */
+{'[', 0x00c80073, 0xffffffff},/*kerning  s È : -0.003906 */
+{'[', 0x00c90073, 0xffffffff},/*kerning  s É : -0.003906 */
+{'[', 0x00ca0073, 0xffffffff},/*kerning  s Ê : -0.003906 */
+{'[', 0x00cb0073, 0xffffffff},/*kerning  s Ë : -0.003906 */
+{'[', 0x00cc0073, 0xffffffff},/*kerning  s Ì : -0.003906 */
+{'[', 0x00cd0073, 0xffffffff},/*kerning  s Í : -0.003906 */
+{'[', 0x00ce0073, 0xffffffff},/*kerning  s Î : -0.003906 */
+{'[', 0x00cf0073, 0xffffffff},/*kerning  s Ï : -0.003906 */
+{'[', 0x00d00073, 0xfffffffe},/*kerning  s Ð : -0.007812 */
+{'[', 0x00d10073, 0xffffffff},/*kerning  s Ñ : -0.003906 */
+{'[', 0x00d90073, 0xfffffffe},/*kerning  s Ù : -0.007812 */
+{'[', 0x00da0073, 0xfffffffe},/*kerning  s Ú : -0.007812 */
+{'[', 0x00db0073, 0xfffffffe},/*kerning  s Û : -0.007812 */
+{'[', 0x00dc0073, 0xfffffffe},/*kerning  s Ü : -0.007812 */
+{'[', 0x00dd0073, 0xffffffed},/*kerning  s Ý : -0.074219 */
+{'[', 0x00de0073, 0xffffffff},/*kerning  s Þ : -0.003906 */
+{'[', 0x00fd0073, 0xfffffffe},/*kerning  s ý : -0.007812 */
+{'[', 0x00ff0073, 0xfffffffe},/*kerning  s ÿ : -0.007812 */
+{'@', 0x00000074, 0x00003800},/*        t        x-advance: 56.000000 */
+{'M', 0x425a3d70, 0xc0851eb8},
+{'8', 0x19c008ec, 0x109f10d4},
+{'8', 0xdf9600c3, 0x97d4dfd4},
+{'l', 0x00000000, 0xc260a3d6},
+{'l', 0xc135c28f, 0x00000000},
+{'l', 0x00000000, 0xc130a3d8},
+{'l', 0x4135c28f, 0x00000000},
+{'l', 0x00000000, 0xc1deb854},
+{'l', 0x416147ad, 0x00000000},
+{'l', 0x00000000, 0x41deb854},
+{'l', 0x4195c290, 0x00000000},
+{'4', 0x00580000, 0x0000ff6b},
+{'l', 0x00000000, 0x424f5c28},
+{'8', 0x35182302, 0x11331115},
+{'8', 0xf53d0021, 0xf025f51c},
+{'l', 0x40570a40, 0x41333333},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00430074, 0xffffffff},/*kerning  t C : -0.003906 */
+{'[', 0x00470074, 0xffffffff},/*kerning  t G : -0.003906 */
+{'[', 0x004f0074, 0xffffffff},/*kerning  t O : -0.003906 */
+{'[', 0x00510074, 0xffffffff},/*kerning  t Q : -0.003906 */
+{'[', 0x00540074, 0xfffffff0},/*kerning  t T : -0.062500 */
+{'[', 0x00550074, 0xfffffffe},/*kerning  t U : -0.007812 */
+{'[', 0x00560074, 0xfffffff8},/*kerning  t V : -0.031250 */
+{'[', 0x00570074, 0xfffffff8},/*kerning  t W : -0.031250 */
+{'[', 0x00590074, 0xfffffff2},/*kerning  t Y : -0.054688 */
+{'[', 0x005c0074, 0xfffffffb},/*kerning  t \ : -0.019531 */
+{'[', 0x00630074, 0xffffffff},/*kerning  t c : -0.003906 */
+{'[', 0x00640074, 0xffffffff},/*kerning  t d : -0.003906 */
+{'[', 0x00650074, 0xffffffff},/*kerning  t e : -0.003906 */
+{'[', 0x00670074, 0xffffffff},/*kerning  t g : -0.003906 */
+{'[', 0x006f0074, 0xffffffff},/*kerning  t o : -0.003906 */
+{'[', 0x00710074, 0xffffffff},/*kerning  t q : -0.003906 */
+{'[', 0x00ab0074, 0xfffffffb},/*kerning  t « : -0.019531 */
+{'[', 0x00c70074, 0xffffffff},/*kerning  t Ç : -0.003906 */
+{'[', 0x00d00074, 0xfffffffe},/*kerning  t Ð : -0.007812 */
+{'[', 0x00d20074, 0xffffffff},/*kerning  t Ò : -0.003906 */
+{'[', 0x00d30074, 0xffffffff},/*kerning  t Ó : -0.003906 */
+{'[', 0x00d40074, 0xffffffff},/*kerning  t Ô : -0.003906 */
+{'[', 0x00d50074, 0xffffffff},/*kerning  t Õ : -0.003906 */
+{'[', 0x00d60074, 0xffffffff},/*kerning  t Ö : -0.003906 */
+{'[', 0x00d80074, 0xffffffff},/*kerning  t Ø : -0.003906 */
+{'[', 0x00d90074, 0xfffffffe},/*kerning  t Ù : -0.007812 */
+{'[', 0x00da0074, 0xfffffffe},/*kerning  t Ú : -0.007812 */
+{'[', 0x00db0074, 0xfffffffe},/*kerning  t Û : -0.007812 */
+{'[', 0x00dc0074, 0xfffffffe},/*kerning  t Ü : -0.007812 */
+{'[', 0x00dd0074, 0xfffffff2},/*kerning  t Ý : -0.054688 */
+{'[', 0x00e70074, 0xffffffff},/*kerning  t ç : -0.003906 */
+{'[', 0x00e80074, 0xffffffff},/*kerning  t è : -0.003906 */
+{'[', 0x00e90074, 0xffffffff},/*kerning  t é : -0.003906 */
+{'[', 0x00ea0074, 0xffffffff},/*kerning  t ê : -0.003906 */
+{'[', 0x00eb0074, 0xffffffff},/*kerning  t ë : -0.003906 */
+{'[', 0x00f00074, 0xfffffffe},/*kerning  t ð : -0.007812 */
+{'[', 0x00f20074, 0xffffffff},/*kerning  t ò : -0.003906 */
+{'[', 0x00f30074, 0xffffffff},/*kerning  t ó : -0.003906 */
+{'[', 0x00f40074, 0xffffffff},/*kerning  t ô : -0.003906 */
+{'[', 0x00f50074, 0xffffffff},/*kerning  t õ : -0.003906 */
+{'[', 0x00f60074, 0xffffffff},/*kerning  t ö : -0.003906 */
+{'[', 0x00f80074, 0xffffffff},/*kerning  t ø : -0.003906 */
+{'@', 0x00000075, 0x00006000},/*        u        x-advance: 96.000000 */
+{'M', 0x4128f5c2, 0xc205c28f},
+{'4', 0xfe700000, 0x00000070},
+{'l', 0x00000000, 0x423d70a3},
+{'q', 0x00000000, 0x41cccccd},
+{0, 0x418e147a, 0x41cccccd},
+{'q', 0x410a3d70, 0x00000000},
+{0, 0x4181eb86, 0xc0b0a3d8},
+{'9', 0xffd4003c, 0xff88005a},
+{'4', 0xfe5e0000, 0x00000070},
+{'l', 0x00000000, 0x42870a3d},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e202ed, 0x00eb00f6},
+{'8', 0xedc900e0, 0xcfe8ede9},
+{'l', 0xbea3d700, 0xc11c28f6},
+{'q', 0xc0ae1470, 0x41147ae2},
+{0, 0xc16a3d6c, 0x41666667},
+{'q', 0xc1133334, 0x40a3d709},
+{0, 0xc1a0a3d8, 0x40a3d709},
+{'q', 0xc1d47ae1, 0x00000000},
+{0, 0xc1d47ae1, 0xc20c28f5},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00430075, 0xffffffff},/*kerning  u C : -0.003906 */
+{'[', 0x00470075, 0xffffffff},/*kerning  u G : -0.003906 */
+{'[', 0x004f0075, 0xffffffff},/*kerning  u O : -0.003906 */
+{'[', 0x00510075, 0xffffffff},/*kerning  u Q : -0.003906 */
+{'[', 0x00540075, 0xffffffeb},/*kerning  u T : -0.082031 */
+{'[', 0x00550075, 0xfffffffe},/*kerning  u U : -0.007812 */
+{'[', 0x00560075, 0xfffffff5},/*kerning  u V : -0.042969 */
+{'[', 0x00570075, 0xfffffff5},/*kerning  u W : -0.042969 */
+{'[', 0x00590075, 0xffffffee},/*kerning  u Y : -0.070312 */
+{'[', 0x005c0075, 0xfffffff8},/*kerning  u \ : -0.031250 */
+{'[', 0x00c70075, 0xffffffff},/*kerning  u Ç : -0.003906 */
+{'[', 0x00d00075, 0xfffffffe},/*kerning  u Ð : -0.007812 */
+{'[', 0x00d20075, 0xffffffff},/*kerning  u Ò : -0.003906 */
+{'[', 0x00d30075, 0xffffffff},/*kerning  u Ó : -0.003906 */
+{'[', 0x00d40075, 0xffffffff},/*kerning  u Ô : -0.003906 */
+{'[', 0x00d50075, 0xffffffff},/*kerning  u Õ : -0.003906 */
+{'[', 0x00d60075, 0xffffffff},/*kerning  u Ö : -0.003906 */
+{'[', 0x00d80075, 0xffffffff},/*kerning  u Ø : -0.003906 */
+{'[', 0x00d90075, 0xfffffffe},/*kerning  u Ù : -0.007812 */
+{'[', 0x00da0075, 0xfffffffe},/*kerning  u Ú : -0.007812 */
+{'[', 0x00db0075, 0xfffffffe},/*kerning  u Û : -0.007812 */
+{'[', 0x00dc0075, 0xfffffffe},/*kerning  u Ü : -0.007812 */
+{'[', 0x00dd0075, 0xffffffee},/*kerning  u Ý : -0.070312 */
+{'@', 0x00000076, 0x00005600},/*        v        x-advance: 86.000000 */
+{'M', 0x420d70a4, 0x80000000},
+{'l', 0xc2033333, 0xc2a70a3d},
+{'l', 0x416b851c, 0x00000000},
+{'l', 0x41d1eb86, 0x428c28f5},
+{'l', 0x41d1eb86, 0xc28c28f5},
+{'4', 0x0000006e, 0x029cfefa},
+{'l', 0xc175c28c, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200076, 0xfffffffa},/*kerning  v   : -0.023438 */
+{'[', 0x00290076, 0xfffffffc},/*kerning  v ) : -0.015625 */
+{'[', 0x002c0076, 0xffffffee},/*kerning  v , : -0.070312 */
+{'[', 0x002d0076, 0xfffffffe},/*kerning  v - : -0.007812 */
+{'[', 0x002e0076, 0xffffffee},/*kerning  v . : -0.070312 */
+{'[', 0x002f0076, 0xfffffff6},/*kerning  v / : -0.039062 */
+{'[', 0x00400076, 0xfffffffe},/*kerning  v @ : -0.007812 */
+{'[', 0x00410076, 0xfffffff8},/*kerning  v A : -0.031250 */
+{'[', 0x004a0076, 0xffffffee},/*kerning  v J : -0.070312 */
+{'[', 0x00540076, 0xffffffeb},/*kerning  v T : -0.082031 */
+{'[', 0x00560076, 0xfffffffd},/*kerning  v V : -0.011719 */
+{'[', 0x00570076, 0xfffffffd},/*kerning  v W : -0.011719 */
+{'[', 0x00580076, 0xfffffff9},/*kerning  v X : -0.027344 */
+{'[', 0x00590076, 0xfffffff7},/*kerning  v Y : -0.035156 */
+{'[', 0x005a0076, 0xfffffffc},/*kerning  v Z : -0.015625 */
+{'[', 0x005c0076, 0xfffffffd},/*kerning  v \ : -0.011719 */
+{'[', 0x00610076, 0xfffffffd},/*kerning  v a : -0.011719 */
+{'[', 0x00630076, 0xfffffffc},/*kerning  v c : -0.015625 */
+{'[', 0x00640076, 0xfffffffc},/*kerning  v d : -0.015625 */
+{'[', 0x00650076, 0xfffffffc},/*kerning  v e : -0.015625 */
+{'[', 0x00670076, 0xfffffffc},/*kerning  v g : -0.015625 */
+{'[', 0x006f0076, 0xfffffffc},/*kerning  v o : -0.015625 */
+{'[', 0x00710076, 0xfffffffc},/*kerning  v q : -0.015625 */
+{'[', 0x00730076, 0xfffffffd},/*kerning  v s : -0.011719 */
+{'[', 0x00ab0076, 0xfffffffa},/*kerning  v « : -0.023438 */
+{'[', 0x00c00076, 0xfffffff8},/*kerning  v À : -0.031250 */
+{'[', 0x00c10076, 0xfffffff8},/*kerning  v Á : -0.031250 */
+{'[', 0x00c20076, 0xfffffff8},/*kerning  v Â : -0.031250 */
+{'[', 0x00c30076, 0xfffffff8},/*kerning  v Ã : -0.031250 */
+{'[', 0x00c40076, 0xfffffff8},/*kerning  v Ä : -0.031250 */
+{'[', 0x00c50076, 0xfffffff8},/*kerning  v Å : -0.031250 */
+{'[', 0x00c60076, 0xfffffff3},/*kerning  v Æ : -0.050781 */
+{'[', 0x00d00076, 0xfffffffe},/*kerning  v Ð : -0.007812 */
+{'[', 0x00dd0076, 0xfffffff7},/*kerning  v Ý : -0.035156 */
+{'[', 0x00e00076, 0xfffffffd},/*kerning  v à : -0.011719 */
+{'[', 0x00e10076, 0xfffffffd},/*kerning  v á : -0.011719 */
+{'[', 0x00e20076, 0xfffffffd},/*kerning  v â : -0.011719 */
+{'[', 0x00e30076, 0xfffffffd},/*kerning  v ã : -0.011719 */
+{'[', 0x00e40076, 0xfffffffd},/*kerning  v ä : -0.011719 */
+{'[', 0x00e50076, 0xfffffffd},/*kerning  v å : -0.011719 */
+{'[', 0x00e60076, 0xfffffffd},/*kerning  v æ : -0.011719 */
+{'[', 0x00e70076, 0xfffffffc},/*kerning  v ç : -0.015625 */
+{'[', 0x00e80076, 0xfffffffc},/*kerning  v è : -0.015625 */
+{'[', 0x00e90076, 0xfffffffc},/*kerning  v é : -0.015625 */
+{'[', 0x00ea0076, 0xfffffffc},/*kerning  v ê : -0.015625 */
+{'[', 0x00eb0076, 0xfffffffc},/*kerning  v ë : -0.015625 */
+{'[', 0x00f00076, 0xfffffffa},/*kerning  v ð : -0.023438 */
+{'[', 0x00f20076, 0xfffffffc},/*kerning  v ò : -0.015625 */
+{'[', 0x00f30076, 0xfffffffc},/*kerning  v ó : -0.015625 */
+{'[', 0x00f40076, 0xfffffffc},/*kerning  v ô : -0.015625 */
+{'[', 0x00f50076, 0xfffffffc},/*kerning  v õ : -0.015625 */
+{'[', 0x00f60076, 0xfffffffc},/*kerning  v ö : -0.015625 */
+{'[', 0x00f80076, 0xfffffffc},/*kerning  v ø : -0.015625 */
+{'@', 0x00000077, 0x00008300},/*        w        x-advance: 131.000000 */
+{'M', 0x42e80000, 0xc2a70a3d},
+{'l', 0x41599990, 0x00000000},
+{'l', 0xc20e147a, 0x42a70a3d},
+{'l', 0xc1451eb8, 0x80000000},
+{'l', 0xc18147ac, 0xc21d70a4},
+{'l', 0xc1800000, 0x421d70a4},
+{'l', 0xc1451eb8, 0x80000000},
+{'l', 0xc20e147b, 0xc2a70a3d},
+{'l', 0x41570a3f, 0x00000000},
+{'l', 0x41e66666, 0x428b3333},
+{'l', 0x41570a3c, 0xc208f5c3},
+{'l', 0xc16147ac, 0xc20ccccd},
+{'l', 0x41451eb8, 0x00000000},
+{'l', 0x411eb850, 0x41d47ae2},
+{'l', 0x411eb850, 0xc1d47ae2},
+{'l', 0x41451eb8, 0x00000000},
+{'4', 0x0119ff91, 0x0111006b},
+{'l', 0x41e51eb8, 0xc28b3332},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200077, 0xfffffff9},/*kerning  w   : -0.027344 */
+{'[', 0x00290077, 0xfffffffc},/*kerning  w ) : -0.015625 */
+{'[', 0x002c0077, 0xffffffee},/*kerning  w , : -0.070312 */
+{'[', 0x002d0077, 0xfffffffe},/*kerning  w - : -0.007812 */
+{'[', 0x002e0077, 0xffffffee},/*kerning  w . : -0.070312 */
+{'[', 0x002f0077, 0xfffffff5},/*kerning  w / : -0.042969 */
+{'[', 0x00410077, 0xfffffff8},/*kerning  w A : -0.031250 */
+{'[', 0x004a0077, 0xffffffed},/*kerning  w J : -0.074219 */
+{'[', 0x00540077, 0xffffffec},/*kerning  w T : -0.078125 */
+{'[', 0x00560077, 0xfffffffe},/*kerning  w V : -0.007812 */
+{'[', 0x00570077, 0xfffffffe},/*kerning  w W : -0.007812 */
+{'[', 0x00580077, 0xfffffffa},/*kerning  w X : -0.023438 */
+{'[', 0x00590077, 0xfffffff8},/*kerning  w Y : -0.031250 */
+{'[', 0x005a0077, 0xfffffffc},/*kerning  w Z : -0.015625 */
+{'[', 0x005c0077, 0xfffffffd},/*kerning  w \ : -0.011719 */
+{'[', 0x00610077, 0xfffffffd},/*kerning  w a : -0.011719 */
+{'[', 0x00630077, 0xfffffffc},/*kerning  w c : -0.015625 */
+{'[', 0x00640077, 0xfffffffc},/*kerning  w d : -0.015625 */
+{'[', 0x00650077, 0xfffffffc},/*kerning  w e : -0.015625 */
+{'[', 0x00670077, 0xfffffffc},/*kerning  w g : -0.015625 */
+{'[', 0x006f0077, 0xfffffffc},/*kerning  w o : -0.015625 */
+{'[', 0x00710077, 0xfffffffc},/*kerning  w q : -0.015625 */
+{'[', 0x00730077, 0xfffffffd},/*kerning  w s : -0.011719 */
+{'[', 0x00ab0077, 0xfffffff9},/*kerning  w « : -0.027344 */
+{'[', 0x00c00077, 0xfffffff8},/*kerning  w À : -0.031250 */
+{'[', 0x00c10077, 0xfffffff8},/*kerning  w Á : -0.031250 */
+{'[', 0x00c20077, 0xfffffff8},/*kerning  w Â : -0.031250 */
+{'[', 0x00c30077, 0xfffffff8},/*kerning  w Ã : -0.031250 */
+{'[', 0x00c40077, 0xfffffff8},/*kerning  w Ä : -0.031250 */
+{'[', 0x00c50077, 0xfffffff8},/*kerning  w Å : -0.031250 */
+{'[', 0x00c60077, 0xfffffff3},/*kerning  w Æ : -0.050781 */
+{'[', 0x00dd0077, 0xfffffff8},/*kerning  w Ý : -0.031250 */
+{'[', 0x00e00077, 0xfffffffd},/*kerning  w à : -0.011719 */
+{'[', 0x00e10077, 0xfffffffd},/*kerning  w á : -0.011719 */
+{'[', 0x00e20077, 0xfffffffd},/*kerning  w â : -0.011719 */
+{'[', 0x00e30077, 0xfffffffd},/*kerning  w ã : -0.011719 */
+{'[', 0x00e40077, 0xfffffffd},/*kerning  w ä : -0.011719 */
+{'[', 0x00e50077, 0xfffffffd},/*kerning  w å : -0.011719 */
+{'[', 0x00e60077, 0xfffffffd},/*kerning  w æ : -0.011719 */
+{'[', 0x00e70077, 0xfffffffc},/*kerning  w ç : -0.015625 */
+{'[', 0x00e80077, 0xfffffffc},/*kerning  w è : -0.015625 */
+{'[', 0x00e90077, 0xfffffffc},/*kerning  w é : -0.015625 */
+{'[', 0x00ea0077, 0xfffffffc},/*kerning  w ê : -0.015625 */
+{'[', 0x00eb0077, 0xfffffffc},/*kerning  w ë : -0.015625 */
+{'[', 0x00f00077, 0xfffffffa},/*kerning  w ð : -0.023438 */
+{'[', 0x00f20077, 0xfffffffc},/*kerning  w ò : -0.015625 */
+{'[', 0x00f30077, 0xfffffffc},/*kerning  w ó : -0.015625 */
+{'[', 0x00f40077, 0xfffffffc},/*kerning  w ô : -0.015625 */
+{'[', 0x00f50077, 0xfffffffc},/*kerning  w õ : -0.015625 */
+{'[', 0x00f60077, 0xfffffffc},/*kerning  w ö : -0.015625 */
+{'[', 0x00f80077, 0xfffffffc},/*kerning  w ø : -0.015625 */
+{'@', 0x00000078, 0x00005200},/*        x        x-advance: 82.000000 */
+{'M', 0x418ccccd, 0xc2a70a3d},
+{'l', 0x41b0a3d7, 0x41f5c28e},
+{'l', 0x3fa3d700, 0x4023d710},
+{'l', 0x3fb851e0, 0xc023d710},
+{'l', 0x41af5c2a, 0xc1f5c28e},
+{'l', 0x417ae148, 0x00000000},
+{'l', 0xc1f70a3e, 0x4227ae14},
+{'l', 0x41f851ea, 0x42266666},
+{'l', 0xc17ae148, 0x80000000},
+{'l', 0xc1b0a3d6, 0xc1f47ae1},
+{'l', 0xbfb851e0, 0xc0199998},
+{'l', 0xbfa3d700, 0x40199998},
+{'l', 0xc1b0a3d7, 0x41f47ae1},
+{'l', 0xc17ae148, 0x80000000},
+{'4', 0xfeb400f8, 0xfeb1ff09},
+{'l', 0x417851ec, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002d0078, 0xfffffffc},/*kerning  x - : -0.015625 */
+{'[', 0x00430078, 0xfffffffe},/*kerning  x C : -0.007812 */
+{'[', 0x00470078, 0xfffffffe},/*kerning  x G : -0.007812 */
+{'[', 0x004f0078, 0xfffffffe},/*kerning  x O : -0.007812 */
+{'[', 0x00510078, 0xfffffffe},/*kerning  x Q : -0.007812 */
+{'[', 0x00540078, 0xffffffed},/*kerning  x T : -0.074219 */
+{'[', 0x00560078, 0xfffffffe},/*kerning  x V : -0.007812 */
+{'[', 0x00570078, 0xfffffffd},/*kerning  x W : -0.011719 */
+{'[', 0x00590078, 0xfffffff9},/*kerning  x Y : -0.027344 */
+{'[', 0x00610078, 0xffffffff},/*kerning  x a : -0.003906 */
+{'[', 0x00630078, 0xfffffffa},/*kerning  x c : -0.023438 */
+{'[', 0x00640078, 0xfffffffb},/*kerning  x d : -0.019531 */
+{'[', 0x00650078, 0xfffffffa},/*kerning  x e : -0.023438 */
+{'[', 0x00670078, 0xfffffffb},/*kerning  x g : -0.019531 */
+{'[', 0x006f0078, 0xfffffffa},/*kerning  x o : -0.023438 */
+{'[', 0x00710078, 0xfffffffb},/*kerning  x q : -0.019531 */
+{'[', 0x00ab0078, 0xfffffff8},/*kerning  x « : -0.031250 */
+{'[', 0x00c70078, 0xfffffffe},/*kerning  x Ç : -0.007812 */
+{'[', 0x00d20078, 0xfffffffe},/*kerning  x Ò : -0.007812 */
+{'[', 0x00d30078, 0xfffffffe},/*kerning  x Ó : -0.007812 */
+{'[', 0x00d40078, 0xfffffffe},/*kerning  x Ô : -0.007812 */
+{'[', 0x00d50078, 0xfffffffe},/*kerning  x Õ : -0.007812 */
+{'[', 0x00d60078, 0xfffffffe},/*kerning  x Ö : -0.007812 */
+{'[', 0x00d80078, 0xfffffffe},/*kerning  x Ø : -0.007812 */
+{'[', 0x00dd0078, 0xfffffff9},/*kerning  x Ý : -0.027344 */
+{'[', 0x00e00078, 0xffffffff},/*kerning  x à : -0.003906 */
+{'[', 0x00e10078, 0xffffffff},/*kerning  x á : -0.003906 */
+{'[', 0x00e20078, 0xffffffff},/*kerning  x â : -0.003906 */
+{'[', 0x00e30078, 0xffffffff},/*kerning  x ã : -0.003906 */
+{'[', 0x00e40078, 0xffffffff},/*kerning  x ä : -0.003906 */
+{'[', 0x00e50078, 0xffffffff},/*kerning  x å : -0.003906 */
+{'[', 0x00e60078, 0xffffffff},/*kerning  x æ : -0.003906 */
+{'[', 0x00e70078, 0xfffffffa},/*kerning  x ç : -0.023438 */
+{'[', 0x00e80078, 0xfffffffa},/*kerning  x è : -0.023438 */
+{'[', 0x00e90078, 0xfffffffa},/*kerning  x é : -0.023438 */
+{'[', 0x00ea0078, 0xfffffffa},/*kerning  x ê : -0.023438 */
+{'[', 0x00eb0078, 0xfffffffa},/*kerning  x ë : -0.023438 */
+{'[', 0x00f00078, 0xfffffff9},/*kerning  x ð : -0.027344 */
+{'[', 0x00f20078, 0xfffffffa},/*kerning  x ò : -0.023438 */
+{'[', 0x00f30078, 0xfffffffa},/*kerning  x ó : -0.023438 */
+{'[', 0x00f40078, 0xfffffffa},/*kerning  x ô : -0.023438 */
+{'[', 0x00f50078, 0xfffffffa},/*kerning  x õ : -0.023438 */
+{'[', 0x00f60078, 0xfffffffa},/*kerning  x ö : -0.023438 */
+{'[', 0x00f80078, 0xfffffffa},/*kerning  x ø : -0.023438 */
+{'@', 0x00000079, 0x00005700},/*        y        x-advance: 87.000000 */
+{'M', 0x41733333, 0x41b5c28f},
+{'8', 0x03210110, 0x01190110},
+{'8', 0xf2230014, 0xca21f20f},
+{'9', 0xffd80012, 0xff8a0030},
+{'l', 0xc20d70a4, 0xc2a70a3d},
+{'l', 0x416e147c, 0x00000000},
+{'l', 0x41e147ae, 0x428a8f5c},
+{'4', 0xfdd600cb, 0x0000006f},
+{'l', 0xc2228f5c, 0x42d2e147},
+{'q', 0xc0051ec0, 0x40b33334},
+{0, 0xc0ee1480, 0x411d70a4},
+{'q', 0xc0ab851c, 0x4087ae18},
+{0, 0xc1651eb6, 0x4087ae18},
+{'8', 0xffe900f5, 0xfbe2fff4},
+{'l', 0x00000000, 0xc147ae16},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00200079, 0xfffffffa},/*kerning  y   : -0.023438 */
+{'[', 0x00290079, 0xfffffffc},/*kerning  y ) : -0.015625 */
+{'[', 0x002c0079, 0xffffffee},/*kerning  y , : -0.070312 */
+{'[', 0x002d0079, 0xfffffffe},/*kerning  y - : -0.007812 */
+{'[', 0x002e0079, 0xffffffee},/*kerning  y . : -0.070312 */
+{'[', 0x002f0079, 0xfffffff6},/*kerning  y / : -0.039062 */
+{'[', 0x00400079, 0xfffffffe},/*kerning  y @ : -0.007812 */
+{'[', 0x00410079, 0xfffffff8},/*kerning  y A : -0.031250 */
+{'[', 0x004a0079, 0xffffffee},/*kerning  y J : -0.070312 */
+{'[', 0x00540079, 0xffffffeb},/*kerning  y T : -0.082031 */
+{'[', 0x00560079, 0xfffffffd},/*kerning  y V : -0.011719 */
+{'[', 0x00570079, 0xfffffffd},/*kerning  y W : -0.011719 */
+{'[', 0x00580079, 0xfffffff9},/*kerning  y X : -0.027344 */
+{'[', 0x00590079, 0xfffffff7},/*kerning  y Y : -0.035156 */
+{'[', 0x005a0079, 0xfffffffc},/*kerning  y Z : -0.015625 */
+{'[', 0x005c0079, 0xfffffffd},/*kerning  y \ : -0.011719 */
+{'[', 0x00610079, 0xfffffffd},/*kerning  y a : -0.011719 */
+{'[', 0x00630079, 0xfffffffc},/*kerning  y c : -0.015625 */
+{'[', 0x00640079, 0xfffffffc},/*kerning  y d : -0.015625 */
+{'[', 0x00650079, 0xfffffffc},/*kerning  y e : -0.015625 */
+{'[', 0x00670079, 0xfffffffc},/*kerning  y g : -0.015625 */
+{'[', 0x006f0079, 0xfffffffc},/*kerning  y o : -0.015625 */
+{'[', 0x00710079, 0xfffffffc},/*kerning  y q : -0.015625 */
+{'[', 0x00730079, 0xfffffffd},/*kerning  y s : -0.011719 */
+{'[', 0x00ab0079, 0xfffffffa},/*kerning  y « : -0.023438 */
+{'[', 0x00c00079, 0xfffffff8},/*kerning  y À : -0.031250 */
+{'[', 0x00c10079, 0xfffffff8},/*kerning  y Á : -0.031250 */
+{'[', 0x00c20079, 0xfffffff8},/*kerning  y Â : -0.031250 */
+{'[', 0x00c30079, 0xfffffff8},/*kerning  y Ã : -0.031250 */
+{'[', 0x00c40079, 0xfffffff8},/*kerning  y Ä : -0.031250 */
+{'[', 0x00c50079, 0xfffffff8},/*kerning  y Å : -0.031250 */
+{'[', 0x00c60079, 0xfffffff3},/*kerning  y Æ : -0.050781 */
+{'[', 0x00d00079, 0xfffffffe},/*kerning  y Ð : -0.007812 */
+{'[', 0x00dd0079, 0xfffffff7},/*kerning  y Ý : -0.035156 */
+{'[', 0x00e00079, 0xfffffffd},/*kerning  y à : -0.011719 */
+{'[', 0x00e10079, 0xfffffffd},/*kerning  y á : -0.011719 */
+{'[', 0x00e20079, 0xfffffffd},/*kerning  y â : -0.011719 */
+{'[', 0x00e30079, 0xfffffffd},/*kerning  y ã : -0.011719 */
+{'[', 0x00e40079, 0xfffffffd},/*kerning  y ä : -0.011719 */
+{'[', 0x00e50079, 0xfffffffd},/*kerning  y å : -0.011719 */
+{'[', 0x00e60079, 0xfffffffd},/*kerning  y æ : -0.011719 */
+{'[', 0x00e70079, 0xfffffffc},/*kerning  y ç : -0.015625 */
+{'[', 0x00e80079, 0xfffffffc},/*kerning  y è : -0.015625 */
+{'[', 0x00e90079, 0xfffffffc},/*kerning  y é : -0.015625 */
+{'[', 0x00ea0079, 0xfffffffc},/*kerning  y ê : -0.015625 */
+{'[', 0x00eb0079, 0xfffffffc},/*kerning  y ë : -0.015625 */
+{'[', 0x00f00079, 0xfffffffa},/*kerning  y ð : -0.023438 */
+{'[', 0x00f20079, 0xfffffffc},/*kerning  y ò : -0.015625 */
+{'[', 0x00f30079, 0xfffffffc},/*kerning  y ó : -0.015625 */
+{'[', 0x00f40079, 0xfffffffc},/*kerning  y ô : -0.015625 */
+{'[', 0x00f50079, 0xfffffffc},/*kerning  y õ : -0.015625 */
+{'[', 0x00f60079, 0xfffffffc},/*kerning  y ö : -0.015625 */
+{'[', 0x00f80079, 0xfffffffc},/*kerning  y ø : -0.015625 */
+{'@', 0x0000007a, 0x00004e00},/*        z        x-advance: 78.000000 */
+{'M', 0x40999999, 0xc111eb85},
+{'l', 0x42528f5c, 0xc28051eb},
+{'l', 0xc24ccccc, 0x00000000},
+{'l', 0xb6000000, 0xc123d708},
+{'l', 0x4286147b, 0x00000000},
+{'l', 0x00000000, 0x4111eb80},
+{'l', 0xc25147ae, 0x428051ec},
+{'l', 0x4251eb84, 0xb6000000},
+{'4', 0x00510000, 0x0000fddb},
+{'l', 0xb6600000, 0xc111eb85},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002d007a, 0xfffffffd},/*kerning  z - : -0.011719 */
+{'[', 0x0054007a, 0xffffffea},/*kerning  z T : -0.085938 */
+{'[', 0x0055007a, 0xffffffff},/*kerning  z U : -0.003906 */
+{'[', 0x0056007a, 0xfffffffa},/*kerning  z V : -0.023438 */
+{'[', 0x0057007a, 0xfffffffa},/*kerning  z W : -0.023438 */
+{'[', 0x0059007a, 0xfffffff4},/*kerning  z Y : -0.046875 */
+{'[', 0x005c007a, 0xfffffffc},/*kerning  z \ : -0.015625 */
+{'[', 0x0063007a, 0xfffffffe},/*kerning  z c : -0.007812 */
+{'[', 0x0064007a, 0xfffffffe},/*kerning  z d : -0.007812 */
+{'[', 0x0065007a, 0xfffffffe},/*kerning  z e : -0.007812 */
+{'[', 0x0067007a, 0xfffffffe},/*kerning  z g : -0.007812 */
+{'[', 0x006f007a, 0xfffffffe},/*kerning  z o : -0.007812 */
+{'[', 0x0071007a, 0xfffffffe},/*kerning  z q : -0.007812 */
+{'[', 0x00ab007a, 0xfffffffa},/*kerning  z « : -0.023438 */
+{'[', 0x00d0007a, 0xfffffffe},/*kerning  z Ð : -0.007812 */
+{'[', 0x00d9007a, 0xffffffff},/*kerning  z Ù : -0.003906 */
+{'[', 0x00da007a, 0xffffffff},/*kerning  z Ú : -0.003906 */
+{'[', 0x00db007a, 0xffffffff},/*kerning  z Û : -0.003906 */
+{'[', 0x00dc007a, 0xffffffff},/*kerning  z Ü : -0.003906 */
+{'[', 0x00dd007a, 0xfffffff4},/*kerning  z Ý : -0.046875 */
+{'[', 0x00e7007a, 0xfffffffe},/*kerning  z ç : -0.007812 */
+{'[', 0x00e8007a, 0xfffffffe},/*kerning  z è : -0.007812 */
+{'[', 0x00e9007a, 0xfffffffe},/*kerning  z é : -0.007812 */
+{'[', 0x00ea007a, 0xfffffffe},/*kerning  z ê : -0.007812 */
+{'[', 0x00eb007a, 0xfffffffe},/*kerning  z ë : -0.007812 */
+{'[', 0x00f0007a, 0xfffffffd},/*kerning  z ð : -0.011719 */
+{'[', 0x00f2007a, 0xfffffffe},/*kerning  z ò : -0.007812 */
+{'[', 0x00f3007a, 0xfffffffe},/*kerning  z ó : -0.007812 */
+{'[', 0x00f4007a, 0xfffffffe},/*kerning  z ô : -0.007812 */
+{'[', 0x00f5007a, 0xfffffffe},/*kerning  z õ : -0.007812 */
+{'[', 0x00f6007a, 0xfffffffe},/*kerning  z ö : -0.007812 */
+{'[', 0x00f8007a, 0xfffffffe},/*kerning  z ø : -0.007812 */
+{'@', 0x0000007b, 0x00002b00},/*        {        x-advance: 43.000000 */
+{'M', 0x41d851eb, 0xc2d5c28f},
+{'l', 0x00000000, 0x421c28f6},
+{'8', 0x28f81100, 0x28e417f8},
+{'8', 0x281c1013, 0x29081708},
+{'l', 0x00000000, 0x42233333},
+{'4', 0x00000046, 0x005c0000},
+{'l', 0xc18f5c29, 0xb5000000},
+{'8', 0xf8ed00f8, 0xe2f6f8f6},
+{'l', 0x00000000, 0xc22d70a4},
+{'8', 0xcff2e400, 0xe7d9ebf2},
+{'l', 0x00000000, 0xc123d708},
+{'8', 0xe628001a, 0xd20de60d},
+{'l', 0x00000000, 0xc2266666},
+{'8', 0xe10be800, 0xf911f90b},
+{'4', 0x0000008f, 0x005c0000},
+{'l', 0xc10cccce, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x00c6007b, 0x00000003},/*kerning  { Æ : 0.011719 */
+{'@', 0x0000007c, 0x00002600},/*        |        x-advance: 38.000000 */
+{'M', 0x4151eb85, 0x41a66666},
+{'l', 0x00000000, 0xc310cccd},
+{'4', 0x00000061, 0x04860000},
+{'l', 0xc1428f5b, 0xb6800000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x006a007c, 0x0000000e},/*kerning  | j : 0.054688 */
+{'@', 0x0000007d, 0x00002b00},/*        }        x-advance: 43.000000 */
+{'M', 0x40f0a3d7, 0xc2d5c28f},
+{'4', 0xffa40000, 0x0000008f},
+{'8', 0x07110006, 0x1f0b070b},
+{'l', 0x00000000, 0x42266666},
+{'8', 0x2e0d1300, 0x1a281a0d},
+{'l', 0x00000000, 0x4123d708},
+{'8', 0x19d903e8, 0x31f215f2},
+{'l', 0x00000000, 0x422d70a4},
+{'8', 0x1ef61500, 0x08ed08f6},
+{'l', 0xc18f5c28, 0x00000000},
+{'4', 0xffa40000, 0x00000046},
+{'l', 0x00000000, 0xc2233333},
+{'8', 0xd708ef00, 0xd81ce908},
+{'8', 0xd8e4efec, 0xd8f8e9f8},
+{'l', 0x00000000, 0xc21c28f6},
+{'l', 0xc10ccccc, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x0000007e, 0x00005500},/*        ~        x-advance: 85.000000 */
+{'M', 0x41266666, 0xc217ae14},
+{'8', 0xe207f900, 0xd019e907},
+{'8', 0xd42ee711, 0xed46ed1c},
+{'8', 0x114a0028, 0x24431121},
+{'8', 0x12451221, 0xf1340021},
+{'8', 0xe01bf113, 0xed08f008},
+{'l', 0x41051eb8, 0x00000000},
+{'8', 0x18f90300, 0x2fe715f9},
+{'8', 0x2dd01aef, 0x13b613e2},
+{'8', 0xefb100d5, 0xddbdefdd},
+{'8', 0xefc0efe1, 0x11d000e2},
+{'8', 0x23e711ef, 0x13f911f9},
+{'l', 0xc1051eb8, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000a0, 0x00002800},/*                 x-advance: 40.000000 */
+{'M', 0x00000000, 0x00000000},
+{'@', 0x000000a1, 0x00002900},/*        ¡        x-advance: 41.000000 */
+{'M', 0x41deb852, 0xc2e47ae1},
+{'l', 0x00000000, 0x419eb850},
+{'4', 0x0000ff90, 0xff620000},
+{'l', 0x416147af, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41deb852, 0xc297ae14},
+{'l', 0x00000000, 0x4298a3d7},
+{'4', 0x0000ff90, 0xfd9e0000},
+{'l', 0x416147af, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000a2, 0x00005b00},/*        ¢        x-advance: 91.000000 */
+{'M', 0x4230a3d7, 0x41999999},
+{'l', 0x00000000, 0xc18e147a},
+{'q', 0xc1028f5c, 0xbf23d714},
+{0, 0xc170a3d8, 0xc08f5c2a},
+{'8', 0xb1a1e2c9, 0x96c2d0d8},
+{'q', 0xc02e147a, 0xc0e8f5c0},
+{0, 0xc02e147a, 0xc16f5c28},
+{'q', 0x00000000, 0xc12e147c},
+{0, 0x408f5c29, 0xc1a28f5c},
+{'q', 0x408f5c28, 0xc1170a40},
+{0, 0x414e147b, 0xc17ae148},
+{'9', 0xffcf0043, 0xffc400a0},
+{'4', 0xff6d0000, 0x00000038},
+{'l', 0x00000000, 0x41933334},
+{'q', 0x413ae148, 0x3ea3d700},
+{0, 0x41a0a3d8, 0x40b33330},
+{'9', 0x002a0043, 0x00740068},
+{'l', 0xc1599998, 0x408a3d70},
+{'8', 0xbbbed2e7, 0xe6a7e9d8},
+{'l', 0x00000000, 0x4275c28f},
+{'8', 0xf140fe1e, 0xdd3cf421},
+{'9', 0xffea001a, 0xffce0023},
+{'l', 0x415c28f0, 0x40851eb8},
+{'8', 0x5cbb37eb, 0x389b25d1},
+{'9', 0x0012ffca, 0x0012ff9c},
+{'4', 0x008c0000, 0x0000ffc8},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a8f5c2, 0xc2251eb8},
+{'8', 0x6a173800, 0x55413217},
+{'9', 0x00230029, 0x002d005f},
+{'l', 0x00000000, 0xc27147ad},
+{'8', 0x2b9d06c7, 0x5ac125d7},
+{'q', 0xc02e1480, 0x40d47ae0},
+{0, 0xc02e1480, 0x415d70a4},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000a3, 0x00005100},/*        £        x-advance: 81.000000 */
+{'M', 0x4107ae14, 0xc10f5c29},
+{'q', 0x41266666, 0xc11c28f5},
+{0, 0x416b851e, 0xc18a3d70},
+{'q', 0x408a3d70, 0xc0f0a3d8},
+{0, 0x408a3d70, 0xc175c290},
+{'9', 0xffe30000, 0xffc4fff9},
+{'4', 0x0000ff70, 0xffa90000},
+{'l', 0x416147ae, 0x00000000},
+{'8', 0x98cacbe6, 0x93e5cee5},
+{'q', 0x00000000, 0xc0f5c290},
+{0, 0x40828f5c, 0xc1600000},
+{'q', 0x40828f5c, 0xc0ca3d70},
+{0, 0x412f5c28, 0xc1200000},
+{'q', 0x40dc28f4, 0xc06b8500},
+{0, 0x41733332, 0xc06b8500},
+{'q', 0x410f5c2c, 0x00000000},
+{0, 0x418851ec, 0x408f5c20},
+{'9', 0x00230040, 0x00620069},
+{'l', 0xc0fae140, 0x410a3d70},
+{'8', 0xb0b0cfe2, 0xe29be2cf},
+{'8', 0x27a000c7, 0x61d927d9},
+{'8', 0x641c3400, 0x6836301c},
+{'4', 0x000000e5, 0x00570000},
+{'l', 0xc1c8f5c2, 0x00000000},
+{'q', 0x3f23d700, 0x40570a40},
+{0, 0x3f23d700, 0x40dc28f8},
+{'q', 0x00000000, 0x40fae148},
+{0, 0xc06147b0, 0x416e147a},
+{'q', 0xc06147b0, 0x40e147ac},
+{0, 0xc1428f5c, 0x41828f5c},
+{'8', 0xf45ef42f, 0x0b5d0034},
+{'8', 0x0b550b28, 0xfb330019},
+{'9', 0xfffb0019, 0xffef0039},
+{'l', 0x406147a0, 0x412b851e},
+{'q', 0xc10a3d70, 0x408a3d70},
+{0, 0xc18e147a, 0x408a3d70},
+{'8', 0xf8b700da, 0xf1b9f8dd},
+{'8', 0xf9b5f9dd, 0x06b900e0},
+{'9', 0x0006ffd9, 0x0010ffb6},
+{'l', 0xc06147b0, 0xc123d70a},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000a4, 0x00005600},/*        ¤        x-advance: 86.000000 */
+{'M', 0x41cccccc, 0xc29b851e},
+{'8', 0xdf3feb1c, 0xf54cf523},
+{'8', 0x0b4c0028, 0x213f0b23},
+{'4', 0xffa4005a, 0x00340034},
+{'l', 0xc13851f0, 0x413851f0},
+{'q', 0x40a8f5c0, 0x40f0a3d0},
+{0, 0x40a8f5c0, 0x418a3d70},
+{'9', 0x004c0000, 0x008affd5},
+{'4', 0x005c005d, 0x002effd2},
+{'l', 0xc13d70a4, 0xc130a3d8},
+{'8', 0x21c014e4, 0x0cb20cdd},
+{'8', 0xf4b200d6, 0xdfbff4dd},
+{'4', 0x0058ffa3, 0xffd2ffd2},
+{'l', 0x413851ea, 0xc13851ec},
+{'q', 0xc0a8f5c0, 0xc0fae148},
+{0, 0xc0a8f5c0, 0xc18a3d70},
+{'9', 0xffb10000, 0xff760028},
+{'4', 0xffa4ffa6, 0xffcc0034},
+{'l', 0x4135c28e, 0x413851f0},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41cb851e, 0xc2570a3d},
+{'8', 0x6e284100, 0x2c632c28},
+{'q', 0x40eb8518, 0x00000000},
+{0, 0x4147ae10, 0xc0b5c290},
+{'q', 0x40a3d710, 0xc0b5c290},
+{0, 0x40a3d710, 0xc1600000},
+{'8', 0x92d8be00, 0xd49dd4d8},
+{'q', 0xc0eb8520, 0x00000000},
+{0, 0xc147ae16, 0x40b33330},
+{'q', 0xc0a3d70c, 0x40b33330},
+{0, 0xc0a3d70c, 0x416147ac},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000a5, 0x00006d00},/*        ¥        x-advance: 109.000000 */
+{'M', 0x429147ae, 0xc27147ae},
+{'l', 0x414f5c28, 0x00000000},
+{'l', 0x00000000, 0x4119999c},
+{'l', 0xc191eb84, 0x00000000},
+{'l', 0xc0ae1480, 0x41147ae0},
+{'l', 0x00000000, 0x408f5c28},
+{'l', 0x41beb850, 0x00000000},
+{'l', 0x00000000, 0x4119999a},
+{'l', 0xc1beb850, 0x00000000},
+{'l', 0x00000000, 0x41dae147},
+{'l', 0xc1666664, 0x80000000},
+{'l', 0x00000000, 0xc1dae147},
+{'l', 0xc1bc28f6, 0x00000000},
+{'l', 0x00000000, 0xc119999a},
+{'l', 0x41bc28f6, 0x00000000},
+{'l', 0x00000000, 0xc0999998},
+{'l', 0xc0a3d710, 0xc10f5c28},
+{'l', 0xc1933332, 0x00000000},
+{'l', 0x00000000, 0xc119999c},
+{'l', 0x41547ae0, 0x00000000},
+{'l', 0xc2028f5c, 0xc2551eb8},
+{'l', 0x417ae148, 0x00000000},
+{'l', 0x42099999, 0x426ccccd},
+{'4', 0xfe270115, 0x0000007e},
+{'l', 0xc2028f5c, 0x42551eb8},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000a6, 0x00002600},/*        ¦        x-advance: 38.000000 */
+{'M', 0x41cb851e, 0xc2f80000},
+{'l', 0x00000000, 0x4280f5c2},
+{'4', 0x0000ff9f, 0xfdfd0000},
+{'l', 0x41428f5b, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41cb851e, 0xc22eb852},
+{'l', 0x00000000, 0x4280f5c2},
+{'4', 0x0000ff9f, 0xfdfd0000},
+{'l', 0x41428f5b, 0xb6800000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x006a00a6, 0x0000000d},/*kerning  ¦ j� : 0.050781 */
+{'@', 0x000000a7, 0x00005200},/*        §        x-advance: 82.000000 */
+{'M', 0x42899999, 0xc200a3d7},
+{'q', 0x40dc2900, 0x40947ae4},
+{0, 0x40dc2900, 0x41851eb8},
+{'8', 0x6ae83d00, 0x49bf2ce8},
+{'8', 0x2aaa1cd8, 0x0ea70ed2},
+{'q', 0xc0f5c290, 0x00000000},
+{0, 0xc1600000, 0xc0199998},
+{'8', 0xd0a9edce, 0xcac3e4db},
+{'l', 0x4111eb84, 0xc10a3d71},
+{'q', 0x4128f5c2, 0x41266667},
+{0, 0x41b851eb, 0x41266667},
+{'8', 0xf2490026, 0xd639f223},
+{'8', 0xbd16e416, 0xc0ebd500},
+{'8', 0xe4c9ebeb, 0xf8bef9df},
+{'q', 0xc163d70c, 0xbf4cccc0},
+{0, 0xc1b851ec, 0xc0f33330},
+{'q', 0xc10ccccd, 0xc0d99998},
+{0, 0xc10ccccd, 0xc198f5c2},
+{'8', 0xc209dd00, 0xd615e609},
+{'8', 0xc7d6ede8, 0xa7eedaee},
+{'q', 0x00000000, 0xc1028f58},
+{0, 0x4091eb85, 0xc168f5c0},
+{'q', 0x4091eb84, 0xc0ccccd0},
+{0, 0x413eb852, 0xc12147b0},
+{'q', 0x40eb851c, 0xc06b8500},
+{0, 0x417851ec, 0xc06b8500},
+{'q', 0x4107ae14, 0x00000000},
+{0, 0x41666664, 0x4023d700},
+{'8', 0x324f142f, 0x3e341e20},
+{'l', 0xc12e147c, 0x40a3d700},
+{'8', 0xc8c0d9ec, 0xf0a8f0d4},
+{'8', 0x219900c7, 0x5ad321d3},
+{'8', 0x592a4100, 0x196a182a},
+{'q', 0x40fae148, 0x00000000},
+{0, 0x4175c28c, 0x401eb840},
+{'q', 0x40f0a3d8, 0x401eb860},
+{0, 0x4147ae18, 0x41000000},
+{'q', 0x409eb850, 0x40b0a3d8},
+{0, 0x409eb850, 0x416f5c2c},
+{'8', 0x42f62300, 0x2fe81ef6},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41c8f5c2, 0xc2533333},
+{'8', 0x41112a00, 0x222e1711},
+{'8', 0x0e3d0a1c, 0x07400321},
+{'8', 0x0c36031f, 0xdd18f40f},
+{'8', 0xd308ea08, 0xbce8d500},
+{'8', 0xddc6e8e8, 0xf6bdf6de},
+{'8', 0xf09e00c6, 0x4ce41ce4},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000a8, 0x00003a00},/*        ¨        x-advance: 58.000000 */
+{'M', 0x4128f5c2, 0xc2c7ae14},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4211eb85, 0xc2c7ae14},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000a9, 0x00008500},/*        ©        x-advance: 133.000000 */
+{'M', 0x42851eb8, 0x3f8f5c29},
+{'q', 0xc14a3d70, 0x00000000},
+{0, 0xc1bb851e, 0xc08a3d71},
+{'q', 0xc12ccccc, 0xc08a3d70},
+{0, 0xc1966666, 0xc1428f5c},
+{'q', 0xc1000000, 0xc0fae144},
+{0, 0xc1466666, 0xc1933332},
+{'q', 0xc08ccccd, 0xc128f5c4},
+{0, 0xc08ccccd, 0xc1b851ec},
+{'q', 0x00000000, 0xc1451eb4},
+{0, 0x408ccccd, 0xc1b70a3a},
+{'q', 0x408ccccc, 0xc128f5c8},
+{0, 0x41466666, 0xc1928f60},
+{'q', 0x41000000, 0xc0f851e0},
+{0, 0x41966666, 0xc14147a8},
+{'q', 0x412ccccc, 0xc08a3d70},
+{0, 0x41bb851e, 0xc08a3d70},
+{'q', 0x414cccd0, 0x00000000},
+{0, 0x41bd70a4, 0x408a3d70},
+{'q', 0x412e1478, 0x408a3d70},
+{0, 0x4197ae14, 0x414147a8},
+{'q', 0x410147b0, 0x40f851f0},
+{0, 0x4148f5c0, 0x41928f60},
+{'q', 0x408f5c30, 0x4128f5c0},
+{0, 0x408f5c30, 0x41b70a3a},
+{'q', 0x00000000, 0x4147ae14},
+{0, 0xc08f5c30, 0x41b851ec},
+{'q', 0xc08f5c20, 0x4128f5c2},
+{0, 0xc148f5c0, 0x41933332},
+{'q', 0xc10147b0, 0x40fae149},
+{0, 0xc197ae14, 0x41428f5d},
+{'9', 0x0022ffa9, 0x0022ff43},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42851eb8, 0xc0bd70a4},
+{'q', 0x416b8520, 0x00000000},
+{0, 0x41d3d708, 0xc0cccccc},
+{'q', 0x413c28f8, 0xc0cccccc},
+{0, 0x4195c290, 0xc18eb852},
+{'q', 0x40deb850, 0xc1370a3c},
+{0, 0x40deb850, 0xc1d28f5c},
+{'q', 0x00000000, 0xc12e147c},
+{0, 0xc07ae140, 0xc1a147ae},
+{'q', 0xc07ae140, 0xc1147ae0},
+{0, 0xc12f5c28, 0xc18147b0},
+{'q', 0xc0e147b0, 0xc0dc28f0},
+{0, 0xc1847ae0, 0xc12b8520},
+{'q', 0xc11851f0, 0xc075c280},
+{0, 0xc1a5c290, 0xc075c280},
+{'q', 0xc130a3d4, 0x00000000},
+{0, 0xc1a3d708, 0x4075c280},
+{'q', 0xc1170a40, 0x4075c2a0},
+{0, 0xc1833334, 0x412b8520},
+{'q', 0xc0deb854, 0x40dc2900},
+{0, 0xc12e147c, 0x4180a3d8},
+{'q', 0xc07ae144, 0x41133338},
+{0, 0xc07ae144, 0x41a0a3d8},
+{'q', 0x00000000, 0x412b8520},
+{0, 0x4075c28c, 0x419f5c2a},
+{'q', 0x4075c290, 0x41133332},
+{0, 0x412e147a, 0x418147ad},
+{'q', 0x40e147b0, 0x40deb852},
+{0, 0x4183d70c, 0x412ccccc},
+{'9', 0x001e004b, 0x001e00a3},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4287ae14, 0xc19ae147},
+{'q', 0xc1266664, 0x00000000},
+{0, 0xc198f5c0, 0xc0970a3c},
+{'q', 0xc10b8520, 0xc0970a40},
+{0, 0xc15eb854, 0xc1533334},
+{'q', 0xc0a66668, 0xc107ae14},
+{0, 0xc0a66668, 0xc19c28f6},
+{'q', 0x00000000, 0xc1147ae4},
+{0, 0x40828f60, 0xc18eb852},
+{'q', 0x40828f58, 0xc108f5c0},
+{0, 0x41466664, 0xc1628f60},
+{'q', 0x41051eb8, 0xc0b33330},
+{0, 0x41a7ae16, 0xc0b33330},
+{'q', 0x41333330, 0x00000000},
+{0, 0x419e147c, 0x409999a0},
+{'9', 0x00260044, 0x006e0063},
+{'l', 0xc1599998, 0x408a3d70},
+{'8', 0xbbbccce8, 0xf0b1f0d4},
+{'8', 0x1e9b00c4, 0x4cc21ed7},
+{'8', 0x61ec2eec, 0x6d1c4000},
+{'8', 0x45482d1c, 0x1755172b},
+{'8', 0xe958002c, 0xbf40e92c},
+{'l', 0x41599998, 0x40851eb8},
+{'8', 0x45cf22f2, 0x3ba823dd},
+{'q', 0xc0d47ae0, 0x40428f58},
+{0, 0xc171eb88, 0x40428f58},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000aa, 0x00004600},/*        ª        x-advance: 70.000000 */
+{'M', 0x41d33333, 0xc25c28f5},
+{'8', 0xd89400c0, 0x9bd4d8d4},
+{'q', 0x00000000, 0xc1000000},
+{0, 0x40d70a3e, 0xc14f5c28},
+{'q', 0x40d70a3c, 0xc09eb860},
+{0, 0x4188f5c2, 0xc09eb860},
+{'9', 0x00000047, 0x0015007a},
+{'l', 0x00000000, 0xc0800000},
+{'8', 0xb0e3cd00, 0xe3ace3e3},
+{'8', 0x0db900dd, 0x27b70ddd},
+{'l', 0xc06b8520, 0xc0e66660},
+{'q', 0x41333334, 0xc0eb8520},
+{0, 0x41b5c28f, 0xc0eb8520},
+{'q', 0x413851ec, 0x00000000},
+{0, 0x4190a3d8, 0x40bd70a0},
+{'9', 0x002f0034, 0x00880034},
+{'l', 0x00000000, 0x41a7ae14},
+{'9', 0x001d0000, 0x001e001a},
+{'l', 0x00000000, 0x411eb850},
+{'8', 0x02eb01f4, 0x01ee01f8},
+{'8', 0xf2d400e4, 0xddeef2f0},
+{'l', 0xbe23d700, 0xc06b8510},
+{'8', 0x3db327e0, 0x159f15d3},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41eccccc, 0xc27e147b},
+{'8', 0xf3450025, 0xdd31f320},
+{'9', 0xfff10010, 0xffdf0010},
+{'l', 0x00000000, 0xc0f5c280},
+{'8', 0xf2ccf6e8, 0xfcc9fce4},
+{'8', 0x15a900cb, 0x3adf15df},
+{'8', 0x3a1a2200, 0x1741171a},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000ab, 0x00005f00},/*        «        x-advance: 95.000000 */
+{'M', 0x40cccccc, 0xc2333333},
+{'l', 0x4221eb84, 0xc1e7ae16},
+{'l', 0x00000000, 0x413d70a8},
+{'l', 0xc1e8f5c1, 0x41a3d70a},
+{'l', 0x41e8f5c1, 0x41a00000},
+{'4', 0x005e0000, 0xff22febd},
+{'l', 0xb6000000, 0xc0eb8520},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42347ae1, 0xc2333333},
+{'l', 0x4221eb85, 0xc1e7ae16},
+{'l', 0x00000000, 0x413d70a8},
+{'l', 0xc1e8f5c2, 0x41a3d70a},
+{'l', 0x41e8f5c2, 0x41a00000},
+{'4', 0x005e0000, 0xff22febd},
+{'l', 0x00000000, 0xc0eb8520},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x005400ab, 0xffffffec},/*kerning  « T� : -0.078125 */
+{'[', 0x005600ab, 0xfffffff8},/*kerning  « V� : -0.031250 */
+{'[', 0x005700ab, 0xfffffff8},/*kerning  « W� : -0.031250 */
+{'[', 0x005900ab, 0xfffffff2},/*kerning  « Y� : -0.054688 */
+{'[', 0x00dd00ab, 0xfffffff2},/*kerning  « Ý : -0.054688 */
+{'@', 0x000000ac, 0x00005e00},/*        ¬        x-advance: 94.000000 */
+{'M', 0x42a6b852, 0xc2700000},
+{'l', 0x00000000, 0x42233334},
+{'l', 0xc1428f60, 0xb6000000},
+{'l', 0x00000000, 0xc1e00001},
+{'4', 0x0000fe1d, 0xff9a0000},
+{'l', 0x429147ae, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000ad, 0x00005d00},/*        ­        x-advance: 93.000000 */
+{'M', 0x4123d70a, 0xc2151eb8},
+{'l', 0x00000000, 0xc14ccccc},
+{'4', 0x00000245, 0x00660000},
+{'l', 0xc29147ae, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000ae, 0x00008500},/*        ®        x-advance: 133.000000 */
+{'M', 0x428570a4, 0x3f8f5c29},
+{'q', 0xc14cccd0, 0x00000000},
+{0, 0xc1bcccce, 0xc08a3d71},
+{'q', 0xc12ccccc, 0xc08a3d70},
+{0, 0xc1966666, 0xc1428f5c},
+{'q', 0xc1000000, 0xc0fae144},
+{0, 0xc1466666, 0xc1933332},
+{'q', 0xc08ccccd, 0xc128f5c4},
+{0, 0xc08ccccd, 0xc1b851ec},
+{'q', 0x00000000, 0xc1451eb4},
+{0, 0x408ccccd, 0xc1b70a3a},
+{'q', 0x408ccccc, 0xc128f5c8},
+{0, 0x41466666, 0xc1928f60},
+{'q', 0x41000000, 0xc0f851e0},
+{0, 0x41966666, 0xc14147a8},
+{'q', 0x412ccccc, 0xc08a3d70},
+{0, 0x41bcccce, 0xc08a3d70},
+{'q', 0x414cccc8, 0x00000000},
+{0, 0x41bd70a0, 0x408a3d70},
+{'q', 0x412e1480, 0x408a3d70},
+{0, 0x41970a40, 0x414147a8},
+{'q', 0x41000000, 0x40f851f0},
+{0, 0x4147ae10, 0x41928f60},
+{'q', 0x408f5c30, 0x4128f5c0},
+{0, 0x408f5c30, 0x41b70a3a},
+{'q', 0x00000000, 0x4147ae14},
+{0, 0xc08f5c30, 0x41b851ec},
+{'q', 0xc08f5c20, 0x4128f5c2},
+{0, 0xc147ae10, 0x41933332},
+{'q', 0xc1000000, 0x40fae149},
+{0, 0xc1970a40, 0x41428f5d},
+{'9', 0x0022ffa9, 0x0022ff43},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x428570a4, 0xc0b851eb},
+{'q', 0x4168f5c0, 0x00000000},
+{0, 0x41d28f58, 0xc0cf5c29},
+{'q', 0x413c28f8, 0xc0cf5c28},
+{0, 0x41951eb8, 0xc18f5c29},
+{'q', 0x40dc2900, 0xc1370a3c},
+{0, 0x40dc2900, 0xc1d3d70a},
+{'q', 0x00000000, 0xc12b8520},
+{0, 0xc075c280, 0xc19f5c28},
+{'q', 0xc075c2a0, 0xc1133330},
+{0, 0xc12e1480, 0xc18147b0},
+{'q', 0xc0e147b0, 0xc0deb850},
+{0, 0xc183d708, 0xc12cccd0},
+{'q', 0xc1170a40, 0xc075c280},
+{0, 0xc1a51eb8, 0xc075c280},
+{'q', 0xc1333334, 0x00000000},
+{0, 0xc1a47ae2, 0x4075c280},
+{'q', 0xc115c290, 0x4075c2a0},
+{0, 0xc1828f5c, 0x412b8520},
+{'q', 0xc0deb854, 0x40dc2900},
+{0, 0xc12cccce, 0x4180a3d8},
+{'q', 0xc075c28c, 0x41133338},
+{0, 0xc075c28c, 0x419f5c2a},
+{'q', 0x00000000, 0x412b8520},
+{0, 0x4075c28c, 0x41a0a3d8},
+{'q', 0x4075c290, 0x4115c28e},
+{0, 0x412cccce, 0x4181eb84},
+{'q', 0x40deb850, 0x40dc28f6},
+{0, 0x41828f5c, 0x412ccccd},
+{'9', 0x001f004a, 0x001f00a4},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4227ae14, 0xc2b947ae},
+{'l', 0x41f5c290, 0x00000000},
+{'8', 0x1b5a0033, 0x453d1b27},
+{'8', 0x57162a16, 0x6bdf3a00},
+{'9', 0x0030ffdf, 0x003effa8},
+{'l', 0x418b851c, 0x41dc28f6},
+{'l', 0xc13ae148, 0x00000000},
+{'l', 0xc1828f5c, 0xc1cf5c28},
+{'l', 0xc18147ac, 0x00000000},
+{'4', 0x00cf0000, 0x0000ffad},
+{'l', 0x00000000, 0xc28fae14},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429051eb, 0xc25f5c29},
+{'8', 0xe147002e, 0xb218e118},
+{'8', 0xb2e4d000, 0xe2b9e2e4},
+{'4', 0x0000ff66, 0x00da0000},
+{'l', 0x419eb850, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000af, 0x00004000},/*        ¯        x-advance: 64.000000 */
+{'M', 0x410f5c29, 0xc2d147ae},
+{'l', 0x00000000, 0xc1147ae0},
+{'4', 0x00000175, 0x004a0000},
+{'l', 0xc23ae148, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000b0, 0x00002b00},/*        °        x-advance: 43.000000 */
+{'M', 0x40f0a3d7, 0xc2cbd70a},
+{'8', 0xb121d100, 0xe050e021},
+{'8', 0x20510030, 0x4f202020},
+{'8', 0x53e03300, 0x20af20e0},
+{'8', 0xdfb000d1, 0xaddfdfdf},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4187ae14, 0xc2d4cccc},
+{'8', 0x26f111f1, 0x250f1500},
+{'8', 0x10261010, 0xf0260018},
+{'8', 0xdb0ff10f, 0xdaf1ec00},
+{'8', 0xf1daf1f4, 0x0fda00e9},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x003000b0, 0xfffffffc},/*kerning  ° 0� : -0.015625 */
+{'[', 0x003300b0, 0xfffffffc},/*kerning  ° 3� : -0.015625 */
+{'[', 0x003400b0, 0xffffffeb},/*kerning  ° 4� : -0.082031 */
+{'[', 0x003500b0, 0xfffffffc},/*kerning  ° 5� : -0.015625 */
+{'[', 0x003900b0, 0xfffffff9},/*kerning  ° 9� : -0.027344 */
+{'@', 0x000000b1, 0x00004a00},/*        ±        x-advance: 74.000000 */
+{'M', 0x427f5c29, 0xc28147ae},
+{'l', 0x00000000, 0x413851ec},
+{'l', 0xc1a147ae, 0x00000000},
+{'l', 0x00000000, 0x41ae147b},
+{'l', 0xc14cccce, 0x00000000},
+{'l', 0x00000000, 0xc1ae147b},
+{'l', 0xc1a147ae, 0x00000000},
+{'l', 0x00000000, 0xc13851ec},
+{'l', 0x41a147ae, 0x00000000},
+{'l', 0x00000000, 0xc1ae147c},
+{'4', 0x00000066, 0x00ae0000},
+{'l', 0x41a147ae, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x412b851e, 0xc1028f5c},
+{'l', 0x00000000, 0xc13851ec},
+{'4', 0x000001a8, 0x005c0000},
+{'l', 0xc2547ae2, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000b2, 0x00003f00},/*        ²        x-advance: 63.000000 */
+{'M', 0x40ae147b, 0xc2800000},
+{'q', 0x00000000, 0xc14a3d70},
+{0, 0x409c28f5, 0xc19a3d70},
+{'q', 0x409c28f6, 0xc0d47ae0},
+{0, 0x41770a3e, 0xc12cccc8},
+{'8', 0xe24ff127, 0xda43f128},
+{'8', 0xc41ae91a, 0xc2e1db00},
+{'8', 0xe8a4e8e1, 0x179b00c3},
+{'9', 0x0017ffd9, 0x002cffc4},
+{'l', 0xc0b851ec, 0xc0c7ae10},
+{'8', 0xe023f508, 0xdb48eb1a},
+{'q', 0x40b851e8, 0xc0051ec0},
+{0, 0x41599998, 0xc0051ec0},
+{'q', 0x41400000, 0x00000000},
+{0, 0x4190a3d8, 0x40b0a3e0},
+{'q', 0x40c28f58, 0x40b0a3d0},
+{0, 0x40c28f58, 0x41628f58},
+{'8', 0x55e33500, 0x31b920e3},
+{'8', 0x1cb411d7, 0x409919b2},
+{'9', 0x0026ffe8, 0x0047ffe8},
+{'4', 0x00000127, 0x00450000},
+{'l', 0xc24b851f, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000b3, 0x00003f00},/*        ³        x-advance: 63.000000 */
+{'M', 0x41f33333, 0xc27c28f5},
+{'q', 0xc11eb852, 0x00000000},
+{0, 0xc1866666, 0xc06b8530},
+{'9', 0xffe3ffc9, 0xffb0ffbd},
+{'l', 0x40a3d70a, 0xc0c28f60},
+{'8', 0x26171102, 0x22371414},
+{'8', 0x0e510e23, 0xea65003c},
+{'8', 0xc429ea29, 0xc0cdd600},
+{'9', 0xffeaffcd, 0xffeaff76},
+{'4', 0x0000ffe3, 0xffbf0000},
+{'l', 0x406b8520, 0x00000000},
+{'q', 0x411eb850, 0x00000000},
+{0, 0x417c28f4, 0xc01eb860},
+{'8', 0xc52eed2e, 0xc4d9da00},
+{'8', 0xeba8ebd9, 0x13a800cd},
+{'9', 0x0013ffdb, 0x0031ffc6},
+{'l', 0xc0bd70a3, 0xc0dc28f0},
+{'q', 0x404cccce, 0xc0947ae0},
+{0, 0x411eb852, 0xc0e8f5c0},
+{'q', 0x40d70a3c, 0xc028f5c0},
+{0, 0x41666666, 0xc028f5c0},
+{'8', 0x1268003a, 0x3348122d},
+{'8', 0x491a201a, 0x48e22b00},
+{'8', 0x28a91ce2, 0x2e60083c},
+{'8', 0x57232523, 0x4ee22e00},
+{'8', 0x31b220e2, 0x109810d0},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000b4, 0x00002500},/*        ´        x-advance: 37.000000 */
+{'M', 0x4187ae14, 0xc2c2e147},
+{'l', 0xc1147ae0, 0xc04ccce0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147ae, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000b5, 0x00006400},/*        µ        x-advance: 100.000000 */
+{'M', 0x4147ae14, 0xc2a70a3d},
+{'4', 0x00000070, 0x017a0000},
+{'q', 0x00000000, 0x41cccccd},
+{0, 0x4190a3d7, 0x41cccccd},
+{'q', 0x4107ae14, 0x00000000},
+{0, 0x4180a3d8, 0xc0b0a3d8},
+{'9', 0xffd4003c, 0xff88005a},
+{'4', 0xfe5e0000, 0x00000070},
+{'l', 0x00000000, 0x42847ae1},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x41428f5c},
+{'8', 0x03e202ed, 0x00eb00f5},
+{'8', 0xe9c600dd, 0xcbeae9ea},
+{'l', 0x00000000, 0xc10ccccd},
+{'8', 0x4cc728ec, 0x39ac23db},
+{'8', 0x159e15d1, 0xe3a200c6},
+{'9', 0xffe3ffdd, 0xffbbffcf},
+{'4', 0x01650006, 0x0000ff90},
+{'l', 0x00000000, 0xc2eae147},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000b6, 0x00006200},/*        ¶        x-advance: 98.000000 */
+{'M', 0x40b33333, 0xc294cccd},
+{'q', 0x00000000, 0xc1947ae0},
+{0, 0x413eb850, 0xc1e70a3c},
+{'9', 0xffae005f, 0xffae0109},
+{'l', 0x42247ae2, 0x00000000},
+{'l', 0x00000000, 0x412e1478},
+{'l', 0xc1333330, 0x00000000},
+{'l', 0x00000000, 0x42e70a3e},
+{'l', 0xc1428f60, 0xb6800000},
+{'l', 0x00000000, 0xc2428f5c},
+{'l', 0xc12b851c, 0x00000000},
+{'4', 0x01850000, 0x0000ff9f},
+{'l', 0x00000000, 0xc2428f5c},
+{'q', 0xc1933333, 0xbea3d700},
+{0, 0xc1e99999, 0xc12a3d70},
+{'9', 0xffaeffaa, 0xff21ffaa},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x418ccccd, 0xc29570a4},
+{'q', 0x00000000, 0x4111eb88},
+{0, 0x4075c288, 0x4171eb88},
+{'8', 0x4951301e, 0x1d6f1933},
+{'l', 0x00000000, 0xc2600001},
+{'q', 0xc1599998, 0x3e23d800},
+{0, 0xc1a66666, 0x40f5c2a0},
+{'9', 0x003cffc7, 0x00a2ffc7},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4288f5c2, 0xc2cd70a4},
+{'l', 0xc12b851c, 0x00000000},
+{'4', 0x01c00000, 0x00000055},
+{'l', 0x00000000, 0xc2600001},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000b7, 0x00002000},/*        ·        x-advance: 32.000000 */
+{'M', 0x4123d70a, 0xc21ccccd},
+{'l', 0x00000000, 0xc19eb850},
+{'4', 0x0000005e, 0x009e0000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x003300b7, 0xfffffffc},/*kerning  · 3� : -0.015625 */
+{'[', 0x003700b7, 0xfffffff9},/*kerning  · 7� : -0.027344 */
+{'[', 0x006c00b7, 0xfffffff6},/*kerning  · l� : -0.039062 */
+{'@', 0x000000b8, 0x00002f00},/*        ¸        x-advance: 47.000000 */
+{'M', 0x41beb852, 0x41ee147b},
+{'8', 0xf8b800df, 0xe6b4f8d9},
+{'l', 0x4075c290, 0xc0fae144},
+{'8', 0x14300c19, 0x07320716},
+{'8', 0xf03d0027, 0xd215f015},
+{'8', 0xc8eae000, 0xd0c1e8ea},
+{'l', 0x40a3d70c, 0xc06b851e},
+{'8', 0x42541f34, 0x57202220},
+{'8', 0x53dd3400, 0x1e9d1edd},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000b9, 0x00002c00},/*        ¹        x-advance: 44.000000 */
+{'M', 0x4225c28f, 0xc2919999},
+{'l', 0x00000000, 0x410cccc8},
+{'l', 0xc2066666, 0x00000000},
+{'4', 0xffba0000, 0x00000066},
+{'l', 0x00000000, 0xc23c28f6},
+{'8', 0x19e20af8, 0x1ad20feb},
+{'9', 0x000affe8, 0x000affd3},
+{'l', 0x00000000, 0xc10cccc8},
+{'8', 0xef37001a, 0xdd2fef1c},
+{'9', 0xffef0013, 0xffed0013},
+{'4', 0x00000047, 0x01c70000},
+{'l', 0x413d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000ba, 0x00004700},/*        º        x-advance: 71.000000 */
+{'M', 0x420f5c29, 0xc25c28f5},
+{'q', 0xc10cccce, 0x00000000},
+{0, 0xc175c290, 0xc0828f58},
+{'q', 0xc0d1eb84, 0xc0828f60},
+{0, 0xc1228f5c, 0xc12cccd0},
+{'q', 0xc0666666, 0xc0d70a40},
+{0, 0xc0666666, 0xc1666668},
+{'q', 0x00000000, 0xc1000000},
+{0, 0x406b851e, 0xc16b8518},
+{'q', 0x406b8520, 0xc0d70a40},
+{0, 0x4123d70a, 0xc12b8520},
+{'q', 0x40d1eb84, 0xc0800000},
+{0, 0x41733334, 0xc0800000},
+{'q', 0x410ccccc, 0x00000000},
+{0, 0x41747ae0, 0x40800000},
+{'q', 0x40cf5c28, 0x40800000},
+{0, 0x41228f5c, 0x412b8520},
+{'q', 0x406b8520, 0x40d70a30},
+{0, 0x406b8520, 0x416b8518},
+{'q', 0x00000000, 0x40f5c290},
+{0, 0xc0666660, 0x41666668},
+{'q', 0xc0666670, 0x40d70a40},
+{0, 0xc1228f60, 0x412cccd0},
+{'9', 0x0020ffcc, 0x0020ff86},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4191eb85, 0xc2a851eb},
+{'8', 0x6e284100, 0x2c632c28},
+{'q', 0x40eb8520, 0x00000000},
+{0, 0x4147ae14, 0xc0b5c290},
+{'q', 0x40a3d708, 0xc0b5c290},
+{0, 0x40a3d708, 0xc1600000},
+{'8', 0x92d8be00, 0xd49dd4d8},
+{'q', 0xc0eb8520, 0x00000000},
+{0, 0xc147ae14, 0x40b33330},
+{'q', 0xc0a3d70c, 0x40b33330},
+{0, 0xc0a3d70c, 0x416147b0},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000bb, 0x00005f00},/*        »        x-advance: 95.000000 */
+{'M', 0x42b1eb85, 0xc215c28f},
+{'l', 0xc221eb85, 0x41deb852},
+{'l', 0x00000000, 0xc13d70a4},
+{'l', 0x41e8f5c2, 0xc1a00000},
+{'l', 0xc1e8f5c2, 0xc1a3d70a},
+{'4', 0xffa20000, 0x00e70143},
+{'l', 0x00000000, 0x40eb8520},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4248f5c2, 0xc215c28f},
+{'l', 0xc221eb84, 0x41deb852},
+{'l', 0xb6000000, 0xc13d70a4},
+{'l', 0x41e8f5c1, 0xc1a00000},
+{'l', 0xc1e8f5c1, 0xc1a3d70a},
+{'4', 0xffa20000, 0x00e70143},
+{'l', 0x00000000, 0x40eb8520},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200bb, 0xfffffffb},/*kerning  » "� : -0.019531 */
+{'[', 0x002700bb, 0xfffffffb},/*kerning  » '� : -0.019531 */
+{'[', 0x004100bb, 0xfffffffd},/*kerning  » A� : -0.011719 */
+{'[', 0x004a00bb, 0xfffffffc},/*kerning  » J� : -0.015625 */
+{'[', 0x005400bb, 0xffffffeb},/*kerning  » T� : -0.082031 */
+{'[', 0x005600bb, 0xfffffff3},/*kerning  » V� : -0.050781 */
+{'[', 0x005700bb, 0xfffffff3},/*kerning  » W� : -0.050781 */
+{'[', 0x005800bb, 0xfffffffa},/*kerning  » X� : -0.023438 */
+{'[', 0x005900bb, 0xffffffec},/*kerning  » Y� : -0.078125 */
+{'[', 0x005a00bb, 0xfffffffe},/*kerning  » Z� : -0.007812 */
+{'[', 0x006600bb, 0xfffffffd},/*kerning  » f� : -0.011719 */
+{'[', 0x007400bb, 0xfffffffd},/*kerning  » t� : -0.011719 */
+{'[', 0x007600bb, 0xfffffffa},/*kerning  » v� : -0.023438 */
+{'[', 0x007700bb, 0xfffffff9},/*kerning  » w� : -0.027344 */
+{'[', 0x007800bb, 0xfffffff8},/*kerning  » x� : -0.031250 */
+{'[', 0x007900bb, 0xfffffff9},/*kerning  » y� : -0.027344 */
+{'[', 0x007a00bb, 0xfffffffa},/*kerning  » z� : -0.023438 */
+{'[', 0x00c000bb, 0xfffffffd},/*kerning  » À : -0.011719 */
+{'[', 0x00c100bb, 0xfffffffd},/*kerning  » Á : -0.011719 */
+{'[', 0x00c200bb, 0xfffffffd},/*kerning  » Â : -0.011719 */
+{'[', 0x00c300bb, 0xfffffffd},/*kerning  » Ã : -0.011719 */
+{'[', 0x00c400bb, 0xfffffffd},/*kerning  » Ä : -0.011719 */
+{'[', 0x00c500bb, 0xfffffffd},/*kerning  » Å : -0.011719 */
+{'[', 0x00c600bb, 0xfffffffd},/*kerning  » Æ : -0.011719 */
+{'[', 0x00dd00bb, 0xffffffec},/*kerning  » Ý : -0.078125 */
+{'[', 0x00fd00bb, 0xfffffff9},/*kerning  » ý : -0.027344 */
+{'[', 0x00ff00bb, 0xfffffff9},/*kerning  » ÿ : -0.027344 */
+{'@', 0x000000bc, 0x00008400},/*        ¼        x-advance: 132.000000 */
+{'M', 0x4225c28f, 0xc2700000},
+{'l', 0x00000000, 0x410cccd0},
+{'l', 0xc2066666, 0x00000000},
+{'4', 0xffba0000, 0x00000066},
+{'l', 0x00000000, 0xc23c28f6},
+{'8', 0x19e20af8, 0x1ad20feb},
+{'9', 0x000affe8, 0x000affd3},
+{'l', 0x00000000, 0xc10cccd0},
+{'8', 0xef37001a, 0xdd2fef1c},
+{'9', 0xffef0013, 0xffed0013},
+{'4', 0x00000047, 0x01c70000},
+{'l', 0x413d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x412e147b, 0xc0a8f5c2},
+{'l', 0x42333333, 0xc257ae14},
+{'l', 0x422b851e, 0xc25ccccc},
+{'l', 0x40dc28f0, 0x40bd70a0},
+{'4', 0x01acfe9e, 0x01bdfea4},
+{'l', 0xc0d70a42, 0xc0c28f5a},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42da8f5c, 0x80000000},
+{'l', 0x00000000, 0xc1800000},
+{'l', 0xc210a3d8, 0x00000000},
+{'l', 0x00000000, 0xc107ae14},
+{'l', 0x421b8520, 0xc221eb85},
+{'l', 0x40c28f50, 0x00000000},
+{'l', 0x00000000, 0x422147ae},
+{'l', 0x41170a40, 0x00000000},
+{'l', 0x00000000, 0x410a3d70},
+{'4', 0x0000ffb5, 0x00800000},
+{'l', 0xc10cccc8, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42a47ae1, 0xc1c51eb8},
+{'4', 0x000000da, 0xff1a0000},
+{'l', 0xc1dae148, 0x41e66666},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000bd, 0x00008500},/*        ½        x-advance: 133.000000 */
+{'M', 0x4225c28f, 0xc2700000},
+{'l', 0x00000000, 0x410cccd0},
+{'l', 0xc2066666, 0x00000000},
+{'4', 0xffba0000, 0x00000066},
+{'l', 0x00000000, 0xc23c28f6},
+{'8', 0x19e20af8, 0x1ad20feb},
+{'9', 0x000affe8, 0x000affd3},
+{'l', 0x00000000, 0xc10cccd0},
+{'8', 0xef37001a, 0xdd2fef1c},
+{'9', 0xffef0013, 0xffed0013},
+{'4', 0x00000047, 0x01c70000},
+{'l', 0x413d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x412e147b, 0xc0a8f5c2},
+{'l', 0x42333333, 0xc257ae14},
+{'l', 0x422b851e, 0xc25ccccc},
+{'l', 0x40dc28f0, 0x40bd70a0},
+{'4', 0x01acfe9e, 0x01bdfea4},
+{'l', 0xc0d70a42, 0xc0c28f5a},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4299eb85, 0x80000000},
+{'q', 0x00000000, 0xc14a3d70},
+{0, 0x40970a40, 0xc19a3d70},
+{'q', 0x40970a40, 0xc0d47ae4},
+{0, 0x416f5c28, 0xc12cccce},
+{'8', 0xe24cf126, 0xdb40f226},
+{'8', 0xc419e919, 0xc1e2da00},
+{'8', 0xe8a8e8e2, 0x179f00c6},
+{'9', 0x0017ffda, 0x002dffc6},
+{'l', 0xc0ae1480, 0xc0ccccc8},
+{'8', 0xe021f507, 0xdb46eb1a},
+{'q', 0x40b0a3d0, 0xc0051ec0},
+{0, 0x41533330, 0xc0051ec0},
+{'q', 0x413851f0, 0x00000000},
+{0, 0x418ae148, 0x40b0a3e0},
+{'q', 0x40bae150, 0x40b0a3d8},
+{0, 0x40bae150, 0x41651eb8},
+{'8', 0x55e43500, 0x30bd1fe4},
+{'8', 0x1cb811d9, 0x409d19b4},
+{'9', 0x0026ffe9, 0x0047ffe9},
+{'4', 0x00000125, 0x00450000},
+{'l', 0xc248f5c2, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000be, 0x00009600},/*        ¾        x-advance: 150.000000 */
+{'M', 0x41f33333, 0xc248f5c2},
+{'q', 0xc11eb852, 0x00000000},
+{0, 0xc1866666, 0xc06b8520},
+{'9', 0xffe3ffc9, 0xffb0ffbd},
+{'l', 0x40a3d70a, 0xc0c28f60},
+{'8', 0x26171102, 0x22371414},
+{'8', 0x0e510e23, 0xea65003c},
+{'8', 0xc429ea29, 0xc0cdd600},
+{'9', 0xffeaffcd, 0xffeaff76},
+{'4', 0x0000ffe3, 0xffbf0000},
+{'l', 0x406b8520, 0x00000000},
+{'q', 0x411eb850, 0x00000000},
+{0, 0x417c28f4, 0xc01eb840},
+{'8', 0xc52eed2e, 0xc4d9da00},
+{'8', 0xeba8ebd9, 0x13a800cd},
+{'9', 0x0013ffdb, 0x0031ffc6},
+{'l', 0xc0bd70a3, 0xc0dc2900},
+{'q', 0x404cccce, 0xc0947ae0},
+{0, 0x411eb852, 0xc0e8f5c0},
+{'q', 0x40d70a3c, 0xc028f5c0},
+{0, 0x41666666, 0xc028f5c0},
+{'8', 0x1268003a, 0x3348122d},
+{'8', 0x491a201a, 0x48e22b00},
+{'8', 0x28a91ce2, 0x2e60083c},
+{'8', 0x57232523, 0x4ee22e00},
+{'8', 0x31b220e2, 0x109810d0},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41e8f5c2, 0xc0a8f5c2},
+{'l', 0x42333333, 0xc257ae14},
+{'l', 0x422b851e, 0xc25ccccc},
+{'l', 0x40dc2900, 0x40bd70a0},
+{'4', 0x01acfe9e, 0x01bdfea4},
+{'l', 0xc0d70a40, 0xc0c28f5a},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42ff0a3d, 0x80000000},
+{'l', 0x00000000, 0xc1800000},
+{'l', 0xc210a3d6, 0x00000000},
+{'l', 0x00000000, 0xc107ae14},
+{'l', 0x421b851c, 0xc221eb85},
+{'l', 0x40c28f60, 0x00000000},
+{'l', 0x00000000, 0x422147ae},
+{'l', 0x41170a40, 0x00000000},
+{'l', 0x00000000, 0x410a3d70},
+{'4', 0x0000ffb5, 0x00800000},
+{'l', 0xc10cccc8, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42c8f5c2, 0xc1c51eb8},
+{'4', 0x000000da, 0xff1a0000},
+{'l', 0xc1dae148, 0x41e66666},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000000bf, 0x00004b00},/*        ¿        x-advance: 75.000000 */
+{'M', 0x42528f5c, 0xc2a1eb85},
+{'l', 0x00000000, 0x41947ae2},
+{'4', 0x0000ffa2, 0xff6c0000},
+{'l', 0x413d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4253d70a, 0xc23ccccd},
+{'q', 0x00000000, 0x410a3d74},
+{0, 0xc0428f60, 0x4171eb88},
+{'8', 0x58ad33e8, 0x20cb0fe9},
+{'8', 0x27c710e2, 0x35d316e5},
+{'8', 0x4aef1fef, 0x50162f00},
+{'8', 0x313a2116, 0x104c1024},
+{'q', 0x41000000, 0x00000000},
+{0, 0x4163d70c, 0xc091eb84},
+{'9', 0xffdc0031, 0xffab004b},
+{'l', 0x41170a3c, 0x40c7ae14},
+{'q', 0xc08a3d70, 0x411c28f5},
+{0, 0xc1599998, 0x41733333},
+{'q', 0xc1147ae0, 0x40ae1478},
+{0, 0xc19eb852, 0x40ae1478},
+{'q', 0xc0fae148, 0x00000000},
+{0, 0xc1733334, 0xc051eb80},
+{'q', 0xc0eb851c, 0xc051eb88},
+{0, 0xc13ffffe, 0xc1228f5c},
+{'q', 0xc0947ae2, 0xc0dc28f6},
+{0, 0xc0947ae2, 0xc18a3d70},
+{'8', 0x9616bf00, 0xbc3ad816},
+{'8', 0xce4fe524, 0xdb3cef20},
+{'8', 0xcc2eed1c, 0xa812e012},
+{'l', 0x413d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004200bf, 0xfffffffd},/*kerning  ¿ B� : -0.011719 */
+{'[', 0x004300bf, 0xfffffffa},/*kerning  ¿ C� : -0.023438 */
+{'[', 0x004400bf, 0xfffffffd},/*kerning  ¿ D� : -0.011719 */
+{'[', 0x004500bf, 0xfffffffd},/*kerning  ¿ E� : -0.011719 */
+{'[', 0x004600bf, 0xfffffffd},/*kerning  ¿ F� : -0.011719 */
+{'[', 0x004700bf, 0xfffffffa},/*kerning  ¿ G� : -0.023438 */
+{'[', 0x004800bf, 0xfffffffd},/*kerning  ¿ H� : -0.011719 */
+{'[', 0x004900bf, 0xfffffffd},/*kerning  ¿ I� : -0.011719 */
+{'[', 0x004a00bf, 0xfffffffc},/*kerning  ¿ J� : -0.015625 */
+{'[', 0x004b00bf, 0xfffffffd},/*kerning  ¿ K� : -0.011719 */
+{'[', 0x004c00bf, 0xfffffffd},/*kerning  ¿ L� : -0.011719 */
+{'[', 0x004d00bf, 0xfffffffd},/*kerning  ¿ M� : -0.011719 */
+{'[', 0x004e00bf, 0xfffffffd},/*kerning  ¿ N� : -0.011719 */
+{'[', 0x004f00bf, 0xfffffffa},/*kerning  ¿ O� : -0.023438 */
+{'[', 0x005000bf, 0xfffffffd},/*kerning  ¿ P� : -0.011719 */
+{'[', 0x005100bf, 0xfffffffa},/*kerning  ¿ Q� : -0.023438 */
+{'[', 0x005200bf, 0xfffffffd},/*kerning  ¿ R� : -0.011719 */
+{'[', 0x005300bf, 0xfffffffc},/*kerning  ¿ S� : -0.015625 */
+{'[', 0x005400bf, 0xffffffe9},/*kerning  ¿ T� : -0.089844 */
+{'[', 0x005500bf, 0xfffffffa},/*kerning  ¿ U� : -0.023438 */
+{'[', 0x005600bf, 0xfffffff2},/*kerning  ¿ V� : -0.054688 */
+{'[', 0x005700bf, 0xfffffff2},/*kerning  ¿ W� : -0.054688 */
+{'[', 0x005900bf, 0xffffffef},/*kerning  ¿ Y� : -0.066406 */
+{'[', 0x006100bf, 0xfffffff9},/*kerning  ¿ a� : -0.027344 */
+{'[', 0x006200bf, 0xfffffffc},/*kerning  ¿ b� : -0.015625 */
+{'[', 0x006300bf, 0xfffffff9},/*kerning  ¿ c� : -0.027344 */
+{'[', 0x006400bf, 0xfffffff9},/*kerning  ¿ d� : -0.027344 */
+{'[', 0x006500bf, 0xfffffff9},/*kerning  ¿ e� : -0.027344 */
+{'[', 0x006600bf, 0xfffffffb},/*kerning  ¿ f� : -0.019531 */
+{'[', 0x006700bf, 0xfffffff9},/*kerning  ¿ g� : -0.027344 */
+{'[', 0x006800bf, 0xfffffffc},/*kerning  ¿ h� : -0.015625 */
+{'[', 0x006900bf, 0xfffffffc},/*kerning  ¿ i� : -0.015625 */
+{'[', 0x006a00bf, 0x00000014},/*kerning  ¿ j� : 0.078125 */
+{'[', 0x006b00bf, 0xfffffffc},/*kerning  ¿ k� : -0.015625 */
+{'[', 0x006c00bf, 0xfffffffb},/*kerning  ¿ l� : -0.019531 */
+{'[', 0x006d00bf, 0xfffffffc},/*kerning  ¿ m� : -0.015625 */
+{'[', 0x006e00bf, 0xfffffffc},/*kerning  ¿ n� : -0.015625 */
+{'[', 0x006f00bf, 0xfffffff9},/*kerning  ¿ o� : -0.027344 */
+{'[', 0x007000bf, 0xfffffffc},/*kerning  ¿ p� : -0.015625 */
+{'[', 0x007100bf, 0xfffffff9},/*kerning  ¿ q� : -0.027344 */
+{'[', 0x007200bf, 0xfffffffc},/*kerning  ¿ r� : -0.015625 */
+{'[', 0x007300bf, 0xfffffffa},/*kerning  ¿ s� : -0.023438 */
+{'[', 0x007400bf, 0xfffffffa},/*kerning  ¿ t� : -0.023438 */
+{'[', 0x007500bf, 0xfffffffa},/*kerning  ¿ u� : -0.023438 */
+{'[', 0x007600bf, 0xfffffff8},/*kerning  ¿ v� : -0.031250 */
+{'[', 0x007700bf, 0xfffffff8},/*kerning  ¿ w� : -0.031250 */
+{'[', 0x007900bf, 0xfffffffc},/*kerning  ¿ y� : -0.015625 */
+{'[', 0x00c700bf, 0xfffffffa},/*kerning  ¿ Ç : -0.023438 */
+{'[', 0x00c800bf, 0xfffffffd},/*kerning  ¿ È : -0.011719 */
+{'[', 0x00c900bf, 0xfffffffd},/*kerning  ¿ É : -0.011719 */
+{'[', 0x00ca00bf, 0xfffffffd},/*kerning  ¿ Ê : -0.011719 */
+{'[', 0x00cb00bf, 0xfffffffd},/*kerning  ¿ Ë : -0.011719 */
+{'[', 0x00cc00bf, 0xfffffffd},/*kerning  ¿ Ì : -0.011719 */
+{'[', 0x00cd00bf, 0xfffffffd},/*kerning  ¿ Í : -0.011719 */
+{'[', 0x00ce00bf, 0xfffffffd},/*kerning  ¿ Î : -0.011719 */
+{'[', 0x00cf00bf, 0xfffffffd},/*kerning  ¿ Ï : -0.011719 */
+{'[', 0x00d000bf, 0xfffffffb},/*kerning  ¿ Ð : -0.019531 */
+{'[', 0x00d100bf, 0xfffffffd},/*kerning  ¿ Ñ : -0.011719 */
+{'[', 0x00d200bf, 0xfffffffa},/*kerning  ¿ Ò : -0.023438 */
+{'[', 0x00d300bf, 0xfffffffa},/*kerning  ¿ Ó : -0.023438 */
+{'[', 0x00d400bf, 0xfffffffa},/*kerning  ¿ Ô : -0.023438 */
+{'[', 0x00d500bf, 0xfffffffa},/*kerning  ¿ Õ : -0.023438 */
+{'[', 0x00d600bf, 0xfffffffa},/*kerning  ¿ Ö : -0.023438 */
+{'[', 0x00d800bf, 0xfffffffa},/*kerning  ¿ Ø : -0.023438 */
+{'[', 0x00d900bf, 0xfffffffa},/*kerning  ¿ Ù : -0.023438 */
+{'[', 0x00da00bf, 0xfffffffa},/*kerning  ¿ Ú : -0.023438 */
+{'[', 0x00db00bf, 0xfffffffa},/*kerning  ¿ Û : -0.023438 */
+{'[', 0x00dc00bf, 0xfffffffa},/*kerning  ¿ Ü : -0.023438 */
+{'[', 0x00dd00bf, 0xffffffef},/*kerning  ¿ Ý : -0.066406 */
+{'[', 0x00de00bf, 0xfffffffd},/*kerning  ¿ Þ : -0.011719 */
+{'[', 0x00df00bf, 0xfffffffc},/*kerning  ¿ ß : -0.015625 */
+{'[', 0x00e000bf, 0xfffffff9},/*kerning  ¿ à : -0.027344 */
+{'[', 0x00e100bf, 0xfffffff9},/*kerning  ¿ á : -0.027344 */
+{'[', 0x00e200bf, 0xfffffff9},/*kerning  ¿ â : -0.027344 */
+{'[', 0x00e300bf, 0xfffffff9},/*kerning  ¿ ã : -0.027344 */
+{'[', 0x00e400bf, 0xfffffff9},/*kerning  ¿ ä : -0.027344 */
+{'[', 0x00e500bf, 0xfffffff9},/*kerning  ¿ å : -0.027344 */
+{'[', 0x00e600bf, 0xfffffff9},/*kerning  ¿ æ : -0.027344 */
+{'[', 0x00e700bf, 0xfffffff9},/*kerning  ¿ ç : -0.027344 */
+{'[', 0x00e800bf, 0xfffffff9},/*kerning  ¿ è : -0.027344 */
+{'[', 0x00e900bf, 0xfffffff9},/*kerning  ¿ é : -0.027344 */
+{'[', 0x00ea00bf, 0xfffffff9},/*kerning  ¿ ê : -0.027344 */
+{'[', 0x00eb00bf, 0xfffffff9},/*kerning  ¿ ë : -0.027344 */
+{'[', 0x00ec00bf, 0xfffffffc},/*kerning  ¿ ì : -0.015625 */
+{'[', 0x00ed00bf, 0xfffffffc},/*kerning  ¿ í : -0.015625 */
+{'[', 0x00ee00bf, 0xfffffffc},/*kerning  ¿ î : -0.015625 */
+{'[', 0x00ef00bf, 0xfffffffc},/*kerning  ¿ ï : -0.015625 */
+{'[', 0x00f000bf, 0xfffffff9},/*kerning  ¿ ð : -0.027344 */
+{'[', 0x00f100bf, 0xfffffffc},/*kerning  ¿ ñ : -0.015625 */
+{'[', 0x00f200bf, 0xfffffff9},/*kerning  ¿ ò : -0.027344 */
+{'[', 0x00f300bf, 0xfffffff9},/*kerning  ¿ ó : -0.027344 */
+{'[', 0x00f400bf, 0xfffffff9},/*kerning  ¿ ô : -0.027344 */
+{'[', 0x00f500bf, 0xfffffff9},/*kerning  ¿ õ : -0.027344 */
+{'[', 0x00f600bf, 0xfffffff9},/*kerning  ¿ ö : -0.027344 */
+{'[', 0x00f800bf, 0xfffffff9},/*kerning  ¿ ø : -0.027344 */
+{'[', 0x00f900bf, 0xfffffffa},/*kerning  ¿ ù : -0.023438 */
+{'[', 0x00fa00bf, 0xfffffffa},/*kerning  ¿ ú : -0.023438 */
+{'[', 0x00fb00bf, 0xfffffffa},/*kerning  ¿ û : -0.023438 */
+{'[', 0x00fc00bf, 0xfffffffa},/*kerning  ¿ ü : -0.023438 */
+{'[', 0x00fd00bf, 0xfffffffc},/*kerning  ¿ ý : -0.015625 */
+{'[', 0x00fe00bf, 0xfffffffc},/*kerning  ¿ þ : -0.015625 */
+{'[', 0x00ff00bf, 0xfffffffc},/*kerning  ¿ ÿ : -0.015625 */
+{'@', 0x000000c0, 0x00006c00},/*        À        x-advance: 108.000000 */
+{'M', 0x4240a3d7, 0xc2e33333},
+{'l', 0x41428f5c, 0x00000000},
+{'l', 0x4239999a, 0x42e33333},
+{'l', 0xc175c290, 0x80000000},
+{'l', 0xc1570a40, 0xc2051eb8},
+{'l', 0xc23eb852, 0x00000000},
+{'4', 0x010aff96, 0x0000ff86},
+{'l', 0x423a3d70, 0xc2e33333},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429570a4, 0xc231eb85},
+{'4', 0xfe5dff5d, 0x01a3ff58},
+{'l', 0x42266667, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42166666, 0xc312b852},
+{'l', 0x415eb854, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d70c, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002000c0, 0xfffffff9},/*kerning  À  � : -0.027344 */
+{'[', 0x002200c0, 0xfffffff0},/*kerning  À "� : -0.062500 */
+{'[', 0x002600c0, 0xfffffffd},/*kerning  À &� : -0.011719 */
+{'[', 0x002700c0, 0xfffffff0},/*kerning  À '� : -0.062500 */
+{'[', 0x002a00c0, 0xffffffef},/*kerning  À *� : -0.066406 */
+{'[', 0x003000c0, 0xfffffffc},/*kerning  À 0� : -0.015625 */
+{'[', 0x003600c0, 0xfffffffc},/*kerning  À 6� : -0.015625 */
+{'[', 0x003700c0, 0xfffffffd},/*kerning  À 7� : -0.011719 */
+{'[', 0x003800c0, 0xfffffffd},/*kerning  À 8� : -0.011719 */
+{'[', 0x003f00c0, 0xfffffffa},/*kerning  À ?� : -0.023438 */
+{'[', 0x004000c0, 0xfffffffd},/*kerning  À @� : -0.011719 */
+{'[', 0x004300c0, 0xfffffffa},/*kerning  À C� : -0.023438 */
+{'[', 0x004700c0, 0xfffffffa},/*kerning  À G� : -0.023438 */
+{'[', 0x004f00c0, 0xfffffffa},/*kerning  À O� : -0.023438 */
+{'[', 0x005100c0, 0xfffffffa},/*kerning  À Q� : -0.023438 */
+{'[', 0x005300c0, 0xfffffffe},/*kerning  À S� : -0.007812 */
+{'[', 0x005400c0, 0xffffffef},/*kerning  À T� : -0.066406 */
+{'[', 0x005500c0, 0xfffffff9},/*kerning  À U� : -0.027344 */
+{'[', 0x005600c0, 0xfffffff2},/*kerning  À V� : -0.054688 */
+{'[', 0x005700c0, 0xfffffff1},/*kerning  À W� : -0.058594 */
+{'[', 0x005900c0, 0xffffffed},/*kerning  À Y� : -0.074219 */
+{'[', 0x005c00c0, 0xffffffed},/*kerning  À \� : -0.074219 */
+{'[', 0x006100c0, 0xfffffffe},/*kerning  À a� : -0.007812 */
+{'[', 0x006300c0, 0xfffffffc},/*kerning  À c� : -0.015625 */
+{'[', 0x006400c0, 0xfffffffd},/*kerning  À d� : -0.011719 */
+{'[', 0x006500c0, 0xfffffffc},/*kerning  À e� : -0.015625 */
+{'[', 0x006600c0, 0xfffffffc},/*kerning  À f� : -0.015625 */
+{'[', 0x006700c0, 0xfffffffd},/*kerning  À g� : -0.011719 */
+{'[', 0x006f00c0, 0xfffffffc},/*kerning  À o� : -0.015625 */
+{'[', 0x007100c0, 0xfffffffd},/*kerning  À q� : -0.011719 */
+{'[', 0x007300c0, 0xfffffffe},/*kerning  À s� : -0.007812 */
+{'[', 0x007400c0, 0xfffffffb},/*kerning  À t� : -0.019531 */
+{'[', 0x007500c0, 0xfffffffe},/*kerning  À u� : -0.007812 */
+{'[', 0x007600c0, 0xfffffff8},/*kerning  À v� : -0.031250 */
+{'[', 0x007700c0, 0xfffffff8},/*kerning  À w� : -0.031250 */
+{'[', 0x007900c0, 0xfffffff8},/*kerning  À y� : -0.031250 */
+{'[', 0x00a900c0, 0xfffffffb},/*kerning  À © : -0.019531 */
+{'[', 0x00aa00c0, 0xfffffff4},/*kerning  À ª : -0.046875 */
+{'[', 0x00ab00c0, 0xfffffffd},/*kerning  À « : -0.011719 */
+{'[', 0x00ae00c0, 0xfffffffb},/*kerning  À ® : -0.019531 */
+{'[', 0x00ba00c0, 0xfffffff3},/*kerning  À º : -0.050781 */
+{'[', 0x00c700c0, 0xfffffffa},/*kerning  À Ç : -0.023438 */
+{'[', 0x00d200c0, 0xfffffffa},/*kerning  À Ò : -0.023438 */
+{'[', 0x00d300c0, 0xfffffffa},/*kerning  À Ó : -0.023438 */
+{'[', 0x00d400c0, 0xfffffffa},/*kerning  À Ô : -0.023438 */
+{'[', 0x00d500c0, 0xfffffffa},/*kerning  À Õ : -0.023438 */
+{'[', 0x00d600c0, 0xfffffffa},/*kerning  À Ö : -0.023438 */
+{'[', 0x00d800c0, 0xfffffffa},/*kerning  À Ø : -0.023438 */
+{'[', 0x00d900c0, 0xfffffff9},/*kerning  À Ù : -0.027344 */
+{'[', 0x00da00c0, 0xfffffff9},/*kerning  À Ú : -0.027344 */
+{'[', 0x00db00c0, 0xfffffff9},/*kerning  À Û : -0.027344 */
+{'[', 0x00dc00c0, 0xfffffff9},/*kerning  À Ü : -0.027344 */
+{'[', 0x00dd00c0, 0xffffffed},/*kerning  À Ý : -0.074219 */
+{'[', 0x00e000c0, 0xfffffffe},/*kerning  À à : -0.007812 */
+{'[', 0x00e100c0, 0xfffffffe},/*kerning  À á : -0.007812 */
+{'[', 0x00e200c0, 0xfffffffe},/*kerning  À â : -0.007812 */
+{'[', 0x00e300c0, 0xfffffffe},/*kerning  À ã : -0.007812 */
+{'[', 0x00e400c0, 0xfffffffe},/*kerning  À ä : -0.007812 */
+{'[', 0x00e500c0, 0xfffffffe},/*kerning  À å : -0.007812 */
+{'[', 0x00e600c0, 0xfffffffe},/*kerning  À æ : -0.007812 */
+{'[', 0x00e700c0, 0xfffffffc},/*kerning  À ç : -0.015625 */
+{'[', 0x00e800c0, 0xfffffffc},/*kerning  À è : -0.015625 */
+{'[', 0x00e900c0, 0xfffffffc},/*kerning  À é : -0.015625 */
+{'[', 0x00ea00c0, 0xfffffffc},/*kerning  À ê : -0.015625 */
+{'[', 0x00eb00c0, 0xfffffffc},/*kerning  À ë : -0.015625 */
+{'[', 0x00f000c0, 0xfffffffd},/*kerning  À ð : -0.011719 */
+{'[', 0x00f200c0, 0xfffffffc},/*kerning  À ò : -0.015625 */
+{'[', 0x00f300c0, 0xfffffffc},/*kerning  À ó : -0.015625 */
+{'[', 0x00f400c0, 0xfffffffc},/*kerning  À ô : -0.015625 */
+{'[', 0x00f500c0, 0xfffffffc},/*kerning  À õ : -0.015625 */
+{'[', 0x00f600c0, 0xfffffffc},/*kerning  À ö : -0.015625 */
+{'[', 0x00f800c0, 0xfffffffc},/*kerning  À ø : -0.015625 */
+{'[', 0x00f900c0, 0xfffffffe},/*kerning  À ù : -0.007812 */
+{'[', 0x00fa00c0, 0xfffffffe},/*kerning  À ú : -0.007812 */
+{'[', 0x00fb00c0, 0xfffffffe},/*kerning  À û : -0.007812 */
+{'[', 0x00fc00c0, 0xfffffffe},/*kerning  À ü : -0.007812 */
+{'[', 0x00fd00c0, 0xfffffff8},/*kerning  À ý : -0.031250 */
+{'[', 0x00ff00c0, 0xfffffff8},/*kerning  À ÿ : -0.031250 */
+{'@', 0x000000c1, 0x00006c00},/*        Á        x-advance: 108.000000 */
+{'M', 0x4240a3d7, 0xc2e33333},
+{'l', 0x41428f5c, 0x00000000},
+{'l', 0x4239999a, 0x42e33333},
+{'l', 0xc175c290, 0x80000000},
+{'l', 0xc1570a40, 0xc2051eb8},
+{'l', 0xc23eb852, 0x00000000},
+{'4', 0x010aff96, 0x0000ff86},
+{'l', 0x423a3d70, 0xc2e33333},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429570a4, 0xc231eb85},
+{'4', 0xfe5dff5d, 0x01a3ff58},
+{'l', 0x42266667, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x426ccccc, 0xc2fe6666},
+{'l', 0xc1147ae0, 0xc04cccc0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147b0, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002000c1, 0xfffffff9},/*kerning  Á  � : -0.027344 */
+{'[', 0x002200c1, 0xfffffff0},/*kerning  Á "� : -0.062500 */
+{'[', 0x002600c1, 0xfffffffd},/*kerning  Á &� : -0.011719 */
+{'[', 0x002700c1, 0xfffffff0},/*kerning  Á '� : -0.062500 */
+{'[', 0x002a00c1, 0xffffffef},/*kerning  Á *� : -0.066406 */
+{'[', 0x003000c1, 0xfffffffc},/*kerning  Á 0� : -0.015625 */
+{'[', 0x003600c1, 0xfffffffc},/*kerning  Á 6� : -0.015625 */
+{'[', 0x003700c1, 0xfffffffd},/*kerning  Á 7� : -0.011719 */
+{'[', 0x003800c1, 0xfffffffd},/*kerning  Á 8� : -0.011719 */
+{'[', 0x003f00c1, 0xfffffffa},/*kerning  Á ?� : -0.023438 */
+{'[', 0x004000c1, 0xfffffffd},/*kerning  Á @� : -0.011719 */
+{'[', 0x004300c1, 0xfffffffa},/*kerning  Á C� : -0.023438 */
+{'[', 0x004700c1, 0xfffffffa},/*kerning  Á G� : -0.023438 */
+{'[', 0x004f00c1, 0xfffffffa},/*kerning  Á O� : -0.023438 */
+{'[', 0x005100c1, 0xfffffffa},/*kerning  Á Q� : -0.023438 */
+{'[', 0x005300c1, 0xfffffffe},/*kerning  Á S� : -0.007812 */
+{'[', 0x005400c1, 0xffffffef},/*kerning  Á T� : -0.066406 */
+{'[', 0x005500c1, 0xfffffff9},/*kerning  Á U� : -0.027344 */
+{'[', 0x005600c1, 0xfffffff2},/*kerning  Á V� : -0.054688 */
+{'[', 0x005700c1, 0xfffffff1},/*kerning  Á W� : -0.058594 */
+{'[', 0x005900c1, 0xffffffed},/*kerning  Á Y� : -0.074219 */
+{'[', 0x005c00c1, 0xffffffed},/*kerning  Á \� : -0.074219 */
+{'[', 0x006100c1, 0xfffffffe},/*kerning  Á a� : -0.007812 */
+{'[', 0x006300c1, 0xfffffffc},/*kerning  Á c� : -0.015625 */
+{'[', 0x006400c1, 0xfffffffd},/*kerning  Á d� : -0.011719 */
+{'[', 0x006500c1, 0xfffffffc},/*kerning  Á e� : -0.015625 */
+{'[', 0x006600c1, 0xfffffffc},/*kerning  Á f� : -0.015625 */
+{'[', 0x006700c1, 0xfffffffd},/*kerning  Á g� : -0.011719 */
+{'[', 0x006f00c1, 0xfffffffc},/*kerning  Á o� : -0.015625 */
+{'[', 0x007100c1, 0xfffffffd},/*kerning  Á q� : -0.011719 */
+{'[', 0x007300c1, 0xfffffffe},/*kerning  Á s� : -0.007812 */
+{'[', 0x007400c1, 0xfffffffb},/*kerning  Á t� : -0.019531 */
+{'[', 0x007500c1, 0xfffffffe},/*kerning  Á u� : -0.007812 */
+{'[', 0x007600c1, 0xfffffff8},/*kerning  Á v� : -0.031250 */
+{'[', 0x007700c1, 0xfffffff8},/*kerning  Á w� : -0.031250 */
+{'[', 0x007900c1, 0xfffffff8},/*kerning  Á y� : -0.031250 */
+{'[', 0x00a900c1, 0xfffffffb},/*kerning  Á © : -0.019531 */
+{'[', 0x00aa00c1, 0xfffffff4},/*kerning  Á ª : -0.046875 */
+{'[', 0x00ab00c1, 0xfffffffd},/*kerning  Á « : -0.011719 */
+{'[', 0x00ae00c1, 0xfffffffb},/*kerning  Á ® : -0.019531 */
+{'[', 0x00ba00c1, 0xfffffff3},/*kerning  Á º : -0.050781 */
+{'[', 0x00c700c1, 0xfffffffa},/*kerning  Á Ç : -0.023438 */
+{'[', 0x00d200c1, 0xfffffffa},/*kerning  Á Ò : -0.023438 */
+{'[', 0x00d300c1, 0xfffffffa},/*kerning  Á Ó : -0.023438 */
+{'[', 0x00d400c1, 0xfffffffa},/*kerning  Á Ô : -0.023438 */
+{'[', 0x00d500c1, 0xfffffffa},/*kerning  Á Õ : -0.023438 */
+{'[', 0x00d600c1, 0xfffffffa},/*kerning  Á Ö : -0.023438 */
+{'[', 0x00d800c1, 0xfffffffa},/*kerning  Á Ø : -0.023438 */
+{'[', 0x00d900c1, 0xfffffff9},/*kerning  Á Ù : -0.027344 */
+{'[', 0x00da00c1, 0xfffffff9},/*kerning  Á Ú : -0.027344 */
+{'[', 0x00db00c1, 0xfffffff9},/*kerning  Á Û : -0.027344 */
+{'[', 0x00dc00c1, 0xfffffff9},/*kerning  Á Ü : -0.027344 */
+{'[', 0x00dd00c1, 0xffffffed},/*kerning  Á Ý : -0.074219 */
+{'[', 0x00e000c1, 0xfffffffe},/*kerning  Á à : -0.007812 */
+{'[', 0x00e100c1, 0xfffffffe},/*kerning  Á á : -0.007812 */
+{'[', 0x00e200c1, 0xfffffffe},/*kerning  Á â : -0.007812 */
+{'[', 0x00e300c1, 0xfffffffe},/*kerning  Á ã : -0.007812 */
+{'[', 0x00e400c1, 0xfffffffe},/*kerning  Á ä : -0.007812 */
+{'[', 0x00e500c1, 0xfffffffe},/*kerning  Á å : -0.007812 */
+{'[', 0x00e600c1, 0xfffffffe},/*kerning  Á æ : -0.007812 */
+{'[', 0x00e700c1, 0xfffffffc},/*kerning  Á ç : -0.015625 */
+{'[', 0x00e800c1, 0xfffffffc},/*kerning  Á è : -0.015625 */
+{'[', 0x00e900c1, 0xfffffffc},/*kerning  Á é : -0.015625 */
+{'[', 0x00ea00c1, 0xfffffffc},/*kerning  Á ê : -0.015625 */
+{'[', 0x00eb00c1, 0xfffffffc},/*kerning  Á ë : -0.015625 */
+{'[', 0x00f000c1, 0xfffffffd},/*kerning  Á ð : -0.011719 */
+{'[', 0x00f200c1, 0xfffffffc},/*kerning  Á ò : -0.015625 */
+{'[', 0x00f300c1, 0xfffffffc},/*kerning  Á ó : -0.015625 */
+{'[', 0x00f400c1, 0xfffffffc},/*kerning  Á ô : -0.015625 */
+{'[', 0x00f500c1, 0xfffffffc},/*kerning  Á õ : -0.015625 */
+{'[', 0x00f600c1, 0xfffffffc},/*kerning  Á ö : -0.015625 */
+{'[', 0x00f800c1, 0xfffffffc},/*kerning  Á ø : -0.015625 */
+{'[', 0x00f900c1, 0xfffffffe},/*kerning  Á ù : -0.007812 */
+{'[', 0x00fa00c1, 0xfffffffe},/*kerning  Á ú : -0.007812 */
+{'[', 0x00fb00c1, 0xfffffffe},/*kerning  Á û : -0.007812 */
+{'[', 0x00fc00c1, 0xfffffffe},/*kerning  Á ü : -0.007812 */
+{'[', 0x00fd00c1, 0xfffffff8},/*kerning  Á ý : -0.031250 */
+{'[', 0x00ff00c1, 0xfffffff8},/*kerning  Á ÿ : -0.031250 */
+{'@', 0x000000c2, 0x00006c00},/*        Â        x-advance: 108.000000 */
+{'M', 0x4240a3d7, 0xc2e33333},
+{'l', 0x41428f5c, 0x00000000},
+{'l', 0x4239999a, 0x42e33333},
+{'l', 0xc175c290, 0x80000000},
+{'l', 0xc1570a40, 0xc2051eb8},
+{'l', 0xc23eb852, 0x00000000},
+{'4', 0x010aff96, 0x0000ff86},
+{'l', 0x423a3d70, 0xc2e33333},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429570a4, 0xc231eb85},
+{'4', 0xfe5dff5d, 0x01a3ff58},
+{'l', 0x42266667, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4203d70a, 0xc30428f6},
+{'l', 0x418147ae, 0xc1666660},
+{'l', 0x4123d708, 0x00000000},
+{'l', 0x418147ae, 0x41666660},
+{'0', 0xb0941ec3, 0xe2c35094},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002000c2, 0xfffffff9},/*kerning  Â  � : -0.027344 */
+{'[', 0x002200c2, 0xfffffff0},/*kerning  Â "� : -0.062500 */
+{'[', 0x002600c2, 0xfffffffd},/*kerning  Â &� : -0.011719 */
+{'[', 0x002700c2, 0xfffffff0},/*kerning  Â '� : -0.062500 */
+{'[', 0x002a00c2, 0xffffffef},/*kerning  Â *� : -0.066406 */
+{'[', 0x003000c2, 0xfffffffc},/*kerning  Â 0� : -0.015625 */
+{'[', 0x003600c2, 0xfffffffc},/*kerning  Â 6� : -0.015625 */
+{'[', 0x003700c2, 0xfffffffd},/*kerning  Â 7� : -0.011719 */
+{'[', 0x003800c2, 0xfffffffd},/*kerning  Â 8� : -0.011719 */
+{'[', 0x003f00c2, 0xfffffffa},/*kerning  Â ?� : -0.023438 */
+{'[', 0x004000c2, 0xfffffffd},/*kerning  Â @� : -0.011719 */
+{'[', 0x004300c2, 0xfffffffa},/*kerning  Â C� : -0.023438 */
+{'[', 0x004700c2, 0xfffffffa},/*kerning  Â G� : -0.023438 */
+{'[', 0x004f00c2, 0xfffffffa},/*kerning  Â O� : -0.023438 */
+{'[', 0x005100c2, 0xfffffffa},/*kerning  Â Q� : -0.023438 */
+{'[', 0x005300c2, 0xfffffffe},/*kerning  Â S� : -0.007812 */
+{'[', 0x005400c2, 0xffffffef},/*kerning  Â T� : -0.066406 */
+{'[', 0x005500c2, 0xfffffff9},/*kerning  Â U� : -0.027344 */
+{'[', 0x005600c2, 0xfffffff2},/*kerning  Â V� : -0.054688 */
+{'[', 0x005700c2, 0xfffffff1},/*kerning  Â W� : -0.058594 */
+{'[', 0x005900c2, 0xffffffed},/*kerning  Â Y� : -0.074219 */
+{'[', 0x005c00c2, 0xffffffed},/*kerning  Â \� : -0.074219 */
+{'[', 0x006100c2, 0xfffffffe},/*kerning  Â a� : -0.007812 */
+{'[', 0x006300c2, 0xfffffffc},/*kerning  Â c� : -0.015625 */
+{'[', 0x006400c2, 0xfffffffd},/*kerning  Â d� : -0.011719 */
+{'[', 0x006500c2, 0xfffffffc},/*kerning  Â e� : -0.015625 */
+{'[', 0x006600c2, 0xfffffffc},/*kerning  Â f� : -0.015625 */
+{'[', 0x006700c2, 0xfffffffd},/*kerning  Â g� : -0.011719 */
+{'[', 0x006f00c2, 0xfffffffc},/*kerning  Â o� : -0.015625 */
+{'[', 0x007100c2, 0xfffffffd},/*kerning  Â q� : -0.011719 */
+{'[', 0x007300c2, 0xfffffffe},/*kerning  Â s� : -0.007812 */
+{'[', 0x007400c2, 0xfffffffb},/*kerning  Â t� : -0.019531 */
+{'[', 0x007500c2, 0xfffffffe},/*kerning  Â u� : -0.007812 */
+{'[', 0x007600c2, 0xfffffff8},/*kerning  Â v� : -0.031250 */
+{'[', 0x007700c2, 0xfffffff8},/*kerning  Â w� : -0.031250 */
+{'[', 0x007900c2, 0xfffffff8},/*kerning  Â y� : -0.031250 */
+{'[', 0x00a900c2, 0xfffffffb},/*kerning  Â © : -0.019531 */
+{'[', 0x00aa00c2, 0xfffffff4},/*kerning  Â ª : -0.046875 */
+{'[', 0x00ab00c2, 0xfffffffd},/*kerning  Â « : -0.011719 */
+{'[', 0x00ae00c2, 0xfffffffb},/*kerning  Â ® : -0.019531 */
+{'[', 0x00ba00c2, 0xfffffff3},/*kerning  Â º : -0.050781 */
+{'[', 0x00c700c2, 0xfffffffa},/*kerning  Â Ç : -0.023438 */
+{'[', 0x00d200c2, 0xfffffffa},/*kerning  Â Ò : -0.023438 */
+{'[', 0x00d300c2, 0xfffffffa},/*kerning  Â Ó : -0.023438 */
+{'[', 0x00d400c2, 0xfffffffa},/*kerning  Â Ô : -0.023438 */
+{'[', 0x00d500c2, 0xfffffffa},/*kerning  Â Õ : -0.023438 */
+{'[', 0x00d600c2, 0xfffffffa},/*kerning  Â Ö : -0.023438 */
+{'[', 0x00d800c2, 0xfffffffa},/*kerning  Â Ø : -0.023438 */
+{'[', 0x00d900c2, 0xfffffff9},/*kerning  Â Ù : -0.027344 */
+{'[', 0x00da00c2, 0xfffffff9},/*kerning  Â Ú : -0.027344 */
+{'[', 0x00db00c2, 0xfffffff9},/*kerning  Â Û : -0.027344 */
+{'[', 0x00dc00c2, 0xfffffff9},/*kerning  Â Ü : -0.027344 */
+{'[', 0x00dd00c2, 0xffffffed},/*kerning  Â Ý : -0.074219 */
+{'[', 0x00e000c2, 0xfffffffe},/*kerning  Â à : -0.007812 */
+{'[', 0x00e100c2, 0xfffffffe},/*kerning  Â á : -0.007812 */
+{'[', 0x00e200c2, 0xfffffffe},/*kerning  Â â : -0.007812 */
+{'[', 0x00e300c2, 0xfffffffe},/*kerning  Â ã : -0.007812 */
+{'[', 0x00e400c2, 0xfffffffe},/*kerning  Â ä : -0.007812 */
+{'[', 0x00e500c2, 0xfffffffe},/*kerning  Â å : -0.007812 */
+{'[', 0x00e600c2, 0xfffffffe},/*kerning  Â æ : -0.007812 */
+{'[', 0x00e700c2, 0xfffffffc},/*kerning  Â ç : -0.015625 */
+{'[', 0x00e800c2, 0xfffffffc},/*kerning  Â è : -0.015625 */
+{'[', 0x00e900c2, 0xfffffffc},/*kerning  Â é : -0.015625 */
+{'[', 0x00ea00c2, 0xfffffffc},/*kerning  Â ê : -0.015625 */
+{'[', 0x00eb00c2, 0xfffffffc},/*kerning  Â ë : -0.015625 */
+{'[', 0x00f000c2, 0xfffffffd},/*kerning  Â ð : -0.011719 */
+{'[', 0x00f200c2, 0xfffffffc},/*kerning  Â ò : -0.015625 */
+{'[', 0x00f300c2, 0xfffffffc},/*kerning  Â ó : -0.015625 */
+{'[', 0x00f400c2, 0xfffffffc},/*kerning  Â ô : -0.015625 */
+{'[', 0x00f500c2, 0xfffffffc},/*kerning  Â õ : -0.015625 */
+{'[', 0x00f600c2, 0xfffffffc},/*kerning  Â ö : -0.015625 */
+{'[', 0x00f800c2, 0xfffffffc},/*kerning  Â ø : -0.015625 */
+{'[', 0x00f900c2, 0xfffffffe},/*kerning  Â ù : -0.007812 */
+{'[', 0x00fa00c2, 0xfffffffe},/*kerning  Â ú : -0.007812 */
+{'[', 0x00fb00c2, 0xfffffffe},/*kerning  Â û : -0.007812 */
+{'[', 0x00fc00c2, 0xfffffffe},/*kerning  Â ü : -0.007812 */
+{'[', 0x00fd00c2, 0xfffffff8},/*kerning  Â ý : -0.031250 */
+{'[', 0x00ff00c2, 0xfffffff8},/*kerning  Â ÿ : -0.031250 */
+{'@', 0x000000c3, 0x00006c00},/*        Ã        x-advance: 108.000000 */
+{'M', 0x4240a3d7, 0xc2e33333},
+{'l', 0x41428f5c, 0x00000000},
+{'l', 0x4239999a, 0x42e33333},
+{'l', 0xc175c290, 0x80000000},
+{'l', 0xc1570a40, 0xc2051eb8},
+{'l', 0xc23eb852, 0x00000000},
+{'4', 0x010aff96, 0x0000ff86},
+{'l', 0x423a3d70, 0xc2e33333},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429570a4, 0xc231eb85},
+{'4', 0xfe5dff5d, 0x01a3ff58},
+{'l', 0x42266667, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x428051eb, 0xc302147b},
+{'8', 0xf3bf00da, 0xe6cff3e6},
+{'8', 0xf3cef3ea, 0x0ed700e4},
+{'8', 0x1def0ef3, 0x11fd0ffd},
+{'l', 0xc1051eba, 0x00000000},
+{'8', 0xe405f900, 0xd413eb05},
+{'8', 0xd826e90e, 0xef3eef18},
+{'8', 0x0d3e0025, 0x1b300d18},
+{'8', 0x0e360e17, 0xf22f0021},
+{'8', 0xe213f20e, 0xef04f104},
+{'l', 0x41051eb8, 0x00000000},
+{'8', 0x1cfb0700, 0x2ceb14fb},
+{'8', 0x29d718f1, 0x11bd11e6},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002000c3, 0xfffffff9},/*kerning  Ã  � : -0.027344 */
+{'[', 0x002200c3, 0xfffffff0},/*kerning  Ã "� : -0.062500 */
+{'[', 0x002600c3, 0xfffffffd},/*kerning  Ã &� : -0.011719 */
+{'[', 0x002700c3, 0xfffffff0},/*kerning  Ã '� : -0.062500 */
+{'[', 0x002a00c3, 0xffffffef},/*kerning  Ã *� : -0.066406 */
+{'[', 0x003000c3, 0xfffffffc},/*kerning  Ã 0� : -0.015625 */
+{'[', 0x003600c3, 0xfffffffc},/*kerning  Ã 6� : -0.015625 */
+{'[', 0x003700c3, 0xfffffffd},/*kerning  Ã 7� : -0.011719 */
+{'[', 0x003800c3, 0xfffffffd},/*kerning  Ã 8� : -0.011719 */
+{'[', 0x003f00c3, 0xfffffffa},/*kerning  Ã ?� : -0.023438 */
+{'[', 0x004000c3, 0xfffffffd},/*kerning  Ã @� : -0.011719 */
+{'[', 0x004300c3, 0xfffffffa},/*kerning  Ã C� : -0.023438 */
+{'[', 0x004700c3, 0xfffffffa},/*kerning  Ã G� : -0.023438 */
+{'[', 0x004f00c3, 0xfffffffa},/*kerning  Ã O� : -0.023438 */
+{'[', 0x005100c3, 0xfffffffa},/*kerning  Ã Q� : -0.023438 */
+{'[', 0x005300c3, 0xfffffffe},/*kerning  Ã S� : -0.007812 */
+{'[', 0x005400c3, 0xffffffef},/*kerning  Ã T� : -0.066406 */
+{'[', 0x005500c3, 0xfffffff9},/*kerning  Ã U� : -0.027344 */
+{'[', 0x005600c3, 0xfffffff2},/*kerning  Ã V� : -0.054688 */
+{'[', 0x005700c3, 0xfffffff1},/*kerning  Ã W� : -0.058594 */
+{'[', 0x005900c3, 0xffffffed},/*kerning  Ã Y� : -0.074219 */
+{'[', 0x005c00c3, 0xffffffed},/*kerning  Ã \� : -0.074219 */
+{'[', 0x006100c3, 0xfffffffe},/*kerning  Ã a� : -0.007812 */
+{'[', 0x006300c3, 0xfffffffc},/*kerning  Ã c� : -0.015625 */
+{'[', 0x006400c3, 0xfffffffd},/*kerning  Ã d� : -0.011719 */
+{'[', 0x006500c3, 0xfffffffc},/*kerning  Ã e� : -0.015625 */
+{'[', 0x006600c3, 0xfffffffc},/*kerning  Ã f� : -0.015625 */
+{'[', 0x006700c3, 0xfffffffd},/*kerning  Ã g� : -0.011719 */
+{'[', 0x006f00c3, 0xfffffffc},/*kerning  Ã o� : -0.015625 */
+{'[', 0x007100c3, 0xfffffffd},/*kerning  Ã q� : -0.011719 */
+{'[', 0x007300c3, 0xfffffffe},/*kerning  Ã s� : -0.007812 */
+{'[', 0x007400c3, 0xfffffffb},/*kerning  Ã t� : -0.019531 */
+{'[', 0x007500c3, 0xfffffffe},/*kerning  Ã u� : -0.007812 */
+{'[', 0x007600c3, 0xfffffff8},/*kerning  Ã v� : -0.031250 */
+{'[', 0x007700c3, 0xfffffff8},/*kerning  Ã w� : -0.031250 */
+{'[', 0x007900c3, 0xfffffff8},/*kerning  Ã y� : -0.031250 */
+{'[', 0x00a900c3, 0xfffffffb},/*kerning  Ã © : -0.019531 */
+{'[', 0x00aa00c3, 0xfffffff4},/*kerning  Ã ª : -0.046875 */
+{'[', 0x00ab00c3, 0xfffffffd},/*kerning  Ã « : -0.011719 */
+{'[', 0x00ae00c3, 0xfffffffb},/*kerning  Ã ® : -0.019531 */
+{'[', 0x00ba00c3, 0xfffffff3},/*kerning  Ã º : -0.050781 */
+{'[', 0x00c700c3, 0xfffffffa},/*kerning  Ã Ç : -0.023438 */
+{'[', 0x00d200c3, 0xfffffffa},/*kerning  Ã Ò : -0.023438 */
+{'[', 0x00d300c3, 0xfffffffa},/*kerning  Ã Ó : -0.023438 */
+{'[', 0x00d400c3, 0xfffffffa},/*kerning  Ã Ô : -0.023438 */
+{'[', 0x00d500c3, 0xfffffffa},/*kerning  Ã Õ : -0.023438 */
+{'[', 0x00d600c3, 0xfffffffa},/*kerning  Ã Ö : -0.023438 */
+{'[', 0x00d800c3, 0xfffffffa},/*kerning  Ã Ø : -0.023438 */
+{'[', 0x00d900c3, 0xfffffff9},/*kerning  Ã Ù : -0.027344 */
+{'[', 0x00da00c3, 0xfffffff9},/*kerning  Ã Ú : -0.027344 */
+{'[', 0x00db00c3, 0xfffffff9},/*kerning  Ã Û : -0.027344 */
+{'[', 0x00dc00c3, 0xfffffff9},/*kerning  Ã Ü : -0.027344 */
+{'[', 0x00dd00c3, 0xffffffed},/*kerning  Ã Ý : -0.074219 */
+{'[', 0x00e000c3, 0xfffffffe},/*kerning  Ã à : -0.007812 */
+{'[', 0x00e100c3, 0xfffffffe},/*kerning  Ã á : -0.007812 */
+{'[', 0x00e200c3, 0xfffffffe},/*kerning  Ã â : -0.007812 */
+{'[', 0x00e300c3, 0xfffffffe},/*kerning  Ã ã : -0.007812 */
+{'[', 0x00e400c3, 0xfffffffe},/*kerning  Ã ä : -0.007812 */
+{'[', 0x00e500c3, 0xfffffffe},/*kerning  Ã å : -0.007812 */
+{'[', 0x00e600c3, 0xfffffffe},/*kerning  Ã æ : -0.007812 */
+{'[', 0x00e700c3, 0xfffffffc},/*kerning  Ã ç : -0.015625 */
+{'[', 0x00e800c3, 0xfffffffc},/*kerning  Ã è : -0.015625 */
+{'[', 0x00e900c3, 0xfffffffc},/*kerning  Ã é : -0.015625 */
+{'[', 0x00ea00c3, 0xfffffffc},/*kerning  Ã ê : -0.015625 */
+{'[', 0x00eb00c3, 0xfffffffc},/*kerning  Ã ë : -0.015625 */
+{'[', 0x00f000c3, 0xfffffffd},/*kerning  Ã ð : -0.011719 */
+{'[', 0x00f200c3, 0xfffffffc},/*kerning  Ã ò : -0.015625 */
+{'[', 0x00f300c3, 0xfffffffc},/*kerning  Ã ó : -0.015625 */
+{'[', 0x00f400c3, 0xfffffffc},/*kerning  Ã ô : -0.015625 */
+{'[', 0x00f500c3, 0xfffffffc},/*kerning  Ã õ : -0.015625 */
+{'[', 0x00f600c3, 0xfffffffc},/*kerning  Ã ö : -0.015625 */
+{'[', 0x00f800c3, 0xfffffffc},/*kerning  Ã ø : -0.015625 */
+{'[', 0x00f900c3, 0xfffffffe},/*kerning  Ã ù : -0.007812 */
+{'[', 0x00fa00c3, 0xfffffffe},/*kerning  Ã ú : -0.007812 */
+{'[', 0x00fb00c3, 0xfffffffe},/*kerning  Ã û : -0.007812 */
+{'[', 0x00fc00c3, 0xfffffffe},/*kerning  Ã ü : -0.007812 */
+{'[', 0x00fd00c3, 0xfffffff8},/*kerning  Ã ý : -0.031250 */
+{'[', 0x00ff00c3, 0xfffffff8},/*kerning  Ã ÿ : -0.031250 */
+{'@', 0x000000c4, 0x00006c00},/*        Ä        x-advance: 108.000000 */
+{'M', 0x4240a3d7, 0xc2e33333},
+{'l', 0x41428f5c, 0x00000000},
+{'l', 0x4239999a, 0x42e33333},
+{'l', 0xc175c290, 0x80000000},
+{'l', 0xc1570a40, 0xc2051eb8},
+{'l', 0xc23eb852, 0x00000000},
+{'4', 0x010aff96, 0x0000ff86},
+{'l', 0x423a3d70, 0xc2e33333},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429570a4, 0xc231eb85},
+{'4', 0xfe5dff5d, 0x01a3ff58},
+{'l', 0x42266667, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x420d70a4, 0xc301c28f},
+{'l', 0x00000000, 0xc1828f60},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42751eb8, 0xc301c28f},
+{'l', 0x00000000, 0xc1828f60},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a0, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002000c4, 0xfffffff9},/*kerning  Ä  � : -0.027344 */
+{'[', 0x002200c4, 0xfffffff0},/*kerning  Ä "� : -0.062500 */
+{'[', 0x002600c4, 0xfffffffd},/*kerning  Ä &� : -0.011719 */
+{'[', 0x002700c4, 0xfffffff0},/*kerning  Ä '� : -0.062500 */
+{'[', 0x002a00c4, 0xffffffef},/*kerning  Ä *� : -0.066406 */
+{'[', 0x003000c4, 0xfffffffc},/*kerning  Ä 0� : -0.015625 */
+{'[', 0x003600c4, 0xfffffffc},/*kerning  Ä 6� : -0.015625 */
+{'[', 0x003700c4, 0xfffffffd},/*kerning  Ä 7� : -0.011719 */
+{'[', 0x003800c4, 0xfffffffd},/*kerning  Ä 8� : -0.011719 */
+{'[', 0x003f00c4, 0xfffffffa},/*kerning  Ä ?� : -0.023438 */
+{'[', 0x004000c4, 0xfffffffd},/*kerning  Ä @� : -0.011719 */
+{'[', 0x004300c4, 0xfffffffa},/*kerning  Ä C� : -0.023438 */
+{'[', 0x004700c4, 0xfffffffa},/*kerning  Ä G� : -0.023438 */
+{'[', 0x004f00c4, 0xfffffffa},/*kerning  Ä O� : -0.023438 */
+{'[', 0x005100c4, 0xfffffffa},/*kerning  Ä Q� : -0.023438 */
+{'[', 0x005300c4, 0xfffffffe},/*kerning  Ä S� : -0.007812 */
+{'[', 0x005400c4, 0xffffffef},/*kerning  Ä T� : -0.066406 */
+{'[', 0x005500c4, 0xfffffff9},/*kerning  Ä U� : -0.027344 */
+{'[', 0x005600c4, 0xfffffff2},/*kerning  Ä V� : -0.054688 */
+{'[', 0x005700c4, 0xfffffff1},/*kerning  Ä W� : -0.058594 */
+{'[', 0x005900c4, 0xffffffed},/*kerning  Ä Y� : -0.074219 */
+{'[', 0x005c00c4, 0xffffffed},/*kerning  Ä \� : -0.074219 */
+{'[', 0x006100c4, 0xfffffffe},/*kerning  Ä a� : -0.007812 */
+{'[', 0x006300c4, 0xfffffffc},/*kerning  Ä c� : -0.015625 */
+{'[', 0x006400c4, 0xfffffffd},/*kerning  Ä d� : -0.011719 */
+{'[', 0x006500c4, 0xfffffffc},/*kerning  Ä e� : -0.015625 */
+{'[', 0x006600c4, 0xfffffffc},/*kerning  Ä f� : -0.015625 */
+{'[', 0x006700c4, 0xfffffffd},/*kerning  Ä g� : -0.011719 */
+{'[', 0x006f00c4, 0xfffffffc},/*kerning  Ä o� : -0.015625 */
+{'[', 0x007100c4, 0xfffffffd},/*kerning  Ä q� : -0.011719 */
+{'[', 0x007300c4, 0xfffffffe},/*kerning  Ä s� : -0.007812 */
+{'[', 0x007400c4, 0xfffffffb},/*kerning  Ä t� : -0.019531 */
+{'[', 0x007500c4, 0xfffffffe},/*kerning  Ä u� : -0.007812 */
+{'[', 0x007600c4, 0xfffffff8},/*kerning  Ä v� : -0.031250 */
+{'[', 0x007700c4, 0xfffffff8},/*kerning  Ä w� : -0.031250 */
+{'[', 0x007900c4, 0xfffffff8},/*kerning  Ä y� : -0.031250 */
+{'[', 0x00a900c4, 0xfffffffb},/*kerning  Ä © : -0.019531 */
+{'[', 0x00aa00c4, 0xfffffff4},/*kerning  Ä ª : -0.046875 */
+{'[', 0x00ab00c4, 0xfffffffd},/*kerning  Ä « : -0.011719 */
+{'[', 0x00ae00c4, 0xfffffffb},/*kerning  Ä ® : -0.019531 */
+{'[', 0x00ba00c4, 0xfffffff3},/*kerning  Ä º : -0.050781 */
+{'[', 0x00c700c4, 0xfffffffa},/*kerning  Ä Ç : -0.023438 */
+{'[', 0x00d200c4, 0xfffffffa},/*kerning  Ä Ò : -0.023438 */
+{'[', 0x00d300c4, 0xfffffffa},/*kerning  Ä Ó : -0.023438 */
+{'[', 0x00d400c4, 0xfffffffa},/*kerning  Ä Ô : -0.023438 */
+{'[', 0x00d500c4, 0xfffffffa},/*kerning  Ä Õ : -0.023438 */
+{'[', 0x00d600c4, 0xfffffffa},/*kerning  Ä Ö : -0.023438 */
+{'[', 0x00d800c4, 0xfffffffa},/*kerning  Ä Ø : -0.023438 */
+{'[', 0x00d900c4, 0xfffffff9},/*kerning  Ä Ù : -0.027344 */
+{'[', 0x00da00c4, 0xfffffff9},/*kerning  Ä Ú : -0.027344 */
+{'[', 0x00db00c4, 0xfffffff9},/*kerning  Ä Û : -0.027344 */
+{'[', 0x00dc00c4, 0xfffffff9},/*kerning  Ä Ü : -0.027344 */
+{'[', 0x00dd00c4, 0xffffffed},/*kerning  Ä Ý : -0.074219 */
+{'[', 0x00e000c4, 0xfffffffe},/*kerning  Ä à : -0.007812 */
+{'[', 0x00e100c4, 0xfffffffe},/*kerning  Ä á : -0.007812 */
+{'[', 0x00e200c4, 0xfffffffe},/*kerning  Ä â : -0.007812 */
+{'[', 0x00e300c4, 0xfffffffe},/*kerning  Ä ã : -0.007812 */
+{'[', 0x00e400c4, 0xfffffffe},/*kerning  Ä ä : -0.007812 */
+{'[', 0x00e500c4, 0xfffffffe},/*kerning  Ä å : -0.007812 */
+{'[', 0x00e600c4, 0xfffffffe},/*kerning  Ä æ : -0.007812 */
+{'[', 0x00e700c4, 0xfffffffc},/*kerning  Ä ç : -0.015625 */
+{'[', 0x00e800c4, 0xfffffffc},/*kerning  Ä è : -0.015625 */
+{'[', 0x00e900c4, 0xfffffffc},/*kerning  Ä é : -0.015625 */
+{'[', 0x00ea00c4, 0xfffffffc},/*kerning  Ä ê : -0.015625 */
+{'[', 0x00eb00c4, 0xfffffffc},/*kerning  Ä ë : -0.015625 */
+{'[', 0x00f000c4, 0xfffffffd},/*kerning  Ä ð : -0.011719 */
+{'[', 0x00f200c4, 0xfffffffc},/*kerning  Ä ò : -0.015625 */
+{'[', 0x00f300c4, 0xfffffffc},/*kerning  Ä ó : -0.015625 */
+{'[', 0x00f400c4, 0xfffffffc},/*kerning  Ä ô : -0.015625 */
+{'[', 0x00f500c4, 0xfffffffc},/*kerning  Ä õ : -0.015625 */
+{'[', 0x00f600c4, 0xfffffffc},/*kerning  Ä ö : -0.015625 */
+{'[', 0x00f800c4, 0xfffffffc},/*kerning  Ä ø : -0.015625 */
+{'[', 0x00f900c4, 0xfffffffe},/*kerning  Ä ù : -0.007812 */
+{'[', 0x00fa00c4, 0xfffffffe},/*kerning  Ä ú : -0.007812 */
+{'[', 0x00fb00c4, 0xfffffffe},/*kerning  Ä û : -0.007812 */
+{'[', 0x00fc00c4, 0xfffffffe},/*kerning  Ä ü : -0.007812 */
+{'[', 0x00fd00c4, 0xfffffff8},/*kerning  Ä ý : -0.031250 */
+{'[', 0x00ff00c4, 0xfffffff8},/*kerning  Ä ÿ : -0.031250 */
+{'@', 0x000000c5, 0x00006c00},/*        Å        x-advance: 108.000000 */
+{'M', 0x4240a3d7, 0xc2e33333},
+{'l', 0x41428f5c, 0x00000000},
+{'l', 0x4239999a, 0x42e33333},
+{'l', 0xc175c290, 0x80000000},
+{'l', 0xc1570a40, 0xc2051eb8},
+{'l', 0xc23eb852, 0x00000000},
+{'4', 0x010aff96, 0x0000ff86},
+{'l', 0x423a3d70, 0xc2e33333},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429570a4, 0xc231eb85},
+{'4', 0xfe5dff5d, 0x01a3ff58},
+{'l', 0x42266667, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x421c28f6, 0xc30828f6},
+{'8', 0xaf22cd00, 0xe257e222},
+{'8', 0x1e570035, 0x51211e21},
+{'8', 0x50df3100, 0x1ea91edf},
+{'8', 0xe2a900cc, 0xb0dee2de},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4258f5c2, 0xc30fd70a},
+{'8', 0x10d600e8, 0x2def10ef},
+{'8', 0x2a111900, 0x112a1111},
+{'8', 0xf02a0018, 0xd512f012},
+{'8', 0xd3efe300, 0xf0d5f0ef},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002000c5, 0xfffffff9},/*kerning  Å  � : -0.027344 */
+{'[', 0x002200c5, 0xfffffff0},/*kerning  Å "� : -0.062500 */
+{'[', 0x002600c5, 0xfffffffd},/*kerning  Å &� : -0.011719 */
+{'[', 0x002700c5, 0xfffffff0},/*kerning  Å '� : -0.062500 */
+{'[', 0x002a00c5, 0xffffffef},/*kerning  Å *� : -0.066406 */
+{'[', 0x003000c5, 0xfffffffc},/*kerning  Å 0� : -0.015625 */
+{'[', 0x003600c5, 0xfffffffc},/*kerning  Å 6� : -0.015625 */
+{'[', 0x003700c5, 0xfffffffd},/*kerning  Å 7� : -0.011719 */
+{'[', 0x003800c5, 0xfffffffd},/*kerning  Å 8� : -0.011719 */
+{'[', 0x003f00c5, 0xfffffffa},/*kerning  Å ?� : -0.023438 */
+{'[', 0x004000c5, 0xfffffffd},/*kerning  Å @� : -0.011719 */
+{'[', 0x004300c5, 0xfffffffa},/*kerning  Å C� : -0.023438 */
+{'[', 0x004700c5, 0xfffffffa},/*kerning  Å G� : -0.023438 */
+{'[', 0x004f00c5, 0xfffffffa},/*kerning  Å O� : -0.023438 */
+{'[', 0x005100c5, 0xfffffffa},/*kerning  Å Q� : -0.023438 */
+{'[', 0x005300c5, 0xfffffffe},/*kerning  Å S� : -0.007812 */
+{'[', 0x005400c5, 0xffffffef},/*kerning  Å T� : -0.066406 */
+{'[', 0x005500c5, 0xfffffff9},/*kerning  Å U� : -0.027344 */
+{'[', 0x005600c5, 0xfffffff2},/*kerning  Å V� : -0.054688 */
+{'[', 0x005700c5, 0xfffffff1},/*kerning  Å W� : -0.058594 */
+{'[', 0x005900c5, 0xffffffed},/*kerning  Å Y� : -0.074219 */
+{'[', 0x005c00c5, 0xffffffed},/*kerning  Å \� : -0.074219 */
+{'[', 0x006100c5, 0xfffffffe},/*kerning  Å a� : -0.007812 */
+{'[', 0x006300c5, 0xfffffffc},/*kerning  Å c� : -0.015625 */
+{'[', 0x006400c5, 0xfffffffd},/*kerning  Å d� : -0.011719 */
+{'[', 0x006500c5, 0xfffffffc},/*kerning  Å e� : -0.015625 */
+{'[', 0x006600c5, 0xfffffffc},/*kerning  Å f� : -0.015625 */
+{'[', 0x006700c5, 0xfffffffd},/*kerning  Å g� : -0.011719 */
+{'[', 0x006f00c5, 0xfffffffc},/*kerning  Å o� : -0.015625 */
+{'[', 0x007100c5, 0xfffffffd},/*kerning  Å q� : -0.011719 */
+{'[', 0x007300c5, 0xfffffffe},/*kerning  Å s� : -0.007812 */
+{'[', 0x007400c5, 0xfffffffb},/*kerning  Å t� : -0.019531 */
+{'[', 0x007500c5, 0xfffffffe},/*kerning  Å u� : -0.007812 */
+{'[', 0x007600c5, 0xfffffff8},/*kerning  Å v� : -0.031250 */
+{'[', 0x007700c5, 0xfffffff8},/*kerning  Å w� : -0.031250 */
+{'[', 0x007900c5, 0xfffffff8},/*kerning  Å y� : -0.031250 */
+{'[', 0x00a900c5, 0xfffffffb},/*kerning  Å © : -0.019531 */
+{'[', 0x00aa00c5, 0xfffffff4},/*kerning  Å ª : -0.046875 */
+{'[', 0x00ab00c5, 0xfffffffd},/*kerning  Å « : -0.011719 */
+{'[', 0x00ae00c5, 0xfffffffb},/*kerning  Å ® : -0.019531 */
+{'[', 0x00ba00c5, 0xfffffff3},/*kerning  Å º : -0.050781 */
+{'[', 0x00c700c5, 0xfffffffa},/*kerning  Å Ç : -0.023438 */
+{'[', 0x00d200c5, 0xfffffffa},/*kerning  Å Ò : -0.023438 */
+{'[', 0x00d300c5, 0xfffffffa},/*kerning  Å Ó : -0.023438 */
+{'[', 0x00d400c5, 0xfffffffa},/*kerning  Å Ô : -0.023438 */
+{'[', 0x00d500c5, 0xfffffffa},/*kerning  Å Õ : -0.023438 */
+{'[', 0x00d600c5, 0xfffffffa},/*kerning  Å Ö : -0.023438 */
+{'[', 0x00d800c5, 0xfffffffa},/*kerning  Å Ø : -0.023438 */
+{'[', 0x00d900c5, 0xfffffff9},/*kerning  Å Ù : -0.027344 */
+{'[', 0x00da00c5, 0xfffffff9},/*kerning  Å Ú : -0.027344 */
+{'[', 0x00db00c5, 0xfffffff9},/*kerning  Å Û : -0.027344 */
+{'[', 0x00dc00c5, 0xfffffff9},/*kerning  Å Ü : -0.027344 */
+{'[', 0x00dd00c5, 0xffffffed},/*kerning  Å Ý : -0.074219 */
+{'[', 0x00e000c5, 0xfffffffe},/*kerning  Å à : -0.007812 */
+{'[', 0x00e100c5, 0xfffffffe},/*kerning  Å á : -0.007812 */
+{'[', 0x00e200c5, 0xfffffffe},/*kerning  Å â : -0.007812 */
+{'[', 0x00e300c5, 0xfffffffe},/*kerning  Å ã : -0.007812 */
+{'[', 0x00e400c5, 0xfffffffe},/*kerning  Å ä : -0.007812 */
+{'[', 0x00e500c5, 0xfffffffe},/*kerning  Å å : -0.007812 */
+{'[', 0x00e600c5, 0xfffffffe},/*kerning  Å æ : -0.007812 */
+{'[', 0x00e700c5, 0xfffffffc},/*kerning  Å ç : -0.015625 */
+{'[', 0x00e800c5, 0xfffffffc},/*kerning  Å è : -0.015625 */
+{'[', 0x00e900c5, 0xfffffffc},/*kerning  Å é : -0.015625 */
+{'[', 0x00ea00c5, 0xfffffffc},/*kerning  Å ê : -0.015625 */
+{'[', 0x00eb00c5, 0xfffffffc},/*kerning  Å ë : -0.015625 */
+{'[', 0x00f000c5, 0xfffffffd},/*kerning  Å ð : -0.011719 */
+{'[', 0x00f200c5, 0xfffffffc},/*kerning  Å ò : -0.015625 */
+{'[', 0x00f300c5, 0xfffffffc},/*kerning  Å ó : -0.015625 */
+{'[', 0x00f400c5, 0xfffffffc},/*kerning  Å ô : -0.015625 */
+{'[', 0x00f500c5, 0xfffffffc},/*kerning  Å õ : -0.015625 */
+{'[', 0x00f600c5, 0xfffffffc},/*kerning  Å ö : -0.015625 */
+{'[', 0x00f800c5, 0xfffffffc},/*kerning  Å ø : -0.015625 */
+{'[', 0x00f900c5, 0xfffffffe},/*kerning  Å ù : -0.007812 */
+{'[', 0x00fa00c5, 0xfffffffe},/*kerning  Å ú : -0.007812 */
+{'[', 0x00fb00c5, 0xfffffffe},/*kerning  Å û : -0.007812 */
+{'[', 0x00fc00c5, 0xfffffffe},/*kerning  Å ü : -0.007812 */
+{'[', 0x00fd00c5, 0xfffffff8},/*kerning  Å ý : -0.031250 */
+{'[', 0x00ff00c5, 0xfffffff8},/*kerning  Å ÿ : -0.031250 */
+{'@', 0x000000c6, 0x00009900},/*        Æ        x-advance: 153.000000 */
+{'M', 0x4288f5c2, 0xc2e33333},
+{'l', 0x429c28f6, 0x00000000},
+{'l', 0x00000000, 0x414cccd0},
+{'l', 0xc2700000, 0x00000000},
+{'l', 0x00000000, 0x4211eb84},
+{'l', 0x424d70a4, 0x00000000},
+{'l', 0x00000000, 0x414ccccc},
+{'l', 0xc24d70a4, 0x00000000},
+{'l', 0x00000000, 0x421ae148},
+{'l', 0x4275c290, 0x00000000},
+{'l', 0x00000000, 0x414ccccc},
+{'l', 0xc2975c29, 0x80000000},
+{'l', 0x00000000, 0xc2051eb8},
+{'l', 0xc21f5c29, 0x00000000},
+{'4', 0x010aff5a, 0x0000ff83},
+{'l', 0x4290f5c2, 0xc2e33333},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x428eb852, 0xc23851eb},
+{'4', 0xfe6b0000, 0x0195fefd},
+{'l', 0x4201eb86, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004300c6, 0xfffffffd},/*kerning  Æ C� : -0.011719 */
+{'[', 0x004700c6, 0xfffffffd},/*kerning  Æ G� : -0.011719 */
+{'[', 0x004f00c6, 0xfffffffd},/*kerning  Æ O� : -0.011719 */
+{'[', 0x005100c6, 0xfffffffd},/*kerning  Æ Q� : -0.011719 */
+{'[', 0x006300c6, 0xfffffffd},/*kerning  Æ c� : -0.011719 */
+{'[', 0x006400c6, 0xfffffffe},/*kerning  Æ d� : -0.007812 */
+{'[', 0x006500c6, 0xfffffffd},/*kerning  Æ e� : -0.011719 */
+{'[', 0x006600c6, 0xfffffffe},/*kerning  Æ f� : -0.007812 */
+{'[', 0x006700c6, 0xfffffffe},/*kerning  Æ g� : -0.007812 */
+{'[', 0x006d00c6, 0xffffffff},/*kerning  Æ m� : -0.003906 */
+{'[', 0x006e00c6, 0xffffffff},/*kerning  Æ n� : -0.003906 */
+{'[', 0x006f00c6, 0xfffffffd},/*kerning  Æ o� : -0.011719 */
+{'[', 0x007000c6, 0xffffffff},/*kerning  Æ p� : -0.003906 */
+{'[', 0x007100c6, 0xfffffffe},/*kerning  Æ q� : -0.007812 */
+{'[', 0x007200c6, 0xffffffff},/*kerning  Æ r� : -0.003906 */
+{'[', 0x007400c6, 0xffffffff},/*kerning  Æ t� : -0.003906 */
+{'[', 0x007500c6, 0xfffffffe},/*kerning  Æ u� : -0.007812 */
+{'[', 0x007600c6, 0xfffffffd},/*kerning  Æ v� : -0.011719 */
+{'[', 0x007700c6, 0xfffffffd},/*kerning  Æ w� : -0.011719 */
+{'[', 0x007900c6, 0xfffffffd},/*kerning  Æ y� : -0.011719 */
+{'[', 0x00c700c6, 0xfffffffd},/*kerning  Æ Ç : -0.011719 */
+{'[', 0x00d200c6, 0xfffffffd},/*kerning  Æ Ò : -0.011719 */
+{'[', 0x00d300c6, 0xfffffffd},/*kerning  Æ Ó : -0.011719 */
+{'[', 0x00d400c6, 0xfffffffd},/*kerning  Æ Ô : -0.011719 */
+{'[', 0x00d500c6, 0xfffffffd},/*kerning  Æ Õ : -0.011719 */
+{'[', 0x00d600c6, 0xfffffffd},/*kerning  Æ Ö : -0.011719 */
+{'[', 0x00d800c6, 0xfffffffd},/*kerning  Æ Ø : -0.011719 */
+{'[', 0x00e700c6, 0xfffffffd},/*kerning  Æ ç : -0.011719 */
+{'[', 0x00e800c6, 0xfffffffd},/*kerning  Æ è : -0.011719 */
+{'[', 0x00e900c6, 0xfffffffd},/*kerning  Æ é : -0.011719 */
+{'[', 0x00ea00c6, 0xfffffffd},/*kerning  Æ ê : -0.011719 */
+{'[', 0x00eb00c6, 0xfffffffd},/*kerning  Æ ë : -0.011719 */
+{'[', 0x00f000c6, 0xfffffffd},/*kerning  Æ ð : -0.011719 */
+{'[', 0x00f100c6, 0xffffffff},/*kerning  Æ ñ : -0.003906 */
+{'[', 0x00f200c6, 0xfffffffd},/*kerning  Æ ò : -0.011719 */
+{'[', 0x00f300c6, 0xfffffffd},/*kerning  Æ ó : -0.011719 */
+{'[', 0x00f400c6, 0xfffffffd},/*kerning  Æ ô : -0.011719 */
+{'[', 0x00f500c6, 0xfffffffd},/*kerning  Æ õ : -0.011719 */
+{'[', 0x00f600c6, 0xfffffffd},/*kerning  Æ ö : -0.011719 */
+{'[', 0x00f800c6, 0xfffffffd},/*kerning  Æ ø : -0.011719 */
+{'[', 0x00f900c6, 0xfffffffe},/*kerning  Æ ù : -0.007812 */
+{'[', 0x00fa00c6, 0xfffffffe},/*kerning  Æ ú : -0.007812 */
+{'[', 0x00fb00c6, 0xfffffffe},/*kerning  Æ û : -0.007812 */
+{'[', 0x00fc00c6, 0xfffffffe},/*kerning  Æ ü : -0.007812 */
+{'[', 0x00fd00c6, 0xfffffffd},/*kerning  Æ ý : -0.011719 */
+{'[', 0x00ff00c6, 0xfffffffd},/*kerning  Æ ÿ : -0.011719 */
+{'@', 0x000000c7, 0x00006d00},/*        Ç        x-advance: 109.000000 */
+{'M', 0x40c7ae14, 0xc2666666},
+{'q', 0x00000000, 0xc1266668},
+{0, 0x40666668, 0xc1a33334},
+{'q', 0x40666664, 0xc1200000},
+{0, 0x4128f5c2, 0xc191eb84},
+{'q', 0x40deb850, 0xc103d708},
+{0, 0x418851eb, 0xc151eb88},
+{'q', 0x412147b0, 0xc09c28f0},
+{0, 0x41b70a3e, 0xc09c28f0},
+{'q', 0x41733330, 0x00000000},
+{0, 0x41d0a3d4, 0x40deb850},
+{'9', 0x00370057, 0x008e0081},
+{'l', 0xc135c290, 0x40eb8510},
+{'8', 0xa5bcc7e6, 0xd0a7dfd7},
+{'q', 0xc0c00000, 0xbfe147c0},
+{0, 0xc13c28f0, 0xbfe147c0},
+{'q', 0xc1170a40, 0x00000000},
+{0, 0xc185c290, 0x4075c280},
+{'q', 0xc0e8f5c0, 0x4075c2a0},
+{0, 0xc143d708, 0x4123d710},
+{'q', 0xc09eb854, 0x40ccccd0},
+{0, 0xc0ee1480, 0x41651eb8},
+{'q', 0xc01eb850, 0x40fd70a0},
+{0, 0xc01eb850, 0x417eb850},
+{'q', 0x00000000, 0x410ccccc},
+{0, 0x403d70a0, 0x4187ae14},
+{'q', 0x403d70a8, 0x41028f5c},
+{0, 0x4103d70c, 0x41666668},
+{'q', 0x40a8f5c0, 0x40c7ae14},
+{0, 0x4147ae14, 0x411eb851},
+{'q', 0x40e66668, 0x406b851c},
+{0, 0x417ae148, 0x406b851c},
+{'8', 0xf061002f, 0xcd5df031},
+{'9', 0xffdd002b, 0xffa50045},
+{'l', 0x41400000, 0x40d1eb88},
+{'q', 0xc06147c0, 0x4107ae14},
+{0, 0xc12e1480, 0x41666666},
+{'q', 0xc0eb8510, 0x40bd70a2},
+{0, 0xc1833330, 0x410f5c28},
+{'q', 0xc110a3d8, 0x40428f5c},
+{0, 0xc18eb852, 0x40428f5c},
+{'q', 0xc13ae148, 0xb3800000},
+{0, 0xc1ab851e, 0xc0a147ae},
+{'q', 0xc11c28f8, 0xc0a147ae},
+{0, 0xc1870a3e, 0xc1570a3e},
+{'q', 0xc0e3d70c, 0xc1066666},
+{0, 0xc130a3d8, 0xc1970a3c},
+{'9', 0xffadffe1, 0xff57ffe1},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42670a3d, 0x41ee147b},
+{'8', 0xf8b800df, 0xe6b4f8d9},
+{'l', 0x4075c290, 0xc0fae144},
+{'8', 0x14300c19, 0x07320716},
+{'8', 0xf03d0027, 0xd215f015},
+{'8', 0xc8eae000, 0xd0c1e8ea},
+{'l', 0x40a3d710, 0xc06b851e},
+{'8', 0x42541f34, 0x57202220},
+{'8', 0x53dd3400, 0x1e9d1edd},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004100c7, 0xfffffffe},/*kerning  Ç A� : -0.007812 */
+{'[', 0x004300c7, 0xfffffffe},/*kerning  Ç C� : -0.007812 */
+{'[', 0x004700c7, 0xfffffffe},/*kerning  Ç G� : -0.007812 */
+{'[', 0x004f00c7, 0xfffffffe},/*kerning  Ç O� : -0.007812 */
+{'[', 0x005100c7, 0xfffffffe},/*kerning  Ç Q� : -0.007812 */
+{'[', 0x005600c7, 0xfffffffd},/*kerning  Ç V� : -0.011719 */
+{'[', 0x005700c7, 0xfffffffe},/*kerning  Ç W� : -0.007812 */
+{'[', 0x005800c7, 0xffffffff},/*kerning  Ç X� : -0.003906 */
+{'[', 0x005900c7, 0xfffffffc},/*kerning  Ç Y� : -0.015625 */
+{'[', 0x00c000c7, 0xfffffffe},/*kerning  Ç À : -0.007812 */
+{'[', 0x00c100c7, 0xfffffffe},/*kerning  Ç Á : -0.007812 */
+{'[', 0x00c200c7, 0xfffffffe},/*kerning  Ç Â : -0.007812 */
+{'[', 0x00c300c7, 0xfffffffe},/*kerning  Ç Ã : -0.007812 */
+{'[', 0x00c400c7, 0xfffffffe},/*kerning  Ç Ä : -0.007812 */
+{'[', 0x00c500c7, 0xfffffffe},/*kerning  Ç Å : -0.007812 */
+{'[', 0x00c600c7, 0xfffffffe},/*kerning  Ç Æ : -0.007812 */
+{'[', 0x00c700c7, 0xfffffffe},/*kerning  Ç Ç : -0.007812 */
+{'[', 0x00d200c7, 0xfffffffe},/*kerning  Ç Ò : -0.007812 */
+{'[', 0x00d300c7, 0xfffffffe},/*kerning  Ç Ó : -0.007812 */
+{'[', 0x00d400c7, 0xfffffffe},/*kerning  Ç Ô : -0.007812 */
+{'[', 0x00d500c7, 0xfffffffe},/*kerning  Ç Õ : -0.007812 */
+{'[', 0x00d600c7, 0xfffffffe},/*kerning  Ç Ö : -0.007812 */
+{'[', 0x00d800c7, 0xfffffffe},/*kerning  Ç Ø : -0.007812 */
+{'[', 0x00dd00c7, 0xfffffffc},/*kerning  Ç Ý : -0.015625 */
+{'@', 0x000000c8, 0x00006000},/*        È        x-advance: 96.000000 */
+{'M', 0x42b570a4, 0xc14ccccc},
+{'l', 0x00000000, 0x414ccccc},
+{'l', 0xc29a3d71, 0x80000000},
+{'l', 0x35800000, 0xc2e33333},
+{'l', 0x42975c29, 0x00000000},
+{'l', 0x00000000, 0x414cccd0},
+{'l', 0xc2751eb8, 0x00000000},
+{'l', 0x00000000, 0x42133332},
+{'l', 0x42551eb8, 0x00000000},
+{'l', 0x00000000, 0x41400000},
+{'4', 0x0000fe56, 0x01390000},
+{'l', 0x427ae148, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42133333, 0xc312b852},
+{'l', 0x415eb850, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d708, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004300c8, 0xfffffffd},/*kerning  È C� : -0.011719 */
+{'[', 0x004700c8, 0xfffffffd},/*kerning  È G� : -0.011719 */
+{'[', 0x004f00c8, 0xfffffffd},/*kerning  È O� : -0.011719 */
+{'[', 0x005100c8, 0xfffffffd},/*kerning  È Q� : -0.011719 */
+{'[', 0x006300c8, 0xfffffffd},/*kerning  È c� : -0.011719 */
+{'[', 0x006400c8, 0xfffffffe},/*kerning  È d� : -0.007812 */
+{'[', 0x006500c8, 0xfffffffd},/*kerning  È e� : -0.011719 */
+{'[', 0x006600c8, 0xfffffffe},/*kerning  È f� : -0.007812 */
+{'[', 0x006700c8, 0xfffffffe},/*kerning  È g� : -0.007812 */
+{'[', 0x006d00c8, 0xffffffff},/*kerning  È m� : -0.003906 */
+{'[', 0x006e00c8, 0xffffffff},/*kerning  È n� : -0.003906 */
+{'[', 0x006f00c8, 0xfffffffd},/*kerning  È o� : -0.011719 */
+{'[', 0x007000c8, 0xffffffff},/*kerning  È p� : -0.003906 */
+{'[', 0x007100c8, 0xfffffffe},/*kerning  È q� : -0.007812 */
+{'[', 0x007200c8, 0xffffffff},/*kerning  È r� : -0.003906 */
+{'[', 0x007400c8, 0xffffffff},/*kerning  È t� : -0.003906 */
+{'[', 0x007500c8, 0xfffffffe},/*kerning  È u� : -0.007812 */
+{'[', 0x007600c8, 0xfffffffd},/*kerning  È v� : -0.011719 */
+{'[', 0x007700c8, 0xfffffffd},/*kerning  È w� : -0.011719 */
+{'[', 0x007900c8, 0xfffffffd},/*kerning  È y� : -0.011719 */
+{'[', 0x00c700c8, 0xfffffffd},/*kerning  È Ç : -0.011719 */
+{'[', 0x00d200c8, 0xfffffffd},/*kerning  È Ò : -0.011719 */
+{'[', 0x00d300c8, 0xfffffffd},/*kerning  È Ó : -0.011719 */
+{'[', 0x00d400c8, 0xfffffffd},/*kerning  È Ô : -0.011719 */
+{'[', 0x00d500c8, 0xfffffffd},/*kerning  È Õ : -0.011719 */
+{'[', 0x00d600c8, 0xfffffffd},/*kerning  È Ö : -0.011719 */
+{'[', 0x00d800c8, 0xfffffffd},/*kerning  È Ø : -0.011719 */
+{'[', 0x00e700c8, 0xfffffffd},/*kerning  È ç : -0.011719 */
+{'[', 0x00e800c8, 0xfffffffd},/*kerning  È è : -0.011719 */
+{'[', 0x00e900c8, 0xfffffffd},/*kerning  È é : -0.011719 */
+{'[', 0x00ea00c8, 0xfffffffd},/*kerning  È ê : -0.011719 */
+{'[', 0x00eb00c8, 0xfffffffd},/*kerning  È ë : -0.011719 */
+{'[', 0x00f000c8, 0xfffffffd},/*kerning  È ð : -0.011719 */
+{'[', 0x00f100c8, 0xffffffff},/*kerning  È ñ : -0.003906 */
+{'[', 0x00f200c8, 0xfffffffd},/*kerning  È ò : -0.011719 */
+{'[', 0x00f300c8, 0xfffffffd},/*kerning  È ó : -0.011719 */
+{'[', 0x00f400c8, 0xfffffffd},/*kerning  È ô : -0.011719 */
+{'[', 0x00f500c8, 0xfffffffd},/*kerning  È õ : -0.011719 */
+{'[', 0x00f600c8, 0xfffffffd},/*kerning  È ö : -0.011719 */
+{'[', 0x00f800c8, 0xfffffffd},/*kerning  È ø : -0.011719 */
+{'[', 0x00f900c8, 0xfffffffe},/*kerning  È ù : -0.007812 */
+{'[', 0x00fa00c8, 0xfffffffe},/*kerning  È ú : -0.007812 */
+{'[', 0x00fb00c8, 0xfffffffe},/*kerning  È û : -0.007812 */
+{'[', 0x00fc00c8, 0xfffffffe},/*kerning  È ü : -0.007812 */
+{'[', 0x00fd00c8, 0xfffffffd},/*kerning  È ý : -0.011719 */
+{'[', 0x00ff00c8, 0xfffffffd},/*kerning  È ÿ : -0.011719 */
+{'@', 0x000000c9, 0x00006000},/*        É        x-advance: 96.000000 */
+{'M', 0x42b570a4, 0xc14ccccc},
+{'l', 0x00000000, 0x414ccccc},
+{'l', 0xc29a3d71, 0x80000000},
+{'l', 0x35800000, 0xc2e33333},
+{'l', 0x42975c29, 0x00000000},
+{'l', 0x00000000, 0x414cccd0},
+{'l', 0xc2751eb8, 0x00000000},
+{'l', 0x00000000, 0x42133332},
+{'l', 0x42551eb8, 0x00000000},
+{'l', 0x00000000, 0x41400000},
+{'4', 0x0000fe56, 0x01390000},
+{'l', 0x427ae148, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42699999, 0xc2fe6666},
+{'l', 0xc1147ae0, 0xc04cccc0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147ac, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004300c9, 0xfffffffd},/*kerning  É C� : -0.011719 */
+{'[', 0x004700c9, 0xfffffffd},/*kerning  É G� : -0.011719 */
+{'[', 0x004f00c9, 0xfffffffd},/*kerning  É O� : -0.011719 */
+{'[', 0x005100c9, 0xfffffffd},/*kerning  É Q� : -0.011719 */
+{'[', 0x006300c9, 0xfffffffd},/*kerning  É c� : -0.011719 */
+{'[', 0x006400c9, 0xfffffffe},/*kerning  É d� : -0.007812 */
+{'[', 0x006500c9, 0xfffffffd},/*kerning  É e� : -0.011719 */
+{'[', 0x006600c9, 0xfffffffe},/*kerning  É f� : -0.007812 */
+{'[', 0x006700c9, 0xfffffffe},/*kerning  É g� : -0.007812 */
+{'[', 0x006d00c9, 0xffffffff},/*kerning  É m� : -0.003906 */
+{'[', 0x006e00c9, 0xffffffff},/*kerning  É n� : -0.003906 */
+{'[', 0x006f00c9, 0xfffffffd},/*kerning  É o� : -0.011719 */
+{'[', 0x007000c9, 0xffffffff},/*kerning  É p� : -0.003906 */
+{'[', 0x007100c9, 0xfffffffe},/*kerning  É q� : -0.007812 */
+{'[', 0x007200c9, 0xffffffff},/*kerning  É r� : -0.003906 */
+{'[', 0x007400c9, 0xffffffff},/*kerning  É t� : -0.003906 */
+{'[', 0x007500c9, 0xfffffffe},/*kerning  É u� : -0.007812 */
+{'[', 0x007600c9, 0xfffffffd},/*kerning  É v� : -0.011719 */
+{'[', 0x007700c9, 0xfffffffd},/*kerning  É w� : -0.011719 */
+{'[', 0x007900c9, 0xfffffffd},/*kerning  É y� : -0.011719 */
+{'[', 0x00c700c9, 0xfffffffd},/*kerning  É Ç : -0.011719 */
+{'[', 0x00d200c9, 0xfffffffd},/*kerning  É Ò : -0.011719 */
+{'[', 0x00d300c9, 0xfffffffd},/*kerning  É Ó : -0.011719 */
+{'[', 0x00d400c9, 0xfffffffd},/*kerning  É Ô : -0.011719 */
+{'[', 0x00d500c9, 0xfffffffd},/*kerning  É Õ : -0.011719 */
+{'[', 0x00d600c9, 0xfffffffd},/*kerning  É Ö : -0.011719 */
+{'[', 0x00d800c9, 0xfffffffd},/*kerning  É Ø : -0.011719 */
+{'[', 0x00e700c9, 0xfffffffd},/*kerning  É ç : -0.011719 */
+{'[', 0x00e800c9, 0xfffffffd},/*kerning  É è : -0.011719 */
+{'[', 0x00e900c9, 0xfffffffd},/*kerning  É é : -0.011719 */
+{'[', 0x00ea00c9, 0xfffffffd},/*kerning  É ê : -0.011719 */
+{'[', 0x00eb00c9, 0xfffffffd},/*kerning  É ë : -0.011719 */
+{'[', 0x00f000c9, 0xfffffffd},/*kerning  É ð : -0.011719 */
+{'[', 0x00f100c9, 0xffffffff},/*kerning  É ñ : -0.003906 */
+{'[', 0x00f200c9, 0xfffffffd},/*kerning  É ò : -0.011719 */
+{'[', 0x00f300c9, 0xfffffffd},/*kerning  É ó : -0.011719 */
+{'[', 0x00f400c9, 0xfffffffd},/*kerning  É ô : -0.011719 */
+{'[', 0x00f500c9, 0xfffffffd},/*kerning  É õ : -0.011719 */
+{'[', 0x00f600c9, 0xfffffffd},/*kerning  É ö : -0.011719 */
+{'[', 0x00f800c9, 0xfffffffd},/*kerning  É ø : -0.011719 */
+{'[', 0x00f900c9, 0xfffffffe},/*kerning  É ù : -0.007812 */
+{'[', 0x00fa00c9, 0xfffffffe},/*kerning  É ú : -0.007812 */
+{'[', 0x00fb00c9, 0xfffffffe},/*kerning  É û : -0.007812 */
+{'[', 0x00fc00c9, 0xfffffffe},/*kerning  É ü : -0.007812 */
+{'[', 0x00fd00c9, 0xfffffffd},/*kerning  É ý : -0.011719 */
+{'[', 0x00ff00c9, 0xfffffffd},/*kerning  É ÿ : -0.011719 */
+{'@', 0x000000ca, 0x00006000},/*        Ê        x-advance: 96.000000 */
+{'M', 0x42b570a4, 0xc14ccccc},
+{'l', 0x00000000, 0x414ccccc},
+{'l', 0xc29a3d71, 0x80000000},
+{'l', 0x35800000, 0xc2e33333},
+{'l', 0x42975c29, 0x00000000},
+{'l', 0x00000000, 0x414cccd0},
+{'l', 0xc2751eb8, 0x00000000},
+{'l', 0x00000000, 0x42133332},
+{'l', 0x42551eb8, 0x00000000},
+{'l', 0x00000000, 0x41400000},
+{'4', 0x0000fe56, 0x01390000},
+{'l', 0x427ae148, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4200a3d7, 0xc30428f6},
+{'l', 0x418147ae, 0xc1666660},
+{'l', 0x4123d708, 0x00000000},
+{'l', 0x418147b0, 0x41666660},
+{'0', 0xb0941ec3, 0xe2c35094},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004300ca, 0xfffffffd},/*kerning  Ê C� : -0.011719 */
+{'[', 0x004700ca, 0xfffffffd},/*kerning  Ê G� : -0.011719 */
+{'[', 0x004f00ca, 0xfffffffd},/*kerning  Ê O� : -0.011719 */
+{'[', 0x005100ca, 0xfffffffd},/*kerning  Ê Q� : -0.011719 */
+{'[', 0x006300ca, 0xfffffffd},/*kerning  Ê c� : -0.011719 */
+{'[', 0x006400ca, 0xfffffffe},/*kerning  Ê d� : -0.007812 */
+{'[', 0x006500ca, 0xfffffffd},/*kerning  Ê e� : -0.011719 */
+{'[', 0x006600ca, 0xfffffffe},/*kerning  Ê f� : -0.007812 */
+{'[', 0x006700ca, 0xfffffffe},/*kerning  Ê g� : -0.007812 */
+{'[', 0x006d00ca, 0xffffffff},/*kerning  Ê m� : -0.003906 */
+{'[', 0x006e00ca, 0xffffffff},/*kerning  Ê n� : -0.003906 */
+{'[', 0x006f00ca, 0xfffffffd},/*kerning  Ê o� : -0.011719 */
+{'[', 0x007000ca, 0xffffffff},/*kerning  Ê p� : -0.003906 */
+{'[', 0x007100ca, 0xfffffffe},/*kerning  Ê q� : -0.007812 */
+{'[', 0x007200ca, 0xffffffff},/*kerning  Ê r� : -0.003906 */
+{'[', 0x007400ca, 0xffffffff},/*kerning  Ê t� : -0.003906 */
+{'[', 0x007500ca, 0xfffffffe},/*kerning  Ê u� : -0.007812 */
+{'[', 0x007600ca, 0xfffffffd},/*kerning  Ê v� : -0.011719 */
+{'[', 0x007700ca, 0xfffffffd},/*kerning  Ê w� : -0.011719 */
+{'[', 0x007900ca, 0xfffffffd},/*kerning  Ê y� : -0.011719 */
+{'[', 0x00c700ca, 0xfffffffd},/*kerning  Ê Ç : -0.011719 */
+{'[', 0x00d200ca, 0xfffffffd},/*kerning  Ê Ò : -0.011719 */
+{'[', 0x00d300ca, 0xfffffffd},/*kerning  Ê Ó : -0.011719 */
+{'[', 0x00d400ca, 0xfffffffd},/*kerning  Ê Ô : -0.011719 */
+{'[', 0x00d500ca, 0xfffffffd},/*kerning  Ê Õ : -0.011719 */
+{'[', 0x00d600ca, 0xfffffffd},/*kerning  Ê Ö : -0.011719 */
+{'[', 0x00d800ca, 0xfffffffd},/*kerning  Ê Ø : -0.011719 */
+{'[', 0x00e700ca, 0xfffffffd},/*kerning  Ê ç : -0.011719 */
+{'[', 0x00e800ca, 0xfffffffd},/*kerning  Ê è : -0.011719 */
+{'[', 0x00e900ca, 0xfffffffd},/*kerning  Ê é : -0.011719 */
+{'[', 0x00ea00ca, 0xfffffffd},/*kerning  Ê ê : -0.011719 */
+{'[', 0x00eb00ca, 0xfffffffd},/*kerning  Ê ë : -0.011719 */
+{'[', 0x00f000ca, 0xfffffffd},/*kerning  Ê ð : -0.011719 */
+{'[', 0x00f100ca, 0xffffffff},/*kerning  Ê ñ : -0.003906 */
+{'[', 0x00f200ca, 0xfffffffd},/*kerning  Ê ò : -0.011719 */
+{'[', 0x00f300ca, 0xfffffffd},/*kerning  Ê ó : -0.011719 */
+{'[', 0x00f400ca, 0xfffffffd},/*kerning  Ê ô : -0.011719 */
+{'[', 0x00f500ca, 0xfffffffd},/*kerning  Ê õ : -0.011719 */
+{'[', 0x00f600ca, 0xfffffffd},/*kerning  Ê ö : -0.011719 */
+{'[', 0x00f800ca, 0xfffffffd},/*kerning  Ê ø : -0.011719 */
+{'[', 0x00f900ca, 0xfffffffe},/*kerning  Ê ù : -0.007812 */
+{'[', 0x00fa00ca, 0xfffffffe},/*kerning  Ê ú : -0.007812 */
+{'[', 0x00fb00ca, 0xfffffffe},/*kerning  Ê û : -0.007812 */
+{'[', 0x00fc00ca, 0xfffffffe},/*kerning  Ê ü : -0.007812 */
+{'[', 0x00fd00ca, 0xfffffffd},/*kerning  Ê ý : -0.011719 */
+{'[', 0x00ff00ca, 0xfffffffd},/*kerning  Ê ÿ : -0.011719 */
+{'@', 0x000000cb, 0x00006000},/*        Ë        x-advance: 96.000000 */
+{'M', 0x42b570a4, 0xc14ccccc},
+{'l', 0x00000000, 0x414ccccc},
+{'l', 0xc29a3d71, 0x80000000},
+{'l', 0x35800000, 0xc2e33333},
+{'l', 0x42975c29, 0x00000000},
+{'l', 0x00000000, 0x414cccd0},
+{'l', 0xc2751eb8, 0x00000000},
+{'l', 0x00000000, 0x42133332},
+{'l', 0x42551eb8, 0x00000000},
+{'l', 0x00000000, 0x41400000},
+{'4', 0x0000fe56, 0x01390000},
+{'l', 0x427ae148, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x420a3d70, 0xc301c28f},
+{'l', 0x00000000, 0xc1828f60},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4271eb85, 0xc301c28f},
+{'l', 0x00000000, 0xc1828f60},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004300cb, 0xfffffffd},/*kerning  Ë C� : -0.011719 */
+{'[', 0x004700cb, 0xfffffffd},/*kerning  Ë G� : -0.011719 */
+{'[', 0x004f00cb, 0xfffffffd},/*kerning  Ë O� : -0.011719 */
+{'[', 0x005100cb, 0xfffffffd},/*kerning  Ë Q� : -0.011719 */
+{'[', 0x006300cb, 0xfffffffd},/*kerning  Ë c� : -0.011719 */
+{'[', 0x006400cb, 0xfffffffe},/*kerning  Ë d� : -0.007812 */
+{'[', 0x006500cb, 0xfffffffd},/*kerning  Ë e� : -0.011719 */
+{'[', 0x006600cb, 0xfffffffe},/*kerning  Ë f� : -0.007812 */
+{'[', 0x006700cb, 0xfffffffe},/*kerning  Ë g� : -0.007812 */
+{'[', 0x006d00cb, 0xffffffff},/*kerning  Ë m� : -0.003906 */
+{'[', 0x006e00cb, 0xffffffff},/*kerning  Ë n� : -0.003906 */
+{'[', 0x006f00cb, 0xfffffffd},/*kerning  Ë o� : -0.011719 */
+{'[', 0x007000cb, 0xffffffff},/*kerning  Ë p� : -0.003906 */
+{'[', 0x007100cb, 0xfffffffe},/*kerning  Ë q� : -0.007812 */
+{'[', 0x007200cb, 0xffffffff},/*kerning  Ë r� : -0.003906 */
+{'[', 0x007400cb, 0xffffffff},/*kerning  Ë t� : -0.003906 */
+{'[', 0x007500cb, 0xfffffffe},/*kerning  Ë u� : -0.007812 */
+{'[', 0x007600cb, 0xfffffffd},/*kerning  Ë v� : -0.011719 */
+{'[', 0x007700cb, 0xfffffffd},/*kerning  Ë w� : -0.011719 */
+{'[', 0x007900cb, 0xfffffffd},/*kerning  Ë y� : -0.011719 */
+{'[', 0x00c700cb, 0xfffffffd},/*kerning  Ë Ç : -0.011719 */
+{'[', 0x00d200cb, 0xfffffffd},/*kerning  Ë Ò : -0.011719 */
+{'[', 0x00d300cb, 0xfffffffd},/*kerning  Ë Ó : -0.011719 */
+{'[', 0x00d400cb, 0xfffffffd},/*kerning  Ë Ô : -0.011719 */
+{'[', 0x00d500cb, 0xfffffffd},/*kerning  Ë Õ : -0.011719 */
+{'[', 0x00d600cb, 0xfffffffd},/*kerning  Ë Ö : -0.011719 */
+{'[', 0x00d800cb, 0xfffffffd},/*kerning  Ë Ø : -0.011719 */
+{'[', 0x00e700cb, 0xfffffffd},/*kerning  Ë ç : -0.011719 */
+{'[', 0x00e800cb, 0xfffffffd},/*kerning  Ë è : -0.011719 */
+{'[', 0x00e900cb, 0xfffffffd},/*kerning  Ë é : -0.011719 */
+{'[', 0x00ea00cb, 0xfffffffd},/*kerning  Ë ê : -0.011719 */
+{'[', 0x00eb00cb, 0xfffffffd},/*kerning  Ë ë : -0.011719 */
+{'[', 0x00f000cb, 0xfffffffd},/*kerning  Ë ð : -0.011719 */
+{'[', 0x00f100cb, 0xffffffff},/*kerning  Ë ñ : -0.003906 */
+{'[', 0x00f200cb, 0xfffffffd},/*kerning  Ë ò : -0.011719 */
+{'[', 0x00f300cb, 0xfffffffd},/*kerning  Ë ó : -0.011719 */
+{'[', 0x00f400cb, 0xfffffffd},/*kerning  Ë ô : -0.011719 */
+{'[', 0x00f500cb, 0xfffffffd},/*kerning  Ë õ : -0.011719 */
+{'[', 0x00f600cb, 0xfffffffd},/*kerning  Ë ö : -0.011719 */
+{'[', 0x00f800cb, 0xfffffffd},/*kerning  Ë ø : -0.011719 */
+{'[', 0x00f900cb, 0xfffffffe},/*kerning  Ë ù : -0.007812 */
+{'[', 0x00fa00cb, 0xfffffffe},/*kerning  Ë ú : -0.007812 */
+{'[', 0x00fb00cb, 0xfffffffe},/*kerning  Ë û : -0.007812 */
+{'[', 0x00fc00cb, 0xfffffffe},/*kerning  Ë ü : -0.007812 */
+{'[', 0x00fd00cb, 0xfffffffd},/*kerning  Ë ý : -0.011719 */
+{'[', 0x00ff00cb, 0xfffffffd},/*kerning  Ë ÿ : -0.011719 */
+{'@', 0x000000cc, 0x00002900},/*        Ì        x-advance: 41.000000 */
+{'M', 0x41599999, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'4', 0x00000073, 0x038c0000},
+{'l', 0xc1666667, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x40851eb8, 0xc312b852},
+{'l', 0x415eb852, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d70a, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x006100cc, 0xffffffff},/*kerning  Ì a� : -0.003906 */
+{'[', 0x006300cc, 0xfffffffe},/*kerning  Ì c� : -0.007812 */
+{'[', 0x006400cc, 0xfffffffe},/*kerning  Ì d� : -0.007812 */
+{'[', 0x006500cc, 0xfffffffe},/*kerning  Ì e� : -0.007812 */
+{'[', 0x006600cc, 0xffffffff},/*kerning  Ì f� : -0.003906 */
+{'[', 0x006700cc, 0xfffffffe},/*kerning  Ì g� : -0.007812 */
+{'[', 0x006f00cc, 0xfffffffe},/*kerning  Ì o� : -0.007812 */
+{'[', 0x007100cc, 0xfffffffe},/*kerning  Ì q� : -0.007812 */
+{'[', 0x007300cc, 0xffffffff},/*kerning  Ì s� : -0.003906 */
+{'[', 0x007400cc, 0xffffffff},/*kerning  Ì t� : -0.003906 */
+{'[', 0x00e000cc, 0xffffffff},/*kerning  Ì à : -0.003906 */
+{'[', 0x00e100cc, 0xffffffff},/*kerning  Ì á : -0.003906 */
+{'[', 0x00e200cc, 0xffffffff},/*kerning  Ì â : -0.003906 */
+{'[', 0x00e300cc, 0xffffffff},/*kerning  Ì ã : -0.003906 */
+{'[', 0x00e400cc, 0xffffffff},/*kerning  Ì ä : -0.003906 */
+{'[', 0x00e500cc, 0xffffffff},/*kerning  Ì å : -0.003906 */
+{'[', 0x00e600cc, 0xffffffff},/*kerning  Ì æ : -0.003906 */
+{'[', 0x00e700cc, 0xfffffffe},/*kerning  Ì ç : -0.007812 */
+{'[', 0x00e800cc, 0xfffffffe},/*kerning  Ì è : -0.007812 */
+{'[', 0x00e900cc, 0xfffffffe},/*kerning  Ì é : -0.007812 */
+{'[', 0x00ea00cc, 0xfffffffe},/*kerning  Ì ê : -0.007812 */
+{'[', 0x00eb00cc, 0xfffffffe},/*kerning  Ì ë : -0.007812 */
+{'[', 0x00f000cc, 0xfffffffe},/*kerning  Ì ð : -0.007812 */
+{'[', 0x00f200cc, 0xfffffffe},/*kerning  Ì ò : -0.007812 */
+{'[', 0x00f300cc, 0xfffffffe},/*kerning  Ì ó : -0.007812 */
+{'[', 0x00f400cc, 0xfffffffe},/*kerning  Ì ô : -0.007812 */
+{'[', 0x00f500cc, 0xfffffffe},/*kerning  Ì õ : -0.007812 */
+{'[', 0x00f600cc, 0xfffffffe},/*kerning  Ì ö : -0.007812 */
+{'[', 0x00f800cc, 0xfffffffe},/*kerning  Ì ø : -0.007812 */
+{'@', 0x000000cd, 0x00002900},/*        Í        x-advance: 41.000000 */
+{'M', 0x41599999, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'4', 0x00000073, 0x038c0000},
+{'l', 0xc1666667, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41ce147b, 0xc2fe6666},
+{'l', 0xc1147ae2, 0xc04cccc0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147ae, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x006100cd, 0xffffffff},/*kerning  Í a� : -0.003906 */
+{'[', 0x006300cd, 0xfffffffe},/*kerning  Í c� : -0.007812 */
+{'[', 0x006400cd, 0xfffffffe},/*kerning  Í d� : -0.007812 */
+{'[', 0x006500cd, 0xfffffffe},/*kerning  Í e� : -0.007812 */
+{'[', 0x006600cd, 0xffffffff},/*kerning  Í f� : -0.003906 */
+{'[', 0x006700cd, 0xfffffffe},/*kerning  Í g� : -0.007812 */
+{'[', 0x006f00cd, 0xfffffffe},/*kerning  Í o� : -0.007812 */
+{'[', 0x007100cd, 0xfffffffe},/*kerning  Í q� : -0.007812 */
+{'[', 0x007300cd, 0xffffffff},/*kerning  Í s� : -0.003906 */
+{'[', 0x007400cd, 0xffffffff},/*kerning  Í t� : -0.003906 */
+{'[', 0x00e000cd, 0xffffffff},/*kerning  Í à : -0.003906 */
+{'[', 0x00e100cd, 0xffffffff},/*kerning  Í á : -0.003906 */
+{'[', 0x00e200cd, 0xffffffff},/*kerning  Í â : -0.003906 */
+{'[', 0x00e300cd, 0xffffffff},/*kerning  Í ã : -0.003906 */
+{'[', 0x00e400cd, 0xffffffff},/*kerning  Í ä : -0.003906 */
+{'[', 0x00e500cd, 0xffffffff},/*kerning  Í å : -0.003906 */
+{'[', 0x00e600cd, 0xffffffff},/*kerning  Í æ : -0.003906 */
+{'[', 0x00e700cd, 0xfffffffe},/*kerning  Í ç : -0.007812 */
+{'[', 0x00e800cd, 0xfffffffe},/*kerning  Í è : -0.007812 */
+{'[', 0x00e900cd, 0xfffffffe},/*kerning  Í é : -0.007812 */
+{'[', 0x00ea00cd, 0xfffffffe},/*kerning  Í ê : -0.007812 */
+{'[', 0x00eb00cd, 0xfffffffe},/*kerning  Í ë : -0.007812 */
+{'[', 0x00f000cd, 0xfffffffe},/*kerning  Í ð : -0.007812 */
+{'[', 0x00f200cd, 0xfffffffe},/*kerning  Í ò : -0.007812 */
+{'[', 0x00f300cd, 0xfffffffe},/*kerning  Í ó : -0.007812 */
+{'[', 0x00f400cd, 0xfffffffe},/*kerning  Í ô : -0.007812 */
+{'[', 0x00f500cd, 0xfffffffe},/*kerning  Í õ : -0.007812 */
+{'[', 0x00f600cd, 0xfffffffe},/*kerning  Í ö : -0.007812 */
+{'[', 0x00f800cd, 0xfffffffe},/*kerning  Í ø : -0.007812 */
+{'@', 0x000000ce, 0x00002900},/*        Î        x-advance: 41.000000 */
+{'M', 0x41599999, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'4', 0x00000073, 0x038c0000},
+{'l', 0xc1666667, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0xbef5c28f, 0xc30428f6},
+{'l', 0x418147ae, 0xc1666660},
+{'l', 0x4123d70a, 0x00000000},
+{'l', 0x418147ad, 0x41666660},
+{'0', 0xb0941ec3, 0xe2c35094},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x006100ce, 0xffffffff},/*kerning  Î a� : -0.003906 */
+{'[', 0x006300ce, 0xfffffffe},/*kerning  Î c� : -0.007812 */
+{'[', 0x006400ce, 0xfffffffe},/*kerning  Î d� : -0.007812 */
+{'[', 0x006500ce, 0xfffffffe},/*kerning  Î e� : -0.007812 */
+{'[', 0x006600ce, 0xffffffff},/*kerning  Î f� : -0.003906 */
+{'[', 0x006700ce, 0xfffffffe},/*kerning  Î g� : -0.007812 */
+{'[', 0x006f00ce, 0xfffffffe},/*kerning  Î o� : -0.007812 */
+{'[', 0x007100ce, 0xfffffffe},/*kerning  Î q� : -0.007812 */
+{'[', 0x007300ce, 0xffffffff},/*kerning  Î s� : -0.003906 */
+{'[', 0x007400ce, 0xffffffff},/*kerning  Î t� : -0.003906 */
+{'[', 0x00e000ce, 0xffffffff},/*kerning  Î à : -0.003906 */
+{'[', 0x00e100ce, 0xffffffff},/*kerning  Î á : -0.003906 */
+{'[', 0x00e200ce, 0xffffffff},/*kerning  Î â : -0.003906 */
+{'[', 0x00e300ce, 0xffffffff},/*kerning  Î ã : -0.003906 */
+{'[', 0x00e400ce, 0xffffffff},/*kerning  Î ä : -0.003906 */
+{'[', 0x00e500ce, 0xffffffff},/*kerning  Î å : -0.003906 */
+{'[', 0x00e600ce, 0xffffffff},/*kerning  Î æ : -0.003906 */
+{'[', 0x00e700ce, 0xfffffffe},/*kerning  Î ç : -0.007812 */
+{'[', 0x00e800ce, 0xfffffffe},/*kerning  Î è : -0.007812 */
+{'[', 0x00e900ce, 0xfffffffe},/*kerning  Î é : -0.007812 */
+{'[', 0x00ea00ce, 0xfffffffe},/*kerning  Î ê : -0.007812 */
+{'[', 0x00eb00ce, 0xfffffffe},/*kerning  Î ë : -0.007812 */
+{'[', 0x00f000ce, 0xfffffffe},/*kerning  Î ð : -0.007812 */
+{'[', 0x00f200ce, 0xfffffffe},/*kerning  Î ò : -0.007812 */
+{'[', 0x00f300ce, 0xfffffffe},/*kerning  Î ó : -0.007812 */
+{'[', 0x00f400ce, 0xfffffffe},/*kerning  Î ô : -0.007812 */
+{'[', 0x00f500ce, 0xfffffffe},/*kerning  Î õ : -0.007812 */
+{'[', 0x00f600ce, 0xfffffffe},/*kerning  Î ö : -0.007812 */
+{'[', 0x00f800ce, 0xfffffffe},/*kerning  Î ø : -0.007812 */
+{'@', 0x000000cf, 0x00002900},/*        Ï        x-advance: 41.000000 */
+{'M', 0x41599999, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'4', 0x00000073, 0x038c0000},
+{'l', 0xc1666667, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x3ff5c28f, 0xc301c28f},
+{'l', 0x00000000, 0xc1828f60},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a3, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41deb852, 0xc301c28f},
+{'l', 0x00000000, 0xc1828f60},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x006100cf, 0xffffffff},/*kerning  Ï a� : -0.003906 */
+{'[', 0x006300cf, 0xfffffffe},/*kerning  Ï c� : -0.007812 */
+{'[', 0x006400cf, 0xfffffffe},/*kerning  Ï d� : -0.007812 */
+{'[', 0x006500cf, 0xfffffffe},/*kerning  Ï e� : -0.007812 */
+{'[', 0x006600cf, 0xffffffff},/*kerning  Ï f� : -0.003906 */
+{'[', 0x006700cf, 0xfffffffe},/*kerning  Ï g� : -0.007812 */
+{'[', 0x006f00cf, 0xfffffffe},/*kerning  Ï o� : -0.007812 */
+{'[', 0x007100cf, 0xfffffffe},/*kerning  Ï q� : -0.007812 */
+{'[', 0x007300cf, 0xffffffff},/*kerning  Ï s� : -0.003906 */
+{'[', 0x007400cf, 0xffffffff},/*kerning  Ï t� : -0.003906 */
+{'[', 0x00e000cf, 0xffffffff},/*kerning  Ï à : -0.003906 */
+{'[', 0x00e100cf, 0xffffffff},/*kerning  Ï á : -0.003906 */
+{'[', 0x00e200cf, 0xffffffff},/*kerning  Ï â : -0.003906 */
+{'[', 0x00e300cf, 0xffffffff},/*kerning  Ï ã : -0.003906 */
+{'[', 0x00e400cf, 0xffffffff},/*kerning  Ï ä : -0.003906 */
+{'[', 0x00e500cf, 0xffffffff},/*kerning  Ï å : -0.003906 */
+{'[', 0x00e600cf, 0xffffffff},/*kerning  Ï æ : -0.003906 */
+{'[', 0x00e700cf, 0xfffffffe},/*kerning  Ï ç : -0.007812 */
+{'[', 0x00e800cf, 0xfffffffe},/*kerning  Ï è : -0.007812 */
+{'[', 0x00e900cf, 0xfffffffe},/*kerning  Ï é : -0.007812 */
+{'[', 0x00ea00cf, 0xfffffffe},/*kerning  Ï ê : -0.007812 */
+{'[', 0x00eb00cf, 0xfffffffe},/*kerning  Ï ë : -0.007812 */
+{'[', 0x00f000cf, 0xfffffffe},/*kerning  Ï ð : -0.007812 */
+{'[', 0x00f200cf, 0xfffffffe},/*kerning  Ï ò : -0.007812 */
+{'[', 0x00f300cf, 0xfffffffe},/*kerning  Ï ó : -0.007812 */
+{'[', 0x00f400cf, 0xfffffffe},/*kerning  Ï ô : -0.007812 */
+{'[', 0x00f500cf, 0xfffffffe},/*kerning  Ï õ : -0.007812 */
+{'[', 0x00f600cf, 0xfffffffe},/*kerning  Ï ö : -0.007812 */
+{'[', 0x00f800cf, 0xfffffffe},/*kerning  Ï ø : -0.007812 */
+{'@', 0x000000d0, 0x00007300},/*        Ð        x-advance: 115.000000 */
+{'M', 0x4168f5c2, 0x80000000},
+{'l', 0x00000000, 0xc24eb852},
+{'l', 0xc111eb84, 0x00000000},
+{'l', 0xb5000000, 0xc12e1478},
+{'4', 0x00000048, 0xfe680000},
+{'l', 0x421d70a4, 0x00000000},
+{'q', 0x4191eb84, 0x00000000},
+{0, 0x41f3d708, 0x40f33330},
+{'q', 0x4143d710, 0x40f33330},
+{0, 0x41928f60, 0x41a3d708},
+{'q', 0x40c28f50, 0x414e1480},
+{0, 0x40c28f50, 0x41e47ae4},
+{'q', 0x00000000, 0x418a3d70},
+{0, 0xc0d70a30, 0x41f0a3d6},
+{'q', 0xc0d70a40, 0x414cccce},
+{0, 0xc19851ec, 0x419eb852},
+{'9', 0x0038ff9e, 0x0038ff18},
+{'l', 0xc21d70a4, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42bc7ae1, 0xc263d70a},
+{'q', 0x00000000, 0xc14cccd0},
+{0, 0xc0970a40, 0xc1b5c290},
+{'q', 0xc0970a40, 0xc11eb850},
+{0, 0xc15ae148, 0xc17851e8},
+{'9', 0xffd4ffb9, 0xffd4ff51},
+{'l', 0xc1c7ae14, 0x00000000},
+{'l', 0x00000000, 0x4218f5c2},
+{'l', 0x41ce147a, 0x00000000},
+{'l', 0x00000000, 0x412e1478},
+{'4', 0x0000ff32, 0x01370000},
+{'l', 0x41c7ae14, 0x00000000},
+{'q', 0x4151eb88, 0x00000000},
+{0, 0x41b0a3d8, 0xc0bae148},
+{'q', 0x410f5c28, 0xc0bae148},
+{0, 0x41599998, 0xc17d70a4},
+{'q', 0x40947ae0, 0xc1200000},
+{0, 0x40947ae0, 0xc1b3d70a},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002900d0, 0xfffffffc},/*kerning  Ð )� : -0.015625 */
+{'[', 0x002c00d0, 0xfffffffd},/*kerning  Ð ,� : -0.011719 */
+{'[', 0x002e00d0, 0xfffffffd},/*kerning  Ð .� : -0.011719 */
+{'[', 0x002f00d0, 0xfffffffa},/*kerning  Ð /� : -0.023438 */
+{'[', 0x004100d0, 0xfffffffa},/*kerning  Ð A� : -0.023438 */
+{'[', 0x004a00d0, 0xfffffffb},/*kerning  Ð J� : -0.019531 */
+{'[', 0x005400d0, 0xfffffffc},/*kerning  Ð T� : -0.015625 */
+{'[', 0x005600d0, 0xfffffffa},/*kerning  Ð V� : -0.023438 */
+{'[', 0x005700d0, 0xfffffffa},/*kerning  Ð W� : -0.023438 */
+{'[', 0x005800d0, 0xfffffff8},/*kerning  Ð X� : -0.031250 */
+{'[', 0x005900d0, 0xfffffff5},/*kerning  Ð Y� : -0.042969 */
+{'[', 0x005a00d0, 0xfffffffd},/*kerning  Ð Z� : -0.011719 */
+{'[', 0x005c00d0, 0xfffffffb},/*kerning  Ð \� : -0.019531 */
+{'[', 0x006100d0, 0xffffffff},/*kerning  Ð a� : -0.003906 */
+{'[', 0x007300d0, 0xffffffff},/*kerning  Ð s� : -0.003906 */
+{'[', 0x007800d0, 0xfffffffe},/*kerning  Ð x� : -0.007812 */
+{'[', 0x00c000d0, 0xfffffffa},/*kerning  Ð À : -0.023438 */
+{'[', 0x00c100d0, 0xfffffffa},/*kerning  Ð Á : -0.023438 */
+{'[', 0x00c200d0, 0xfffffffa},/*kerning  Ð Â : -0.023438 */
+{'[', 0x00c300d0, 0xfffffffa},/*kerning  Ð Ã : -0.023438 */
+{'[', 0x00c400d0, 0xfffffffa},/*kerning  Ð Ä : -0.023438 */
+{'[', 0x00c500d0, 0xfffffffa},/*kerning  Ð Å : -0.023438 */
+{'[', 0x00c600d0, 0xfffffff9},/*kerning  Ð Æ : -0.027344 */
+{'[', 0x00d000d0, 0xffffffff},/*kerning  Ð Ð : -0.003906 */
+{'[', 0x00dd00d0, 0xfffffff5},/*kerning  Ð Ý : -0.042969 */
+{'[', 0x00e000d0, 0xffffffff},/*kerning  Ð à : -0.003906 */
+{'[', 0x00e100d0, 0xffffffff},/*kerning  Ð á : -0.003906 */
+{'[', 0x00e200d0, 0xffffffff},/*kerning  Ð â : -0.003906 */
+{'[', 0x00e300d0, 0xffffffff},/*kerning  Ð ã : -0.003906 */
+{'[', 0x00e400d0, 0xffffffff},/*kerning  Ð ä : -0.003906 */
+{'[', 0x00e500d0, 0xffffffff},/*kerning  Ð å : -0.003906 */
+{'[', 0x00e600d0, 0xffffffff},/*kerning  Ð æ : -0.003906 */
+{'@', 0x000000d1, 0x00007b00},/*        Ñ        x-advance: 123.000000 */
+{'M', 0x41e00000, 0xc2ae147b},
+{'l', 0x00000000, 0x42ae147b},
+{'l', 0xc1666667, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'l', 0x41428f5d, 0x00000000},
+{'l', 0x428ae147, 0x42b1999a},
+{'l', 0x00000000, 0xc2b147ae},
+{'l', 0x41666668, 0x00000000},
+{'4', 0x038b0000, 0x0000ff98},
+{'l', 0xc288f5c2, 0xc2ae147b},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x428fae14, 0xc302147b},
+{'8', 0xf3bf00da, 0xe6cff3e6},
+{'8', 0xf3cef3ea, 0x0ed700e4},
+{'8', 0x1def0ef3, 0x11fd0ffd},
+{'l', 0xc1051eb8, 0x00000000},
+{'8', 0xe405f900, 0xd413eb05},
+{'8', 0xd826e90e, 0xef3eef18},
+{'8', 0x0d3e0025, 0x1b300d18},
+{'8', 0x0e360e17, 0xf2300021},
+{'8', 0xe213f20e, 0xef04f104},
+{'l', 0x41051eb8, 0x00000000},
+{'8', 0x1cfb0700, 0x2ceb14fb},
+{'8', 0x29d718f1, 0x11bd11e6},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x006100d1, 0xffffffff},/*kerning  Ñ a� : -0.003906 */
+{'[', 0x006300d1, 0xfffffffe},/*kerning  Ñ c� : -0.007812 */
+{'[', 0x006400d1, 0xfffffffe},/*kerning  Ñ d� : -0.007812 */
+{'[', 0x006500d1, 0xfffffffe},/*kerning  Ñ e� : -0.007812 */
+{'[', 0x006600d1, 0xffffffff},/*kerning  Ñ f� : -0.003906 */
+{'[', 0x006700d1, 0xfffffffe},/*kerning  Ñ g� : -0.007812 */
+{'[', 0x006f00d1, 0xfffffffe},/*kerning  Ñ o� : -0.007812 */
+{'[', 0x007100d1, 0xfffffffe},/*kerning  Ñ q� : -0.007812 */
+{'[', 0x007300d1, 0xffffffff},/*kerning  Ñ s� : -0.003906 */
+{'[', 0x007400d1, 0xffffffff},/*kerning  Ñ t� : -0.003906 */
+{'[', 0x00e000d1, 0xffffffff},/*kerning  Ñ à : -0.003906 */
+{'[', 0x00e100d1, 0xffffffff},/*kerning  Ñ á : -0.003906 */
+{'[', 0x00e200d1, 0xffffffff},/*kerning  Ñ â : -0.003906 */
+{'[', 0x00e300d1, 0xffffffff},/*kerning  Ñ ã : -0.003906 */
+{'[', 0x00e400d1, 0xffffffff},/*kerning  Ñ ä : -0.003906 */
+{'[', 0x00e500d1, 0xffffffff},/*kerning  Ñ å : -0.003906 */
+{'[', 0x00e600d1, 0xffffffff},/*kerning  Ñ æ : -0.003906 */
+{'[', 0x00e700d1, 0xfffffffe},/*kerning  Ñ ç : -0.007812 */
+{'[', 0x00e800d1, 0xfffffffe},/*kerning  Ñ è : -0.007812 */
+{'[', 0x00e900d1, 0xfffffffe},/*kerning  Ñ é : -0.007812 */
+{'[', 0x00ea00d1, 0xfffffffe},/*kerning  Ñ ê : -0.007812 */
+{'[', 0x00eb00d1, 0xfffffffe},/*kerning  Ñ ë : -0.007812 */
+{'[', 0x00f000d1, 0xfffffffe},/*kerning  Ñ ð : -0.007812 */
+{'[', 0x00f200d1, 0xfffffffe},/*kerning  Ñ ò : -0.007812 */
+{'[', 0x00f300d1, 0xfffffffe},/*kerning  Ñ ó : -0.007812 */
+{'[', 0x00f400d1, 0xfffffffe},/*kerning  Ñ ô : -0.007812 */
+{'[', 0x00f500d1, 0xfffffffe},/*kerning  Ñ õ : -0.007812 */
+{'[', 0x00f600d1, 0xfffffffe},/*kerning  Ñ ö : -0.007812 */
+{'[', 0x00f800d1, 0xfffffffe},/*kerning  Ñ ø : -0.007812 */
+{'@', 0x000000d2, 0x00007700},/*        Ò        x-advance: 119.000000 */
+{'M', 0x426eb852, 0x3f4ccccc},
+{'q', 0xc1400000, 0x00000000},
+{0, 0xc1ae147c, 0xc099999a},
+{'q', 0xc11c28f4, 0xc099999a},
+{0, 0xc1870a3c, 0xc150a3d6},
+{'q', 0xc0e3d70c, 0xc103d70a},
+{0, 0xc12f5c2a, 0xc1947ae1},
+{'q', 0xc075c290, 0xc1251eb8},
+{0, 0xc075c290, 0xc1a9999a},
+{'q', 0x00000000, 0xc135c28c},
+{0, 0x40828f5c, 0xc1ad70a2},
+{'q', 0x40828f5c, 0xc1251eb8},
+{0, 0x4135c290, 0xc1933334},
+{'q', 0x40e8f5c0, 0xc10147b0},
+{0, 0x418851ec, 0xc14cccc8},
+{'q', 0x411c28f4, 0xc0970a40},
+{0, 0x41aa3d70, 0xc0970a40},
+{'q', 0x41400000, 0x00000000},
+{0, 0x41ae1478, 0x409eb850},
+{'q', 0x411c28f8, 0x409eb850},
+{0, 0x41866668, 0x41547ae0},
+{'q', 0x40e147b0, 0x41051eb8},
+{0, 0x412e1480, 0x41947ae0},
+{'q', 0x4075c280, 0x4123d708},
+{0, 0x4075c280, 0x41a7ae14},
+{'q', 0x00000000, 0x4135c290},
+{0, 0xc0800000, 0x41ad70a4},
+{'q', 0xc0800000, 0x41251eb8},
+{0, 0xc1347ae0, 0x41933333},
+{'q', 0xc0e8f5c0, 0x410147ae},
+{0, 0xc18851ec, 0x414b851e},
+{'9', 0x0025ffb2, 0x0025ff56},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a66666, 0xc2633333},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x40333330, 0x4185c28e},
+{'q', 0x40333338, 0x410147b0},
+{0, 0x40fd70a8, 0x41651eba},
+{'q', 0x40a3d708, 0x40c7ae14},
+{0, 0x41451eb4, 0x411eb852},
+{'q', 0x40e66668, 0x406b8520},
+{0, 0x41800002, 0x406b8520},
+{'q', 0x4111eb84, 0x00000000},
+{0, 0x41828f5e, 0xc075c290},
+{'q', 0x40e66660, 0xc075c290},
+{0, 0x4143d700, 0xc123d70a},
+{'q', 0x40a147b0, 0xc0cccccc},
+{0, 0x40f5c2a0, 0xc1666666},
+{'q', 0x4028f5c0, 0xc1000000},
+{0, 0x4028f5c0, 0xc18147ae},
+{'q', 0x00000000, 0xc10a3d6c},
+{0, 0xc0333340, 0xc1851eb6},
+{'q', 0xc0333340, 0xc1000000},
+{0, 0xc1000000, 0xc1651eb8},
+{'q', 0xc0a66660, 0xc0ca3d70},
+{0, 0xc1451eb8, 0xc11eb850},
+{'q', 0xc0e3d710, 0xc0666680},
+{0, 0xc17c28f4, 0xc0666680},
+{'q', 0xc111eb88, 0x00000000},
+{0, 0xc1828f5e, 0x4070a3e0},
+{'q', 0xc0e66660, 0x4070a3e0},
+{0, 0xc143d708, 0x41228f58},
+{'q', 0xc0a147ac, 0x40ccccd0},
+{0, 0xc0f851e8, 0x41651ec0},
+{'9', 0x003fffeb, 0x0081ffeb},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x422d70a4, 0xc312b852},
+{'l', 0x415eb850, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d708, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002900d2, 0xfffffffc},/*kerning  Ò )� : -0.015625 */
+{'[', 0x002c00d2, 0xfffffffd},/*kerning  Ò ,� : -0.011719 */
+{'[', 0x002e00d2, 0xfffffffd},/*kerning  Ò .� : -0.011719 */
+{'[', 0x002f00d2, 0xfffffffa},/*kerning  Ò /� : -0.023438 */
+{'[', 0x004100d2, 0xfffffffa},/*kerning  Ò A� : -0.023438 */
+{'[', 0x004a00d2, 0xfffffffb},/*kerning  Ò J� : -0.019531 */
+{'[', 0x005400d2, 0xfffffffb},/*kerning  Ò T� : -0.019531 */
+{'[', 0x005600d2, 0xfffffffa},/*kerning  Ò V� : -0.023438 */
+{'[', 0x005700d2, 0xfffffffa},/*kerning  Ò W� : -0.023438 */
+{'[', 0x005800d2, 0xfffffff8},/*kerning  Ò X� : -0.031250 */
+{'[', 0x005900d2, 0xfffffff4},/*kerning  Ò Y� : -0.046875 */
+{'[', 0x005a00d2, 0xfffffffd},/*kerning  Ò Z� : -0.011719 */
+{'[', 0x005c00d2, 0xfffffffb},/*kerning  Ò \� : -0.019531 */
+{'[', 0x006100d2, 0xffffffff},/*kerning  Ò a� : -0.003906 */
+{'[', 0x006d00d2, 0xffffffff},/*kerning  Ò m� : -0.003906 */
+{'[', 0x006e00d2, 0xffffffff},/*kerning  Ò n� : -0.003906 */
+{'[', 0x007000d2, 0xffffffff},/*kerning  Ò p� : -0.003906 */
+{'[', 0x007200d2, 0xffffffff},/*kerning  Ò r� : -0.003906 */
+{'[', 0x007800d2, 0xfffffffe},/*kerning  Ò x� : -0.007812 */
+{'[', 0x007900d2, 0xffffffff},/*kerning  Ò y� : -0.003906 */
+{'[', 0x00c000d2, 0xfffffffa},/*kerning  Ò À : -0.023438 */
+{'[', 0x00c100d2, 0xfffffffa},/*kerning  Ò Á : -0.023438 */
+{'[', 0x00c200d2, 0xfffffffa},/*kerning  Ò Â : -0.023438 */
+{'[', 0x00c300d2, 0xfffffffa},/*kerning  Ò Ã : -0.023438 */
+{'[', 0x00c400d2, 0xfffffffa},/*kerning  Ò Ä : -0.023438 */
+{'[', 0x00c500d2, 0xfffffffa},/*kerning  Ò Å : -0.023438 */
+{'[', 0x00c600d2, 0xfffffff9},/*kerning  Ò Æ : -0.027344 */
+{'[', 0x00d000d2, 0xffffffff},/*kerning  Ò Ð : -0.003906 */
+{'[', 0x00dd00d2, 0xfffffff4},/*kerning  Ò Ý : -0.046875 */
+{'[', 0x00e000d2, 0xffffffff},/*kerning  Ò à : -0.003906 */
+{'[', 0x00e100d2, 0xffffffff},/*kerning  Ò á : -0.003906 */
+{'[', 0x00e200d2, 0xffffffff},/*kerning  Ò â : -0.003906 */
+{'[', 0x00e300d2, 0xffffffff},/*kerning  Ò ã : -0.003906 */
+{'[', 0x00e400d2, 0xffffffff},/*kerning  Ò ä : -0.003906 */
+{'[', 0x00e500d2, 0xffffffff},/*kerning  Ò å : -0.003906 */
+{'[', 0x00e600d2, 0xffffffff},/*kerning  Ò æ : -0.003906 */
+{'[', 0x00f100d2, 0xffffffff},/*kerning  Ò ñ : -0.003906 */
+{'[', 0x00fd00d2, 0xffffffff},/*kerning  Ò ý : -0.003906 */
+{'[', 0x00ff00d2, 0xffffffff},/*kerning  Ò ÿ : -0.003906 */
+{'@', 0x000000d3, 0x00007700},/*        Ó        x-advance: 119.000000 */
+{'M', 0x426eb852, 0x3f4ccccc},
+{'q', 0xc1400000, 0x00000000},
+{0, 0xc1ae147c, 0xc099999a},
+{'q', 0xc11c28f4, 0xc099999a},
+{0, 0xc1870a3c, 0xc150a3d6},
+{'q', 0xc0e3d70c, 0xc103d70a},
+{0, 0xc12f5c2a, 0xc1947ae1},
+{'q', 0xc075c290, 0xc1251eb8},
+{0, 0xc075c290, 0xc1a9999a},
+{'q', 0x00000000, 0xc135c28c},
+{0, 0x40828f5c, 0xc1ad70a2},
+{'q', 0x40828f5c, 0xc1251eb8},
+{0, 0x4135c290, 0xc1933334},
+{'q', 0x40e8f5c0, 0xc10147b0},
+{0, 0x418851ec, 0xc14cccc8},
+{'q', 0x411c28f4, 0xc0970a40},
+{0, 0x41aa3d70, 0xc0970a40},
+{'q', 0x41400000, 0x00000000},
+{0, 0x41ae1478, 0x409eb850},
+{'q', 0x411c28f8, 0x409eb850},
+{0, 0x41866668, 0x41547ae0},
+{'q', 0x40e147b0, 0x41051eb8},
+{0, 0x412e1480, 0x41947ae0},
+{'q', 0x4075c280, 0x4123d708},
+{0, 0x4075c280, 0x41a7ae14},
+{'q', 0x00000000, 0x4135c290},
+{0, 0xc0800000, 0x41ad70a4},
+{'q', 0xc0800000, 0x41251eb8},
+{0, 0xc1347ae0, 0x41933333},
+{'q', 0xc0e8f5c0, 0x410147ae},
+{0, 0xc18851ec, 0x414b851e},
+{'9', 0x0025ffb2, 0x0025ff56},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a66666, 0xc2633333},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x40333330, 0x4185c28e},
+{'q', 0x40333338, 0x410147b0},
+{0, 0x40fd70a8, 0x41651eba},
+{'q', 0x40a3d708, 0x40c7ae14},
+{0, 0x41451eb4, 0x411eb852},
+{'q', 0x40e66668, 0x406b8520},
+{0, 0x41800002, 0x406b8520},
+{'q', 0x4111eb84, 0x00000000},
+{0, 0x41828f5e, 0xc075c290},
+{'q', 0x40e66660, 0xc075c290},
+{0, 0x4143d700, 0xc123d70a},
+{'q', 0x40a147b0, 0xc0cccccc},
+{0, 0x40f5c2a0, 0xc1666666},
+{'q', 0x4028f5c0, 0xc1000000},
+{0, 0x4028f5c0, 0xc18147ae},
+{'q', 0x00000000, 0xc10a3d6c},
+{0, 0xc0333340, 0xc1851eb6},
+{'q', 0xc0333340, 0xc1000000},
+{0, 0xc1000000, 0xc1651eb8},
+{'q', 0xc0a66660, 0xc0ca3d70},
+{0, 0xc1451eb8, 0xc11eb850},
+{'q', 0xc0e3d710, 0xc0666680},
+{0, 0xc17c28f4, 0xc0666680},
+{'q', 0xc111eb88, 0x00000000},
+{0, 0xc1828f5e, 0x4070a3e0},
+{'q', 0xc0e66660, 0x4070a3e0},
+{0, 0xc143d708, 0x41228f58},
+{'q', 0xc0a147ac, 0x40ccccd0},
+{0, 0xc0f851e8, 0x41651ec0},
+{'9', 0x003fffeb, 0x0081ffeb},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4281eb85, 0xc2fe6666},
+{'l', 0xc1147ae0, 0xc04cccc0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147b0, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002900d3, 0xfffffffc},/*kerning  Ó )� : -0.015625 */
+{'[', 0x002c00d3, 0xfffffffd},/*kerning  Ó ,� : -0.011719 */
+{'[', 0x002e00d3, 0xfffffffd},/*kerning  Ó .� : -0.011719 */
+{'[', 0x002f00d3, 0xfffffffa},/*kerning  Ó /� : -0.023438 */
+{'[', 0x004100d3, 0xfffffffa},/*kerning  Ó A� : -0.023438 */
+{'[', 0x004a00d3, 0xfffffffb},/*kerning  Ó J� : -0.019531 */
+{'[', 0x005400d3, 0xfffffffb},/*kerning  Ó T� : -0.019531 */
+{'[', 0x005600d3, 0xfffffffa},/*kerning  Ó V� : -0.023438 */
+{'[', 0x005700d3, 0xfffffffa},/*kerning  Ó W� : -0.023438 */
+{'[', 0x005800d3, 0xfffffff8},/*kerning  Ó X� : -0.031250 */
+{'[', 0x005900d3, 0xfffffff4},/*kerning  Ó Y� : -0.046875 */
+{'[', 0x005a00d3, 0xfffffffd},/*kerning  Ó Z� : -0.011719 */
+{'[', 0x005c00d3, 0xfffffffb},/*kerning  Ó \� : -0.019531 */
+{'[', 0x006100d3, 0xffffffff},/*kerning  Ó a� : -0.003906 */
+{'[', 0x006d00d3, 0xffffffff},/*kerning  Ó m� : -0.003906 */
+{'[', 0x006e00d3, 0xffffffff},/*kerning  Ó n� : -0.003906 */
+{'[', 0x007000d3, 0xffffffff},/*kerning  Ó p� : -0.003906 */
+{'[', 0x007200d3, 0xffffffff},/*kerning  Ó r� : -0.003906 */
+{'[', 0x007800d3, 0xfffffffe},/*kerning  Ó x� : -0.007812 */
+{'[', 0x007900d3, 0xffffffff},/*kerning  Ó y� : -0.003906 */
+{'[', 0x00c000d3, 0xfffffffa},/*kerning  Ó À : -0.023438 */
+{'[', 0x00c100d3, 0xfffffffa},/*kerning  Ó Á : -0.023438 */
+{'[', 0x00c200d3, 0xfffffffa},/*kerning  Ó Â : -0.023438 */
+{'[', 0x00c300d3, 0xfffffffa},/*kerning  Ó Ã : -0.023438 */
+{'[', 0x00c400d3, 0xfffffffa},/*kerning  Ó Ä : -0.023438 */
+{'[', 0x00c500d3, 0xfffffffa},/*kerning  Ó Å : -0.023438 */
+{'[', 0x00c600d3, 0xfffffff9},/*kerning  Ó Æ : -0.027344 */
+{'[', 0x00d000d3, 0xffffffff},/*kerning  Ó Ð : -0.003906 */
+{'[', 0x00dd00d3, 0xfffffff4},/*kerning  Ó Ý : -0.046875 */
+{'[', 0x00e000d3, 0xffffffff},/*kerning  Ó à : -0.003906 */
+{'[', 0x00e100d3, 0xffffffff},/*kerning  Ó á : -0.003906 */
+{'[', 0x00e200d3, 0xffffffff},/*kerning  Ó â : -0.003906 */
+{'[', 0x00e300d3, 0xffffffff},/*kerning  Ó ã : -0.003906 */
+{'[', 0x00e400d3, 0xffffffff},/*kerning  Ó ä : -0.003906 */
+{'[', 0x00e500d3, 0xffffffff},/*kerning  Ó å : -0.003906 */
+{'[', 0x00e600d3, 0xffffffff},/*kerning  Ó æ : -0.003906 */
+{'[', 0x00f100d3, 0xffffffff},/*kerning  Ó ñ : -0.003906 */
+{'[', 0x00fd00d3, 0xffffffff},/*kerning  Ó ý : -0.003906 */
+{'[', 0x00ff00d3, 0xffffffff},/*kerning  Ó ÿ : -0.003906 */
+{'@', 0x000000d4, 0x00007700},/*        Ô        x-advance: 119.000000 */
+{'M', 0x426eb852, 0x3f4ccccc},
+{'q', 0xc1400000, 0x00000000},
+{0, 0xc1ae147c, 0xc099999a},
+{'q', 0xc11c28f4, 0xc099999a},
+{0, 0xc1870a3c, 0xc150a3d6},
+{'q', 0xc0e3d70c, 0xc103d70a},
+{0, 0xc12f5c2a, 0xc1947ae1},
+{'q', 0xc075c290, 0xc1251eb8},
+{0, 0xc075c290, 0xc1a9999a},
+{'q', 0x00000000, 0xc135c28c},
+{0, 0x40828f5c, 0xc1ad70a2},
+{'q', 0x40828f5c, 0xc1251eb8},
+{0, 0x4135c290, 0xc1933334},
+{'q', 0x40e8f5c0, 0xc10147b0},
+{0, 0x418851ec, 0xc14cccc8},
+{'q', 0x411c28f4, 0xc0970a40},
+{0, 0x41aa3d70, 0xc0970a40},
+{'q', 0x41400000, 0x00000000},
+{0, 0x41ae1478, 0x409eb850},
+{'q', 0x411c28f8, 0x409eb850},
+{0, 0x41866668, 0x41547ae0},
+{'q', 0x40e147b0, 0x41051eb8},
+{0, 0x412e1480, 0x41947ae0},
+{'q', 0x4075c280, 0x4123d708},
+{0, 0x4075c280, 0x41a7ae14},
+{'q', 0x00000000, 0x4135c290},
+{0, 0xc0800000, 0x41ad70a4},
+{'q', 0xc0800000, 0x41251eb8},
+{0, 0xc1347ae0, 0x41933333},
+{'q', 0xc0e8f5c0, 0x410147ae},
+{0, 0xc18851ec, 0x414b851e},
+{'9', 0x0025ffb2, 0x0025ff56},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a66666, 0xc2633333},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x40333330, 0x4185c28e},
+{'q', 0x40333338, 0x410147b0},
+{0, 0x40fd70a8, 0x41651eba},
+{'q', 0x40a3d708, 0x40c7ae14},
+{0, 0x41451eb4, 0x411eb852},
+{'q', 0x40e66668, 0x406b8520},
+{0, 0x41800002, 0x406b8520},
+{'q', 0x4111eb84, 0x00000000},
+{0, 0x41828f5e, 0xc075c290},
+{'q', 0x40e66660, 0xc075c290},
+{0, 0x4143d700, 0xc123d70a},
+{'q', 0x40a147b0, 0xc0cccccc},
+{0, 0x40f5c2a0, 0xc1666666},
+{'q', 0x4028f5c0, 0xc1000000},
+{0, 0x4028f5c0, 0xc18147ae},
+{'q', 0x00000000, 0xc10a3d6c},
+{0, 0xc0333340, 0xc1851eb6},
+{'q', 0xc0333340, 0xc1000000},
+{0, 0xc1000000, 0xc1651eb8},
+{'q', 0xc0a66660, 0xc0ca3d70},
+{0, 0xc1451eb8, 0xc11eb850},
+{'q', 0xc0e3d710, 0xc0666680},
+{0, 0xc17c28f4, 0xc0666680},
+{'q', 0xc111eb88, 0x00000000},
+{0, 0xc1828f5e, 0x4070a3e0},
+{'q', 0xc0e66660, 0x4070a3e0},
+{0, 0xc143d708, 0x41228f58},
+{'q', 0xc0a147ac, 0x40ccccd0},
+{0, 0xc0f851e8, 0x41651ec0},
+{'9', 0x003fffeb, 0x0081ffeb},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x421ae147, 0xc30428f6},
+{'l', 0x418147ae, 0xc1666660},
+{'l', 0x4123d708, 0x00000000},
+{'l', 0x418147b0, 0x41666660},
+{'0', 0xb0941ec3, 0xe2c35094},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002900d4, 0xfffffffc},/*kerning  Ô )� : -0.015625 */
+{'[', 0x002c00d4, 0xfffffffd},/*kerning  Ô ,� : -0.011719 */
+{'[', 0x002e00d4, 0xfffffffd},/*kerning  Ô .� : -0.011719 */
+{'[', 0x002f00d4, 0xfffffffa},/*kerning  Ô /� : -0.023438 */
+{'[', 0x004100d4, 0xfffffffa},/*kerning  Ô A� : -0.023438 */
+{'[', 0x004a00d4, 0xfffffffb},/*kerning  Ô J� : -0.019531 */
+{'[', 0x005400d4, 0xfffffffb},/*kerning  Ô T� : -0.019531 */
+{'[', 0x005600d4, 0xfffffffa},/*kerning  Ô V� : -0.023438 */
+{'[', 0x005700d4, 0xfffffffa},/*kerning  Ô W� : -0.023438 */
+{'[', 0x005800d4, 0xfffffff8},/*kerning  Ô X� : -0.031250 */
+{'[', 0x005900d4, 0xfffffff4},/*kerning  Ô Y� : -0.046875 */
+{'[', 0x005a00d4, 0xfffffffd},/*kerning  Ô Z� : -0.011719 */
+{'[', 0x005c00d4, 0xfffffffb},/*kerning  Ô \� : -0.019531 */
+{'[', 0x006100d4, 0xffffffff},/*kerning  Ô a� : -0.003906 */
+{'[', 0x006d00d4, 0xffffffff},/*kerning  Ô m� : -0.003906 */
+{'[', 0x006e00d4, 0xffffffff},/*kerning  Ô n� : -0.003906 */
+{'[', 0x007000d4, 0xffffffff},/*kerning  Ô p� : -0.003906 */
+{'[', 0x007200d4, 0xffffffff},/*kerning  Ô r� : -0.003906 */
+{'[', 0x007800d4, 0xfffffffe},/*kerning  Ô x� : -0.007812 */
+{'[', 0x007900d4, 0xffffffff},/*kerning  Ô y� : -0.003906 */
+{'[', 0x00c000d4, 0xfffffffa},/*kerning  Ô À : -0.023438 */
+{'[', 0x00c100d4, 0xfffffffa},/*kerning  Ô Á : -0.023438 */
+{'[', 0x00c200d4, 0xfffffffa},/*kerning  Ô Â : -0.023438 */
+{'[', 0x00c300d4, 0xfffffffa},/*kerning  Ô Ã : -0.023438 */
+{'[', 0x00c400d4, 0xfffffffa},/*kerning  Ô Ä : -0.023438 */
+{'[', 0x00c500d4, 0xfffffffa},/*kerning  Ô Å : -0.023438 */
+{'[', 0x00c600d4, 0xfffffff9},/*kerning  Ô Æ : -0.027344 */
+{'[', 0x00d000d4, 0xffffffff},/*kerning  Ô Ð : -0.003906 */
+{'[', 0x00dd00d4, 0xfffffff4},/*kerning  Ô Ý : -0.046875 */
+{'[', 0x00e000d4, 0xffffffff},/*kerning  Ô à : -0.003906 */
+{'[', 0x00e100d4, 0xffffffff},/*kerning  Ô á : -0.003906 */
+{'[', 0x00e200d4, 0xffffffff},/*kerning  Ô â : -0.003906 */
+{'[', 0x00e300d4, 0xffffffff},/*kerning  Ô ã : -0.003906 */
+{'[', 0x00e400d4, 0xffffffff},/*kerning  Ô ä : -0.003906 */
+{'[', 0x00e500d4, 0xffffffff},/*kerning  Ô å : -0.003906 */
+{'[', 0x00e600d4, 0xffffffff},/*kerning  Ô æ : -0.003906 */
+{'[', 0x00f100d4, 0xffffffff},/*kerning  Ô ñ : -0.003906 */
+{'[', 0x00fd00d4, 0xffffffff},/*kerning  Ô ý : -0.003906 */
+{'[', 0x00ff00d4, 0xffffffff},/*kerning  Ô ÿ : -0.003906 */
+{'@', 0x000000d5, 0x00007700},/*        Õ        x-advance: 119.000000 */
+{'M', 0x426eb852, 0x3f4ccccc},
+{'q', 0xc1400000, 0x00000000},
+{0, 0xc1ae147c, 0xc099999a},
+{'q', 0xc11c28f4, 0xc099999a},
+{0, 0xc1870a3c, 0xc150a3d6},
+{'q', 0xc0e3d70c, 0xc103d70a},
+{0, 0xc12f5c2a, 0xc1947ae1},
+{'q', 0xc075c290, 0xc1251eb8},
+{0, 0xc075c290, 0xc1a9999a},
+{'q', 0x00000000, 0xc135c28c},
+{0, 0x40828f5c, 0xc1ad70a2},
+{'q', 0x40828f5c, 0xc1251eb8},
+{0, 0x4135c290, 0xc1933334},
+{'q', 0x40e8f5c0, 0xc10147b0},
+{0, 0x418851ec, 0xc14cccc8},
+{'q', 0x411c28f4, 0xc0970a40},
+{0, 0x41aa3d70, 0xc0970a40},
+{'q', 0x41400000, 0x00000000},
+{0, 0x41ae1478, 0x409eb850},
+{'q', 0x411c28f8, 0x409eb850},
+{0, 0x41866668, 0x41547ae0},
+{'q', 0x40e147b0, 0x41051eb8},
+{0, 0x412e1480, 0x41947ae0},
+{'q', 0x4075c280, 0x4123d708},
+{0, 0x4075c280, 0x41a7ae14},
+{'q', 0x00000000, 0x4135c290},
+{0, 0xc0800000, 0x41ad70a4},
+{'q', 0xc0800000, 0x41251eb8},
+{0, 0xc1347ae0, 0x41933333},
+{'q', 0xc0e8f5c0, 0x410147ae},
+{0, 0xc18851ec, 0x414b851e},
+{'9', 0x0025ffb2, 0x0025ff56},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a66666, 0xc2633333},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x40333330, 0x4185c28e},
+{'q', 0x40333338, 0x410147b0},
+{0, 0x40fd70a8, 0x41651eba},
+{'q', 0x40a3d708, 0x40c7ae14},
+{0, 0x41451eb4, 0x411eb852},
+{'q', 0x40e66668, 0x406b8520},
+{0, 0x41800002, 0x406b8520},
+{'q', 0x4111eb84, 0x00000000},
+{0, 0x41828f5e, 0xc075c290},
+{'q', 0x40e66660, 0xc075c290},
+{0, 0x4143d700, 0xc123d70a},
+{'q', 0x40a147b0, 0xc0cccccc},
+{0, 0x40f5c2a0, 0xc1666666},
+{'q', 0x4028f5c0, 0xc1000000},
+{0, 0x4028f5c0, 0xc18147ae},
+{'q', 0x00000000, 0xc10a3d6c},
+{0, 0xc0333340, 0xc1851eb6},
+{'q', 0xc0333340, 0xc1000000},
+{0, 0xc1000000, 0xc1651eb8},
+{'q', 0xc0a66660, 0xc0ca3d70},
+{0, 0xc1451eb8, 0xc11eb850},
+{'q', 0xc0e3d710, 0xc0666680},
+{0, 0xc17c28f4, 0xc0666680},
+{'q', 0xc111eb88, 0x00000000},
+{0, 0xc1828f5e, 0x4070a3e0},
+{'q', 0xc0e66660, 0x4070a3e0},
+{0, 0xc143d708, 0x41228f58},
+{'q', 0xc0a147ac, 0x40ccccd0},
+{0, 0xc0f851e8, 0x41651ec0},
+{'9', 0x003fffeb, 0x0081ffeb},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x428bd70a, 0xc302147b},
+{'8', 0xf3bf00da, 0xe6cff3e6},
+{'8', 0xf3cef3ea, 0x0ed700e4},
+{'8', 0x1def0ef3, 0x11fd0ffd},
+{'l', 0xc1051eb8, 0x00000000},
+{'8', 0xe405f900, 0xd413eb05},
+{'8', 0xd826e90e, 0xef3eef18},
+{'8', 0x0d3e0025, 0x1b300d18},
+{'8', 0x0e360e17, 0xf2300021},
+{'8', 0xe213f20e, 0xef04f104},
+{'l', 0x41051eb8, 0x00000000},
+{'8', 0x1cfb0700, 0x2ceb14fb},
+{'8', 0x29d718f1, 0x11bd11e6},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002900d5, 0xfffffffc},/*kerning  Õ )� : -0.015625 */
+{'[', 0x002c00d5, 0xfffffffd},/*kerning  Õ ,� : -0.011719 */
+{'[', 0x002e00d5, 0xfffffffd},/*kerning  Õ .� : -0.011719 */
+{'[', 0x002f00d5, 0xfffffffa},/*kerning  Õ /� : -0.023438 */
+{'[', 0x004100d5, 0xfffffffa},/*kerning  Õ A� : -0.023438 */
+{'[', 0x004a00d5, 0xfffffffb},/*kerning  Õ J� : -0.019531 */
+{'[', 0x005400d5, 0xfffffffb},/*kerning  Õ T� : -0.019531 */
+{'[', 0x005600d5, 0xfffffffa},/*kerning  Õ V� : -0.023438 */
+{'[', 0x005700d5, 0xfffffffa},/*kerning  Õ W� : -0.023438 */
+{'[', 0x005800d5, 0xfffffff8},/*kerning  Õ X� : -0.031250 */
+{'[', 0x005900d5, 0xfffffff4},/*kerning  Õ Y� : -0.046875 */
+{'[', 0x005a00d5, 0xfffffffd},/*kerning  Õ Z� : -0.011719 */
+{'[', 0x005c00d5, 0xfffffffb},/*kerning  Õ \� : -0.019531 */
+{'[', 0x006100d5, 0xffffffff},/*kerning  Õ a� : -0.003906 */
+{'[', 0x006d00d5, 0xffffffff},/*kerning  Õ m� : -0.003906 */
+{'[', 0x006e00d5, 0xffffffff},/*kerning  Õ n� : -0.003906 */
+{'[', 0x007000d5, 0xffffffff},/*kerning  Õ p� : -0.003906 */
+{'[', 0x007200d5, 0xffffffff},/*kerning  Õ r� : -0.003906 */
+{'[', 0x007800d5, 0xfffffffe},/*kerning  Õ x� : -0.007812 */
+{'[', 0x007900d5, 0xffffffff},/*kerning  Õ y� : -0.003906 */
+{'[', 0x00c000d5, 0xfffffffa},/*kerning  Õ À : -0.023438 */
+{'[', 0x00c100d5, 0xfffffffa},/*kerning  Õ Á : -0.023438 */
+{'[', 0x00c200d5, 0xfffffffa},/*kerning  Õ Â : -0.023438 */
+{'[', 0x00c300d5, 0xfffffffa},/*kerning  Õ Ã : -0.023438 */
+{'[', 0x00c400d5, 0xfffffffa},/*kerning  Õ Ä : -0.023438 */
+{'[', 0x00c500d5, 0xfffffffa},/*kerning  Õ Å : -0.023438 */
+{'[', 0x00c600d5, 0xfffffff9},/*kerning  Õ Æ : -0.027344 */
+{'[', 0x00d000d5, 0xffffffff},/*kerning  Õ Ð : -0.003906 */
+{'[', 0x00dd00d5, 0xfffffff4},/*kerning  Õ Ý : -0.046875 */
+{'[', 0x00e000d5, 0xffffffff},/*kerning  Õ à : -0.003906 */
+{'[', 0x00e100d5, 0xffffffff},/*kerning  Õ á : -0.003906 */
+{'[', 0x00e200d5, 0xffffffff},/*kerning  Õ â : -0.003906 */
+{'[', 0x00e300d5, 0xffffffff},/*kerning  Õ ã : -0.003906 */
+{'[', 0x00e400d5, 0xffffffff},/*kerning  Õ ä : -0.003906 */
+{'[', 0x00e500d5, 0xffffffff},/*kerning  Õ å : -0.003906 */
+{'[', 0x00e600d5, 0xffffffff},/*kerning  Õ æ : -0.003906 */
+{'[', 0x00f100d5, 0xffffffff},/*kerning  Õ ñ : -0.003906 */
+{'[', 0x00fd00d5, 0xffffffff},/*kerning  Õ ý : -0.003906 */
+{'[', 0x00ff00d5, 0xffffffff},/*kerning  Õ ÿ : -0.003906 */
+{'@', 0x000000d6, 0x00007700},/*        Ö        x-advance: 119.000000 */
+{'M', 0x426eb852, 0x3f4ccccc},
+{'q', 0xc1400000, 0x00000000},
+{0, 0xc1ae147c, 0xc099999a},
+{'q', 0xc11c28f4, 0xc099999a},
+{0, 0xc1870a3c, 0xc150a3d6},
+{'q', 0xc0e3d70c, 0xc103d70a},
+{0, 0xc12f5c2a, 0xc1947ae1},
+{'q', 0xc075c290, 0xc1251eb8},
+{0, 0xc075c290, 0xc1a9999a},
+{'q', 0x00000000, 0xc135c28c},
+{0, 0x40828f5c, 0xc1ad70a2},
+{'q', 0x40828f5c, 0xc1251eb8},
+{0, 0x4135c290, 0xc1933334},
+{'q', 0x40e8f5c0, 0xc10147b0},
+{0, 0x418851ec, 0xc14cccc8},
+{'q', 0x411c28f4, 0xc0970a40},
+{0, 0x41aa3d70, 0xc0970a40},
+{'q', 0x41400000, 0x00000000},
+{0, 0x41ae1478, 0x409eb850},
+{'q', 0x411c28f8, 0x409eb850},
+{0, 0x41866668, 0x41547ae0},
+{'q', 0x40e147b0, 0x41051eb8},
+{0, 0x412e1480, 0x41947ae0},
+{'q', 0x4075c280, 0x4123d708},
+{0, 0x4075c280, 0x41a7ae14},
+{'q', 0x00000000, 0x4135c290},
+{0, 0xc0800000, 0x41ad70a4},
+{'q', 0xc0800000, 0x41251eb8},
+{0, 0xc1347ae0, 0x41933333},
+{'q', 0xc0e8f5c0, 0x410147ae},
+{0, 0xc18851ec, 0x414b851e},
+{'9', 0x0025ffb2, 0x0025ff56},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a66666, 0xc2633333},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x40333330, 0x4185c28e},
+{'q', 0x40333338, 0x410147b0},
+{0, 0x40fd70a8, 0x41651eba},
+{'q', 0x40a3d708, 0x40c7ae14},
+{0, 0x41451eb4, 0x411eb852},
+{'q', 0x40e66668, 0x406b8520},
+{0, 0x41800002, 0x406b8520},
+{'q', 0x4111eb84, 0x00000000},
+{0, 0x41828f5e, 0xc075c290},
+{'q', 0x40e66660, 0xc075c290},
+{0, 0x4143d700, 0xc123d70a},
+{'q', 0x40a147b0, 0xc0cccccc},
+{0, 0x40f5c2a0, 0xc1666666},
+{'q', 0x4028f5c0, 0xc1000000},
+{0, 0x4028f5c0, 0xc18147ae},
+{'q', 0x00000000, 0xc10a3d6c},
+{0, 0xc0333340, 0xc1851eb6},
+{'q', 0xc0333340, 0xc1000000},
+{0, 0xc1000000, 0xc1651eb8},
+{'q', 0xc0a66660, 0xc0ca3d70},
+{0, 0xc1451eb8, 0xc11eb850},
+{'q', 0xc0e3d710, 0xc0666680},
+{0, 0xc17c28f4, 0xc0666680},
+{'q', 0xc111eb88, 0x00000000},
+{0, 0xc1828f5e, 0x4070a3e0},
+{'q', 0xc0e66660, 0x4070a3e0},
+{0, 0xc143d708, 0x41228f58},
+{'q', 0xc0a147ac, 0x40ccccd0},
+{0, 0xc0f851e8, 0x41651ec0},
+{'9', 0x003fffeb, 0x0081ffeb},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42247ae1, 0xc301c28f},
+{'l', 0x00000000, 0xc1828f60},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4286147b, 0xc301c28f},
+{'l', 0x00000000, 0xc1828f60},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a0, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002900d6, 0xfffffffc},/*kerning  Ö )� : -0.015625 */
+{'[', 0x002c00d6, 0xfffffffd},/*kerning  Ö ,� : -0.011719 */
+{'[', 0x002e00d6, 0xfffffffd},/*kerning  Ö .� : -0.011719 */
+{'[', 0x002f00d6, 0xfffffffa},/*kerning  Ö /� : -0.023438 */
+{'[', 0x004100d6, 0xfffffffa},/*kerning  Ö A� : -0.023438 */
+{'[', 0x004a00d6, 0xfffffffb},/*kerning  Ö J� : -0.019531 */
+{'[', 0x005400d6, 0xfffffffb},/*kerning  Ö T� : -0.019531 */
+{'[', 0x005600d6, 0xfffffffa},/*kerning  Ö V� : -0.023438 */
+{'[', 0x005700d6, 0xfffffffa},/*kerning  Ö W� : -0.023438 */
+{'[', 0x005800d6, 0xfffffff8},/*kerning  Ö X� : -0.031250 */
+{'[', 0x005900d6, 0xfffffff4},/*kerning  Ö Y� : -0.046875 */
+{'[', 0x005a00d6, 0xfffffffd},/*kerning  Ö Z� : -0.011719 */
+{'[', 0x005c00d6, 0xfffffffb},/*kerning  Ö \� : -0.019531 */
+{'[', 0x006100d6, 0xffffffff},/*kerning  Ö a� : -0.003906 */
+{'[', 0x006d00d6, 0xffffffff},/*kerning  Ö m� : -0.003906 */
+{'[', 0x006e00d6, 0xffffffff},/*kerning  Ö n� : -0.003906 */
+{'[', 0x007000d6, 0xffffffff},/*kerning  Ö p� : -0.003906 */
+{'[', 0x007200d6, 0xffffffff},/*kerning  Ö r� : -0.003906 */
+{'[', 0x007800d6, 0xfffffffe},/*kerning  Ö x� : -0.007812 */
+{'[', 0x007900d6, 0xffffffff},/*kerning  Ö y� : -0.003906 */
+{'[', 0x00c000d6, 0xfffffffa},/*kerning  Ö À : -0.023438 */
+{'[', 0x00c100d6, 0xfffffffa},/*kerning  Ö Á : -0.023438 */
+{'[', 0x00c200d6, 0xfffffffa},/*kerning  Ö Â : -0.023438 */
+{'[', 0x00c300d6, 0xfffffffa},/*kerning  Ö Ã : -0.023438 */
+{'[', 0x00c400d6, 0xfffffffa},/*kerning  Ö Ä : -0.023438 */
+{'[', 0x00c500d6, 0xfffffffa},/*kerning  Ö Å : -0.023438 */
+{'[', 0x00c600d6, 0xfffffff9},/*kerning  Ö Æ : -0.027344 */
+{'[', 0x00d000d6, 0xffffffff},/*kerning  Ö Ð : -0.003906 */
+{'[', 0x00dd00d6, 0xfffffff4},/*kerning  Ö Ý : -0.046875 */
+{'[', 0x00e000d6, 0xffffffff},/*kerning  Ö à : -0.003906 */
+{'[', 0x00e100d6, 0xffffffff},/*kerning  Ö á : -0.003906 */
+{'[', 0x00e200d6, 0xffffffff},/*kerning  Ö â : -0.003906 */
+{'[', 0x00e300d6, 0xffffffff},/*kerning  Ö ã : -0.003906 */
+{'[', 0x00e400d6, 0xffffffff},/*kerning  Ö ä : -0.003906 */
+{'[', 0x00e500d6, 0xffffffff},/*kerning  Ö å : -0.003906 */
+{'[', 0x00e600d6, 0xffffffff},/*kerning  Ö æ : -0.003906 */
+{'[', 0x00f100d6, 0xffffffff},/*kerning  Ö ñ : -0.003906 */
+{'[', 0x00fd00d6, 0xffffffff},/*kerning  Ö ý : -0.003906 */
+{'[', 0x00ff00d6, 0xffffffff},/*kerning  Ö ÿ : -0.003906 */
+{'@', 0x000000d7, 0x00004a00},/*        ×        x-advance: 74.000000 */
+{'M', 0x428147ae, 0xc1c8f5c2},
+{'l', 0xc10f5c28, 0x410ccccc},
+{'l', 0xc1947ae2, 0xc1947ae2},
+{'l', 0xc1947ae1, 0x41947ae2},
+{'l', 0xc10ccccc, 0xc10f5c28},
+{'l', 0x41933333, 0xc1933334},
+{'l', 0xc190a3d7, 0xc191eb84},
+{'l', 0x410f5c28, 0xc10cccd0},
+{'l', 0x4190a3d7, 0x4190a3d8},
+{'l', 0x4191eb86, 0xc191eb84},
+{'4', 0x00470046, 0x0091ff70},
+{'l', 0x41947ae2, 0x41947ae2},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x003300d7, 0xfffffffd},/*kerning  × 3� : -0.011719 */
+{'[', 0x003700d7, 0xfffffffb},/*kerning  × 7� : -0.019531 */
+{'@', 0x000000d8, 0x00007700},/*        Ø        x-advance: 119.000000 */
+{'M', 0x426eb852, 0x3f4ccccc},
+{'q', 0xc1400000, 0x00000000},
+{0, 0xc1ae147c, 0xc099999a},
+{'q', 0xc11c28f4, 0xc099999a},
+{0, 0xc1870a3c, 0xc150a3d6},
+{'q', 0xc0e3d70c, 0xc103d70a},
+{0, 0xc12f5c2a, 0xc1947ae1},
+{'q', 0xc075c290, 0xc1251eb8},
+{0, 0xc075c290, 0xc1a9999a},
+{'q', 0x00000000, 0xc135c28c},
+{0, 0x40828f5c, 0xc1ad70a2},
+{'q', 0x40828f5c, 0xc1251eb8},
+{0, 0x4135c290, 0xc1933334},
+{'q', 0x40e8f5c0, 0xc10147b0},
+{0, 0x418851ec, 0xc14cccc8},
+{'q', 0x411c28f4, 0xc0970a40},
+{0, 0x41aa3d70, 0xc0970a40},
+{'q', 0x41400000, 0x00000000},
+{0, 0x41ae1478, 0x409eb850},
+{'q', 0x411c28f8, 0x409eb850},
+{0, 0x41866668, 0x41547ae0},
+{'q', 0x40e147b0, 0x41051eb8},
+{0, 0x412e1480, 0x41947ae0},
+{'q', 0x4075c280, 0x4123d708},
+{0, 0x4075c280, 0x41a7ae14},
+{'q', 0x00000000, 0x4135c290},
+{0, 0xc0800000, 0x41ad70a4},
+{'q', 0xc0800000, 0x41251eb8},
+{0, 0xc1347ae0, 0x41933333},
+{'q', 0xc0e8f5c0, 0x410147ae},
+{0, 0xc18851ec, 0x414b851e},
+{'9', 0x0025ffb2, 0x0025ff56},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a66666, 0xc2633333},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x40333330, 0x4185c28e},
+{'q', 0x40333338, 0x410147b0},
+{0, 0x40fd70a8, 0x41651eba},
+{'q', 0x40a3d708, 0x40c7ae14},
+{0, 0x41451eb4, 0x411eb852},
+{'q', 0x40e66668, 0x406b8520},
+{0, 0x41800002, 0x406b8520},
+{'q', 0x4111eb84, 0x00000000},
+{0, 0x41828f5e, 0xc075c290},
+{'q', 0x40e66660, 0xc075c290},
+{0, 0x4143d700, 0xc123d70a},
+{'q', 0x40a147b0, 0xc0cccccc},
+{0, 0x40f5c2a0, 0xc1666666},
+{'q', 0x4028f5c0, 0xc1000000},
+{0, 0x4028f5c0, 0xc18147ae},
+{'q', 0x00000000, 0xc10a3d6c},
+{0, 0xc0333340, 0xc1851eb6},
+{'q', 0xc0333340, 0xc1000000},
+{0, 0xc1000000, 0xc1651eb8},
+{'q', 0xc0a66660, 0xc0ca3d70},
+{0, 0xc1451eb8, 0xc11eb850},
+{'q', 0xc0e3d710, 0xc0666680},
+{0, 0xc17c28f4, 0xc0666680},
+{'q', 0xc111eb88, 0x00000000},
+{0, 0xc1828f5e, 0x4070a3e0},
+{'q', 0xc0e66660, 0x4070a3e0},
+{0, 0xc143d708, 0x41228f58},
+{'q', 0xc0a147ac, 0x40ccccd0},
+{0, 0xc0f851e8, 0x41651ec0},
+{'9', 0x003fffeb, 0x0081ffeb},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42d428f5, 0xc2e33333},
+{'l', 0xc2999999, 0x42e33333},
+{'4', 0x0000ff83, 0xfc740265},
+{'l', 0x417d70a0, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002900d8, 0xfffffffc},/*kerning  Ø )� : -0.015625 */
+{'[', 0x002c00d8, 0xfffffffd},/*kerning  Ø ,� : -0.011719 */
+{'[', 0x002e00d8, 0xfffffffd},/*kerning  Ø .� : -0.011719 */
+{'[', 0x002f00d8, 0xfffffffa},/*kerning  Ø /� : -0.023438 */
+{'[', 0x004100d8, 0xfffffffa},/*kerning  Ø A� : -0.023438 */
+{'[', 0x004a00d8, 0xfffffffb},/*kerning  Ø J� : -0.019531 */
+{'[', 0x005400d8, 0xfffffffb},/*kerning  Ø T� : -0.019531 */
+{'[', 0x005600d8, 0xfffffffa},/*kerning  Ø V� : -0.023438 */
+{'[', 0x005700d8, 0xfffffffa},/*kerning  Ø W� : -0.023438 */
+{'[', 0x005800d8, 0xfffffff8},/*kerning  Ø X� : -0.031250 */
+{'[', 0x005900d8, 0xfffffff4},/*kerning  Ø Y� : -0.046875 */
+{'[', 0x005a00d8, 0xfffffffd},/*kerning  Ø Z� : -0.011719 */
+{'[', 0x005c00d8, 0xfffffffb},/*kerning  Ø \� : -0.019531 */
+{'[', 0x006100d8, 0xffffffff},/*kerning  Ø a� : -0.003906 */
+{'[', 0x006d00d8, 0xffffffff},/*kerning  Ø m� : -0.003906 */
+{'[', 0x006e00d8, 0xffffffff},/*kerning  Ø n� : -0.003906 */
+{'[', 0x007000d8, 0xffffffff},/*kerning  Ø p� : -0.003906 */
+{'[', 0x007200d8, 0xffffffff},/*kerning  Ø r� : -0.003906 */
+{'[', 0x007800d8, 0xfffffffe},/*kerning  Ø x� : -0.007812 */
+{'[', 0x007900d8, 0xffffffff},/*kerning  Ø y� : -0.003906 */
+{'[', 0x00c000d8, 0xfffffffa},/*kerning  Ø À : -0.023438 */
+{'[', 0x00c100d8, 0xfffffffa},/*kerning  Ø Á : -0.023438 */
+{'[', 0x00c200d8, 0xfffffffa},/*kerning  Ø Â : -0.023438 */
+{'[', 0x00c300d8, 0xfffffffa},/*kerning  Ø Ã : -0.023438 */
+{'[', 0x00c400d8, 0xfffffffa},/*kerning  Ø Ä : -0.023438 */
+{'[', 0x00c500d8, 0xfffffffa},/*kerning  Ø Å : -0.023438 */
+{'[', 0x00c600d8, 0xfffffff9},/*kerning  Ø Æ : -0.027344 */
+{'[', 0x00d000d8, 0xffffffff},/*kerning  Ø Ð : -0.003906 */
+{'[', 0x00dd00d8, 0xfffffff4},/*kerning  Ø Ý : -0.046875 */
+{'[', 0x00e000d8, 0xffffffff},/*kerning  Ø à : -0.003906 */
+{'[', 0x00e100d8, 0xffffffff},/*kerning  Ø á : -0.003906 */
+{'[', 0x00e200d8, 0xffffffff},/*kerning  Ø â : -0.003906 */
+{'[', 0x00e300d8, 0xffffffff},/*kerning  Ø ã : -0.003906 */
+{'[', 0x00e400d8, 0xffffffff},/*kerning  Ø ä : -0.003906 */
+{'[', 0x00e500d8, 0xffffffff},/*kerning  Ø å : -0.003906 */
+{'[', 0x00e600d8, 0xffffffff},/*kerning  Ø æ : -0.003906 */
+{'[', 0x00f100d8, 0xffffffff},/*kerning  Ø ñ : -0.003906 */
+{'[', 0x00fd00d8, 0xffffffff},/*kerning  Ø ý : -0.003906 */
+{'[', 0x00ff00d8, 0xffffffff},/*kerning  Ø ÿ : -0.003906 */
+{'@', 0x000000d9, 0x00007800},/*        Ù        x-advance: 120.000000 */
+{'M', 0x4271eb85, 0x3f4ccccc},
+{'q', 0xc159999c, 0x00000000},
+{0, 0xc1b70a3e, 0xc0970a3c},
+{'q', 0xc1147ae0, 0xc0970a3e},
+{0, 0xc16e147a, 0xc14ccccd},
+{'q', 0xc0b33334, 0xc10147ae},
+{0, 0xc1028f5c, 0xc1928f5d},
+{'9', 0xffafffec, 0xff58ffec},
+{'4', 0xfe350000, 0x00000073},
+{'l', 0x00000000, 0x4265c28f},
+{'q', 0x00000000, 0x41051eb8},
+{0, 0x3fd70a40, 0x4181eb86},
+{'q', 0x3fd70a40, 0x40fd70a0},
+{0, 0x40b0a3d4, 0x41628f5a},
+{'q', 0x4075c290, 0x40c7ae14},
+{0, 0x41266668, 0x411eb852},
+{'q', 0x40d1eb80, 0x406b8520},
+{0, 0x41828f5c, 0x406b8520},
+{'q', 0x411eb850, 0x00000000},
+{0, 0x4183d70c, 0xc070a3d8},
+{'q', 0x40d1eb80, 0xc070a3d8},
+{0, 0x41266660, 0xc12147ae},
+{'q', 0x4075c2a0, 0xc0ca3d70},
+{0, 0x40b0a3e0, 0xc1628f5c},
+{'9', 0xffc2000d, 0xff80000d},
+{'4', 0xfe350000, 0x00000073},
+{'l', 0x00000000, 0x4265c28f},
+{'q', 0x00000000, 0x413851ec},
+{0, 0xc028f5c0, 0x41aeb852},
+{'q', 0xc028f5c0, 0x41251eb8},
+{0, 0xc1066668, 0x419147ae},
+{'q', 0xc0b851e0, 0x40fae148},
+{0, 0xc16f5c20, 0x41466666},
+{'9', 0x0024ffb7, 0x0024ff4e},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x422f5c29, 0xc312b852},
+{'l', 0x415eb850, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d708, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002c00d9, 0xfffffffd},/*kerning  Ù ,� : -0.011719 */
+{'[', 0x002e00d9, 0xfffffffd},/*kerning  Ù .� : -0.011719 */
+{'[', 0x002f00d9, 0xfffffffa},/*kerning  Ù /� : -0.023438 */
+{'[', 0x003400d9, 0xfffffffe},/*kerning  Ù 4� : -0.007812 */
+{'[', 0x004100d9, 0xfffffff9},/*kerning  Ù A� : -0.027344 */
+{'[', 0x004a00d9, 0xfffffffa},/*kerning  Ù J� : -0.023438 */
+{'[', 0x006100d9, 0xfffffffd},/*kerning  Ù a� : -0.011719 */
+{'[', 0x006200d9, 0xffffffff},/*kerning  Ù b� : -0.003906 */
+{'[', 0x006300d9, 0xfffffffe},/*kerning  Ù c� : -0.007812 */
+{'[', 0x006400d9, 0xfffffffe},/*kerning  Ù d� : -0.007812 */
+{'[', 0x006500d9, 0xfffffffe},/*kerning  Ù e� : -0.007812 */
+{'[', 0x006600d9, 0xffffffff},/*kerning  Ù f� : -0.003906 */
+{'[', 0x006700d9, 0xfffffffe},/*kerning  Ù g� : -0.007812 */
+{'[', 0x006800d9, 0xffffffff},/*kerning  Ù h� : -0.003906 */
+{'[', 0x006900d9, 0xfffffffe},/*kerning  Ù i� : -0.007812 */
+{'[', 0x006a00d9, 0xfffffffe},/*kerning  Ù j� : -0.007812 */
+{'[', 0x006b00d9, 0xffffffff},/*kerning  Ù k� : -0.003906 */
+{'[', 0x006c00d9, 0xffffffff},/*kerning  Ù l� : -0.003906 */
+{'[', 0x006d00d9, 0xfffffffe},/*kerning  Ù m� : -0.007812 */
+{'[', 0x006e00d9, 0xfffffffe},/*kerning  Ù n� : -0.007812 */
+{'[', 0x006f00d9, 0xfffffffe},/*kerning  Ù o� : -0.007812 */
+{'[', 0x007000d9, 0xfffffffe},/*kerning  Ù p� : -0.007812 */
+{'[', 0x007100d9, 0xfffffffe},/*kerning  Ù q� : -0.007812 */
+{'[', 0x007200d9, 0xfffffffe},/*kerning  Ù r� : -0.007812 */
+{'[', 0x007300d9, 0xfffffffd},/*kerning  Ù s� : -0.011719 */
+{'[', 0x007400d9, 0xffffffff},/*kerning  Ù t� : -0.003906 */
+{'[', 0x007500d9, 0xfffffffe},/*kerning  Ù u� : -0.007812 */
+{'[', 0x007a00d9, 0xfffffffe},/*kerning  Ù z� : -0.007812 */
+{'[', 0x00c000d9, 0xfffffff9},/*kerning  Ù À : -0.027344 */
+{'[', 0x00c100d9, 0xfffffff9},/*kerning  Ù Á : -0.027344 */
+{'[', 0x00c200d9, 0xfffffff9},/*kerning  Ù Â : -0.027344 */
+{'[', 0x00c300d9, 0xfffffff9},/*kerning  Ù Ã : -0.027344 */
+{'[', 0x00c400d9, 0xfffffff9},/*kerning  Ù Ä : -0.027344 */
+{'[', 0x00c500d9, 0xfffffff9},/*kerning  Ù Å : -0.027344 */
+{'[', 0x00c600d9, 0xfffffff8},/*kerning  Ù Æ : -0.031250 */
+{'[', 0x00d000d9, 0xffffffff},/*kerning  Ù Ð : -0.003906 */
+{'[', 0x00df00d9, 0xffffffff},/*kerning  Ù ß : -0.003906 */
+{'[', 0x00e000d9, 0xfffffffd},/*kerning  Ù à : -0.011719 */
+{'[', 0x00e100d9, 0xfffffffd},/*kerning  Ù á : -0.011719 */
+{'[', 0x00e200d9, 0xfffffffd},/*kerning  Ù â : -0.011719 */
+{'[', 0x00e300d9, 0xfffffffd},/*kerning  Ù ã : -0.011719 */
+{'[', 0x00e400d9, 0xfffffffd},/*kerning  Ù ä : -0.011719 */
+{'[', 0x00e500d9, 0xfffffffd},/*kerning  Ù å : -0.011719 */
+{'[', 0x00e600d9, 0xfffffffd},/*kerning  Ù æ : -0.011719 */
+{'[', 0x00e700d9, 0xfffffffe},/*kerning  Ù ç : -0.007812 */
+{'[', 0x00e800d9, 0xfffffffe},/*kerning  Ù è : -0.007812 */
+{'[', 0x00e900d9, 0xfffffffe},/*kerning  Ù é : -0.007812 */
+{'[', 0x00ea00d9, 0xfffffffe},/*kerning  Ù ê : -0.007812 */
+{'[', 0x00eb00d9, 0xfffffffe},/*kerning  Ù ë : -0.007812 */
+{'[', 0x00ec00d9, 0xfffffffe},/*kerning  Ù ì : -0.007812 */
+{'[', 0x00ed00d9, 0xfffffffe},/*kerning  Ù í : -0.007812 */
+{'[', 0x00ee00d9, 0xfffffffe},/*kerning  Ù î : -0.007812 */
+{'[', 0x00ef00d9, 0xfffffffe},/*kerning  Ù ï : -0.007812 */
+{'[', 0x00f000d9, 0xfffffffd},/*kerning  Ù ð : -0.011719 */
+{'[', 0x00f100d9, 0xfffffffe},/*kerning  Ù ñ : -0.007812 */
+{'[', 0x00f200d9, 0xfffffffe},/*kerning  Ù ò : -0.007812 */
+{'[', 0x00f300d9, 0xfffffffe},/*kerning  Ù ó : -0.007812 */
+{'[', 0x00f400d9, 0xfffffffe},/*kerning  Ù ô : -0.007812 */
+{'[', 0x00f500d9, 0xfffffffe},/*kerning  Ù õ : -0.007812 */
+{'[', 0x00f600d9, 0xfffffffe},/*kerning  Ù ö : -0.007812 */
+{'[', 0x00f800d9, 0xfffffffe},/*kerning  Ù ø : -0.007812 */
+{'[', 0x00f900d9, 0xfffffffe},/*kerning  Ù ù : -0.007812 */
+{'[', 0x00fa00d9, 0xfffffffe},/*kerning  Ù ú : -0.007812 */
+{'[', 0x00fb00d9, 0xfffffffe},/*kerning  Ù û : -0.007812 */
+{'[', 0x00fc00d9, 0xfffffffe},/*kerning  Ù ü : -0.007812 */
+{'[', 0x00fe00d9, 0xffffffff},/*kerning  Ù þ : -0.003906 */
+{'@', 0x000000da, 0x00007800},/*        Ú        x-advance: 120.000000 */
+{'M', 0x4271eb85, 0x3f4ccccc},
+{'q', 0xc159999c, 0x00000000},
+{0, 0xc1b70a3e, 0xc0970a3c},
+{'q', 0xc1147ae0, 0xc0970a3e},
+{0, 0xc16e147a, 0xc14ccccd},
+{'q', 0xc0b33334, 0xc10147ae},
+{0, 0xc1028f5c, 0xc1928f5d},
+{'9', 0xffafffec, 0xff58ffec},
+{'4', 0xfe350000, 0x00000073},
+{'l', 0x00000000, 0x4265c28f},
+{'q', 0x00000000, 0x41051eb8},
+{0, 0x3fd70a40, 0x4181eb86},
+{'q', 0x3fd70a40, 0x40fd70a0},
+{0, 0x40b0a3d4, 0x41628f5a},
+{'q', 0x4075c290, 0x40c7ae14},
+{0, 0x41266668, 0x411eb852},
+{'q', 0x40d1eb80, 0x406b8520},
+{0, 0x41828f5c, 0x406b8520},
+{'q', 0x411eb850, 0x00000000},
+{0, 0x4183d70c, 0xc070a3d8},
+{'q', 0x40d1eb80, 0xc070a3d8},
+{0, 0x41266660, 0xc12147ae},
+{'q', 0x4075c2a0, 0xc0ca3d70},
+{0, 0x40b0a3e0, 0xc1628f5c},
+{'9', 0xffc2000d, 0xff80000d},
+{'4', 0xfe350000, 0x00000073},
+{'l', 0x00000000, 0x4265c28f},
+{'q', 0x00000000, 0x413851ec},
+{0, 0xc028f5c0, 0x41aeb852},
+{'q', 0xc028f5c0, 0x41251eb8},
+{0, 0xc1066668, 0x419147ae},
+{'q', 0xc0b851e0, 0x40fae148},
+{0, 0xc16f5c20, 0x41466666},
+{'9', 0x0024ffb7, 0x0024ff4e},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4282e147, 0xc2fe6666},
+{'l', 0xc1147adc, 0xc04cccc0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147b0, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002c00da, 0xfffffffd},/*kerning  Ú ,� : -0.011719 */
+{'[', 0x002e00da, 0xfffffffd},/*kerning  Ú .� : -0.011719 */
+{'[', 0x002f00da, 0xfffffffa},/*kerning  Ú /� : -0.023438 */
+{'[', 0x003400da, 0xfffffffe},/*kerning  Ú 4� : -0.007812 */
+{'[', 0x004100da, 0xfffffff9},/*kerning  Ú A� : -0.027344 */
+{'[', 0x004a00da, 0xfffffffa},/*kerning  Ú J� : -0.023438 */
+{'[', 0x006100da, 0xfffffffd},/*kerning  Ú a� : -0.011719 */
+{'[', 0x006200da, 0xffffffff},/*kerning  Ú b� : -0.003906 */
+{'[', 0x006300da, 0xfffffffe},/*kerning  Ú c� : -0.007812 */
+{'[', 0x006400da, 0xfffffffe},/*kerning  Ú d� : -0.007812 */
+{'[', 0x006500da, 0xfffffffe},/*kerning  Ú e� : -0.007812 */
+{'[', 0x006600da, 0xffffffff},/*kerning  Ú f� : -0.003906 */
+{'[', 0x006700da, 0xfffffffe},/*kerning  Ú g� : -0.007812 */
+{'[', 0x006800da, 0xffffffff},/*kerning  Ú h� : -0.003906 */
+{'[', 0x006900da, 0xfffffffe},/*kerning  Ú i� : -0.007812 */
+{'[', 0x006a00da, 0xfffffffe},/*kerning  Ú j� : -0.007812 */
+{'[', 0x006b00da, 0xffffffff},/*kerning  Ú k� : -0.003906 */
+{'[', 0x006c00da, 0xffffffff},/*kerning  Ú l� : -0.003906 */
+{'[', 0x006d00da, 0xfffffffe},/*kerning  Ú m� : -0.007812 */
+{'[', 0x006e00da, 0xfffffffe},/*kerning  Ú n� : -0.007812 */
+{'[', 0x006f00da, 0xfffffffe},/*kerning  Ú o� : -0.007812 */
+{'[', 0x007000da, 0xfffffffe},/*kerning  Ú p� : -0.007812 */
+{'[', 0x007100da, 0xfffffffe},/*kerning  Ú q� : -0.007812 */
+{'[', 0x007200da, 0xfffffffe},/*kerning  Ú r� : -0.007812 */
+{'[', 0x007300da, 0xfffffffd},/*kerning  Ú s� : -0.011719 */
+{'[', 0x007400da, 0xffffffff},/*kerning  Ú t� : -0.003906 */
+{'[', 0x007500da, 0xfffffffe},/*kerning  Ú u� : -0.007812 */
+{'[', 0x007a00da, 0xfffffffe},/*kerning  Ú z� : -0.007812 */
+{'[', 0x00c000da, 0xfffffff9},/*kerning  Ú À : -0.027344 */
+{'[', 0x00c100da, 0xfffffff9},/*kerning  Ú Á : -0.027344 */
+{'[', 0x00c200da, 0xfffffff9},/*kerning  Ú Â : -0.027344 */
+{'[', 0x00c300da, 0xfffffff9},/*kerning  Ú Ã : -0.027344 */
+{'[', 0x00c400da, 0xfffffff9},/*kerning  Ú Ä : -0.027344 */
+{'[', 0x00c500da, 0xfffffff9},/*kerning  Ú Å : -0.027344 */
+{'[', 0x00c600da, 0xfffffff8},/*kerning  Ú Æ : -0.031250 */
+{'[', 0x00d000da, 0xffffffff},/*kerning  Ú Ð : -0.003906 */
+{'[', 0x00df00da, 0xffffffff},/*kerning  Ú ß : -0.003906 */
+{'[', 0x00e000da, 0xfffffffd},/*kerning  Ú à : -0.011719 */
+{'[', 0x00e100da, 0xfffffffd},/*kerning  Ú á : -0.011719 */
+{'[', 0x00e200da, 0xfffffffd},/*kerning  Ú â : -0.011719 */
+{'[', 0x00e300da, 0xfffffffd},/*kerning  Ú ã : -0.011719 */
+{'[', 0x00e400da, 0xfffffffd},/*kerning  Ú ä : -0.011719 */
+{'[', 0x00e500da, 0xfffffffd},/*kerning  Ú å : -0.011719 */
+{'[', 0x00e600da, 0xfffffffd},/*kerning  Ú æ : -0.011719 */
+{'[', 0x00e700da, 0xfffffffe},/*kerning  Ú ç : -0.007812 */
+{'[', 0x00e800da, 0xfffffffe},/*kerning  Ú è : -0.007812 */
+{'[', 0x00e900da, 0xfffffffe},/*kerning  Ú é : -0.007812 */
+{'[', 0x00ea00da, 0xfffffffe},/*kerning  Ú ê : -0.007812 */
+{'[', 0x00eb00da, 0xfffffffe},/*kerning  Ú ë : -0.007812 */
+{'[', 0x00ec00da, 0xfffffffe},/*kerning  Ú ì : -0.007812 */
+{'[', 0x00ed00da, 0xfffffffe},/*kerning  Ú í : -0.007812 */
+{'[', 0x00ee00da, 0xfffffffe},/*kerning  Ú î : -0.007812 */
+{'[', 0x00ef00da, 0xfffffffe},/*kerning  Ú ï : -0.007812 */
+{'[', 0x00f000da, 0xfffffffd},/*kerning  Ú ð : -0.011719 */
+{'[', 0x00f100da, 0xfffffffe},/*kerning  Ú ñ : -0.007812 */
+{'[', 0x00f200da, 0xfffffffe},/*kerning  Ú ò : -0.007812 */
+{'[', 0x00f300da, 0xfffffffe},/*kerning  Ú ó : -0.007812 */
+{'[', 0x00f400da, 0xfffffffe},/*kerning  Ú ô : -0.007812 */
+{'[', 0x00f500da, 0xfffffffe},/*kerning  Ú õ : -0.007812 */
+{'[', 0x00f600da, 0xfffffffe},/*kerning  Ú ö : -0.007812 */
+{'[', 0x00f800da, 0xfffffffe},/*kerning  Ú ø : -0.007812 */
+{'[', 0x00f900da, 0xfffffffe},/*kerning  Ú ù : -0.007812 */
+{'[', 0x00fa00da, 0xfffffffe},/*kerning  Ú ú : -0.007812 */
+{'[', 0x00fb00da, 0xfffffffe},/*kerning  Ú û : -0.007812 */
+{'[', 0x00fc00da, 0xfffffffe},/*kerning  Ú ü : -0.007812 */
+{'[', 0x00fe00da, 0xffffffff},/*kerning  Ú þ : -0.003906 */
+{'@', 0x000000db, 0x00007800},/*        Û        x-advance: 120.000000 */
+{'M', 0x4271eb85, 0x3f4ccccc},
+{'q', 0xc159999c, 0x00000000},
+{0, 0xc1b70a3e, 0xc0970a3c},
+{'q', 0xc1147ae0, 0xc0970a3e},
+{0, 0xc16e147a, 0xc14ccccd},
+{'q', 0xc0b33334, 0xc10147ae},
+{0, 0xc1028f5c, 0xc1928f5d},
+{'9', 0xffafffec, 0xff58ffec},
+{'4', 0xfe350000, 0x00000073},
+{'l', 0x00000000, 0x4265c28f},
+{'q', 0x00000000, 0x41051eb8},
+{0, 0x3fd70a40, 0x4181eb86},
+{'q', 0x3fd70a40, 0x40fd70a0},
+{0, 0x40b0a3d4, 0x41628f5a},
+{'q', 0x4075c290, 0x40c7ae14},
+{0, 0x41266668, 0x411eb852},
+{'q', 0x40d1eb80, 0x406b8520},
+{0, 0x41828f5c, 0x406b8520},
+{'q', 0x411eb850, 0x00000000},
+{0, 0x4183d70c, 0xc070a3d8},
+{'q', 0x40d1eb80, 0xc070a3d8},
+{0, 0x41266660, 0xc12147ae},
+{'q', 0x4075c2a0, 0xc0ca3d70},
+{0, 0x40b0a3e0, 0xc1628f5c},
+{'9', 0xffc2000d, 0xff80000d},
+{'4', 0xfe350000, 0x00000073},
+{'l', 0x00000000, 0x4265c28f},
+{'q', 0x00000000, 0x413851ec},
+{0, 0xc028f5c0, 0x41aeb852},
+{'q', 0xc028f5c0, 0x41251eb8},
+{0, 0xc1066668, 0x419147ae},
+{'q', 0xc0b851e0, 0x40fae148},
+{0, 0xc16f5c20, 0x41466666},
+{'9', 0x0024ffb7, 0x0024ff4e},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x421ccccd, 0xc30428f6},
+{'l', 0x418147ae, 0xc1666660},
+{'l', 0x4123d708, 0x00000000},
+{'l', 0x418147ac, 0x41666660},
+{'0', 0xb0941ec3, 0xe2c35094},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002c00db, 0xfffffffd},/*kerning  Û ,� : -0.011719 */
+{'[', 0x002e00db, 0xfffffffd},/*kerning  Û .� : -0.011719 */
+{'[', 0x002f00db, 0xfffffffa},/*kerning  Û /� : -0.023438 */
+{'[', 0x003400db, 0xfffffffe},/*kerning  Û 4� : -0.007812 */
+{'[', 0x004100db, 0xfffffff9},/*kerning  Û A� : -0.027344 */
+{'[', 0x004a00db, 0xfffffffa},/*kerning  Û J� : -0.023438 */
+{'[', 0x006100db, 0xfffffffd},/*kerning  Û a� : -0.011719 */
+{'[', 0x006200db, 0xffffffff},/*kerning  Û b� : -0.003906 */
+{'[', 0x006300db, 0xfffffffe},/*kerning  Û c� : -0.007812 */
+{'[', 0x006400db, 0xfffffffe},/*kerning  Û d� : -0.007812 */
+{'[', 0x006500db, 0xfffffffe},/*kerning  Û e� : -0.007812 */
+{'[', 0x006600db, 0xffffffff},/*kerning  Û f� : -0.003906 */
+{'[', 0x006700db, 0xfffffffe},/*kerning  Û g� : -0.007812 */
+{'[', 0x006800db, 0xffffffff},/*kerning  Û h� : -0.003906 */
+{'[', 0x006900db, 0xfffffffe},/*kerning  Û i� : -0.007812 */
+{'[', 0x006a00db, 0xfffffffe},/*kerning  Û j� : -0.007812 */
+{'[', 0x006b00db, 0xffffffff},/*kerning  Û k� : -0.003906 */
+{'[', 0x006c00db, 0xffffffff},/*kerning  Û l� : -0.003906 */
+{'[', 0x006d00db, 0xfffffffe},/*kerning  Û m� : -0.007812 */
+{'[', 0x006e00db, 0xfffffffe},/*kerning  Û n� : -0.007812 */
+{'[', 0x006f00db, 0xfffffffe},/*kerning  Û o� : -0.007812 */
+{'[', 0x007000db, 0xfffffffe},/*kerning  Û p� : -0.007812 */
+{'[', 0x007100db, 0xfffffffe},/*kerning  Û q� : -0.007812 */
+{'[', 0x007200db, 0xfffffffe},/*kerning  Û r� : -0.007812 */
+{'[', 0x007300db, 0xfffffffd},/*kerning  Û s� : -0.011719 */
+{'[', 0x007400db, 0xffffffff},/*kerning  Û t� : -0.003906 */
+{'[', 0x007500db, 0xfffffffe},/*kerning  Û u� : -0.007812 */
+{'[', 0x007a00db, 0xfffffffe},/*kerning  Û z� : -0.007812 */
+{'[', 0x00c000db, 0xfffffff9},/*kerning  Û À : -0.027344 */
+{'[', 0x00c100db, 0xfffffff9},/*kerning  Û Á : -0.027344 */
+{'[', 0x00c200db, 0xfffffff9},/*kerning  Û Â : -0.027344 */
+{'[', 0x00c300db, 0xfffffff9},/*kerning  Û Ã : -0.027344 */
+{'[', 0x00c400db, 0xfffffff9},/*kerning  Û Ä : -0.027344 */
+{'[', 0x00c500db, 0xfffffff9},/*kerning  Û Å : -0.027344 */
+{'[', 0x00c600db, 0xfffffff8},/*kerning  Û Æ : -0.031250 */
+{'[', 0x00d000db, 0xffffffff},/*kerning  Û Ð : -0.003906 */
+{'[', 0x00df00db, 0xffffffff},/*kerning  Û ß : -0.003906 */
+{'[', 0x00e000db, 0xfffffffd},/*kerning  Û à : -0.011719 */
+{'[', 0x00e100db, 0xfffffffd},/*kerning  Û á : -0.011719 */
+{'[', 0x00e200db, 0xfffffffd},/*kerning  Û â : -0.011719 */
+{'[', 0x00e300db, 0xfffffffd},/*kerning  Û ã : -0.011719 */
+{'[', 0x00e400db, 0xfffffffd},/*kerning  Û ä : -0.011719 */
+{'[', 0x00e500db, 0xfffffffd},/*kerning  Û å : -0.011719 */
+{'[', 0x00e600db, 0xfffffffd},/*kerning  Û æ : -0.011719 */
+{'[', 0x00e700db, 0xfffffffe},/*kerning  Û ç : -0.007812 */
+{'[', 0x00e800db, 0xfffffffe},/*kerning  Û è : -0.007812 */
+{'[', 0x00e900db, 0xfffffffe},/*kerning  Û é : -0.007812 */
+{'[', 0x00ea00db, 0xfffffffe},/*kerning  Û ê : -0.007812 */
+{'[', 0x00eb00db, 0xfffffffe},/*kerning  Û ë : -0.007812 */
+{'[', 0x00ec00db, 0xfffffffe},/*kerning  Û ì : -0.007812 */
+{'[', 0x00ed00db, 0xfffffffe},/*kerning  Û í : -0.007812 */
+{'[', 0x00ee00db, 0xfffffffe},/*kerning  Û î : -0.007812 */
+{'[', 0x00ef00db, 0xfffffffe},/*kerning  Û ï : -0.007812 */
+{'[', 0x00f000db, 0xfffffffd},/*kerning  Û ð : -0.011719 */
+{'[', 0x00f100db, 0xfffffffe},/*kerning  Û ñ : -0.007812 */
+{'[', 0x00f200db, 0xfffffffe},/*kerning  Û ò : -0.007812 */
+{'[', 0x00f300db, 0xfffffffe},/*kerning  Û ó : -0.007812 */
+{'[', 0x00f400db, 0xfffffffe},/*kerning  Û ô : -0.007812 */
+{'[', 0x00f500db, 0xfffffffe},/*kerning  Û õ : -0.007812 */
+{'[', 0x00f600db, 0xfffffffe},/*kerning  Û ö : -0.007812 */
+{'[', 0x00f800db, 0xfffffffe},/*kerning  Û ø : -0.007812 */
+{'[', 0x00f900db, 0xfffffffe},/*kerning  Û ù : -0.007812 */
+{'[', 0x00fa00db, 0xfffffffe},/*kerning  Û ú : -0.007812 */
+{'[', 0x00fb00db, 0xfffffffe},/*kerning  Û û : -0.007812 */
+{'[', 0x00fc00db, 0xfffffffe},/*kerning  Û ü : -0.007812 */
+{'[', 0x00fe00db, 0xffffffff},/*kerning  Û þ : -0.003906 */
+{'@', 0x000000dc, 0x00007800},/*        Ü        x-advance: 120.000000 */
+{'M', 0x4271eb85, 0x3f4ccccc},
+{'q', 0xc159999c, 0x00000000},
+{0, 0xc1b70a3e, 0xc0970a3c},
+{'q', 0xc1147ae0, 0xc0970a3e},
+{0, 0xc16e147a, 0xc14ccccd},
+{'q', 0xc0b33334, 0xc10147ae},
+{0, 0xc1028f5c, 0xc1928f5d},
+{'9', 0xffafffec, 0xff58ffec},
+{'4', 0xfe350000, 0x00000073},
+{'l', 0x00000000, 0x4265c28f},
+{'q', 0x00000000, 0x41051eb8},
+{0, 0x3fd70a40, 0x4181eb86},
+{'q', 0x3fd70a40, 0x40fd70a0},
+{0, 0x40b0a3d4, 0x41628f5a},
+{'q', 0x4075c290, 0x40c7ae14},
+{0, 0x41266668, 0x411eb852},
+{'q', 0x40d1eb80, 0x406b8520},
+{0, 0x41828f5c, 0x406b8520},
+{'q', 0x411eb850, 0x00000000},
+{0, 0x4183d70c, 0xc070a3d8},
+{'q', 0x40d1eb80, 0xc070a3d8},
+{0, 0x41266660, 0xc12147ae},
+{'q', 0x4075c2a0, 0xc0ca3d70},
+{0, 0x40b0a3e0, 0xc1628f5c},
+{'9', 0xffc2000d, 0xff80000d},
+{'4', 0xfe350000, 0x00000073},
+{'l', 0x00000000, 0x4265c28f},
+{'q', 0x00000000, 0x413851ec},
+{0, 0xc028f5c0, 0x41aeb852},
+{'q', 0xc028f5c0, 0x41251eb8},
+{0, 0xc1066668, 0x419147ae},
+{'q', 0xc0b851e0, 0x40fae148},
+{0, 0xc16f5c20, 0x41466666},
+{'9', 0x0024ffb7, 0x0024ff4e},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42266666, 0xc301c28f},
+{'l', 0x00000000, 0xc1828f60},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42870a3d, 0xc301c28f},
+{'l', 0x00000000, 0xc1828f60},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a8, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002c00dc, 0xfffffffd},/*kerning  Ü ,� : -0.011719 */
+{'[', 0x002e00dc, 0xfffffffd},/*kerning  Ü .� : -0.011719 */
+{'[', 0x002f00dc, 0xfffffffa},/*kerning  Ü /� : -0.023438 */
+{'[', 0x003400dc, 0xfffffffe},/*kerning  Ü 4� : -0.007812 */
+{'[', 0x004100dc, 0xfffffff9},/*kerning  Ü A� : -0.027344 */
+{'[', 0x004a00dc, 0xfffffffa},/*kerning  Ü J� : -0.023438 */
+{'[', 0x006100dc, 0xfffffffd},/*kerning  Ü a� : -0.011719 */
+{'[', 0x006200dc, 0xffffffff},/*kerning  Ü b� : -0.003906 */
+{'[', 0x006300dc, 0xfffffffe},/*kerning  Ü c� : -0.007812 */
+{'[', 0x006400dc, 0xfffffffe},/*kerning  Ü d� : -0.007812 */
+{'[', 0x006500dc, 0xfffffffe},/*kerning  Ü e� : -0.007812 */
+{'[', 0x006600dc, 0xffffffff},/*kerning  Ü f� : -0.003906 */
+{'[', 0x006700dc, 0xfffffffe},/*kerning  Ü g� : -0.007812 */
+{'[', 0x006800dc, 0xffffffff},/*kerning  Ü h� : -0.003906 */
+{'[', 0x006900dc, 0xfffffffe},/*kerning  Ü i� : -0.007812 */
+{'[', 0x006a00dc, 0xfffffffe},/*kerning  Ü j� : -0.007812 */
+{'[', 0x006b00dc, 0xffffffff},/*kerning  Ü k� : -0.003906 */
+{'[', 0x006c00dc, 0xffffffff},/*kerning  Ü l� : -0.003906 */
+{'[', 0x006d00dc, 0xfffffffe},/*kerning  Ü m� : -0.007812 */
+{'[', 0x006e00dc, 0xfffffffe},/*kerning  Ü n� : -0.007812 */
+{'[', 0x006f00dc, 0xfffffffe},/*kerning  Ü o� : -0.007812 */
+{'[', 0x007000dc, 0xfffffffe},/*kerning  Ü p� : -0.007812 */
+{'[', 0x007100dc, 0xfffffffe},/*kerning  Ü q� : -0.007812 */
+{'[', 0x007200dc, 0xfffffffe},/*kerning  Ü r� : -0.007812 */
+{'[', 0x007300dc, 0xfffffffd},/*kerning  Ü s� : -0.011719 */
+{'[', 0x007400dc, 0xffffffff},/*kerning  Ü t� : -0.003906 */
+{'[', 0x007500dc, 0xfffffffe},/*kerning  Ü u� : -0.007812 */
+{'[', 0x007a00dc, 0xfffffffe},/*kerning  Ü z� : -0.007812 */
+{'[', 0x00c000dc, 0xfffffff9},/*kerning  Ü À : -0.027344 */
+{'[', 0x00c100dc, 0xfffffff9},/*kerning  Ü Á : -0.027344 */
+{'[', 0x00c200dc, 0xfffffff9},/*kerning  Ü Â : -0.027344 */
+{'[', 0x00c300dc, 0xfffffff9},/*kerning  Ü Ã : -0.027344 */
+{'[', 0x00c400dc, 0xfffffff9},/*kerning  Ü Ä : -0.027344 */
+{'[', 0x00c500dc, 0xfffffff9},/*kerning  Ü Å : -0.027344 */
+{'[', 0x00c600dc, 0xfffffff8},/*kerning  Ü Æ : -0.031250 */
+{'[', 0x00d000dc, 0xffffffff},/*kerning  Ü Ð : -0.003906 */
+{'[', 0x00df00dc, 0xffffffff},/*kerning  Ü ß : -0.003906 */
+{'[', 0x00e000dc, 0xfffffffd},/*kerning  Ü à : -0.011719 */
+{'[', 0x00e100dc, 0xfffffffd},/*kerning  Ü á : -0.011719 */
+{'[', 0x00e200dc, 0xfffffffd},/*kerning  Ü â : -0.011719 */
+{'[', 0x00e300dc, 0xfffffffd},/*kerning  Ü ã : -0.011719 */
+{'[', 0x00e400dc, 0xfffffffd},/*kerning  Ü ä : -0.011719 */
+{'[', 0x00e500dc, 0xfffffffd},/*kerning  Ü å : -0.011719 */
+{'[', 0x00e600dc, 0xfffffffd},/*kerning  Ü æ : -0.011719 */
+{'[', 0x00e700dc, 0xfffffffe},/*kerning  Ü ç : -0.007812 */
+{'[', 0x00e800dc, 0xfffffffe},/*kerning  Ü è : -0.007812 */
+{'[', 0x00e900dc, 0xfffffffe},/*kerning  Ü é : -0.007812 */
+{'[', 0x00ea00dc, 0xfffffffe},/*kerning  Ü ê : -0.007812 */
+{'[', 0x00eb00dc, 0xfffffffe},/*kerning  Ü ë : -0.007812 */
+{'[', 0x00ec00dc, 0xfffffffe},/*kerning  Ü ì : -0.007812 */
+{'[', 0x00ed00dc, 0xfffffffe},/*kerning  Ü í : -0.007812 */
+{'[', 0x00ee00dc, 0xfffffffe},/*kerning  Ü î : -0.007812 */
+{'[', 0x00ef00dc, 0xfffffffe},/*kerning  Ü ï : -0.007812 */
+{'[', 0x00f000dc, 0xfffffffd},/*kerning  Ü ð : -0.011719 */
+{'[', 0x00f100dc, 0xfffffffe},/*kerning  Ü ñ : -0.007812 */
+{'[', 0x00f200dc, 0xfffffffe},/*kerning  Ü ò : -0.007812 */
+{'[', 0x00f300dc, 0xfffffffe},/*kerning  Ü ó : -0.007812 */
+{'[', 0x00f400dc, 0xfffffffe},/*kerning  Ü ô : -0.007812 */
+{'[', 0x00f500dc, 0xfffffffe},/*kerning  Ü õ : -0.007812 */
+{'[', 0x00f600dc, 0xfffffffe},/*kerning  Ü ö : -0.007812 */
+{'[', 0x00f800dc, 0xfffffffe},/*kerning  Ü ø : -0.007812 */
+{'[', 0x00f900dc, 0xfffffffe},/*kerning  Ü ù : -0.007812 */
+{'[', 0x00fa00dc, 0xfffffffe},/*kerning  Ü ú : -0.007812 */
+{'[', 0x00fb00dc, 0xfffffffe},/*kerning  Ü û : -0.007812 */
+{'[', 0x00fc00dc, 0xfffffffe},/*kerning  Ü ü : -0.007812 */
+{'[', 0x00fe00dc, 0xffffffff},/*kerning  Ü þ : -0.003906 */
+{'@', 0x000000dd, 0x00006800},/*        Ý        x-advance: 104.000000 */
+{'M', 0x418f5c29, 0xc2e33333},
+{'l', 0x4209999a, 0x426ccccd},
+{'l', 0x420ae148, 0xc26ccccd},
+{'l', 0x417ae148, 0x00000000},
+{'l', 0xc22ccccd, 0x429051ec},
+{'l', 0x00000000, 0x4225c28e},
+{'l', 0xc1666668, 0x80000000},
+{'4', 0xfeb20000, 0xfdc2fea8},
+{'l', 0x417d70a6, 0xb7000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42651eb8, 0xc2fe6666},
+{'l', 0xc1147ae0, 0xc04cccc0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147b0, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002000dd, 0xfffffff7},/*kerning  Ý  � : -0.035156 */
+{'[', 0x002600dd, 0xfffffff9},/*kerning  Ý &� : -0.027344 */
+{'[', 0x002c00dd, 0xffffffeb},/*kerning  Ý ,� : -0.082031 */
+{'[', 0x002d00dd, 0xfffffff0},/*kerning  Ý -� : -0.062500 */
+{'[', 0x002e00dd, 0xffffffeb},/*kerning  Ý .� : -0.082031 */
+{'[', 0x002f00dd, 0xffffffeb},/*kerning  Ý /� : -0.082031 */
+{'[', 0x003000dd, 0xfffffff1},/*kerning  Ý 0� : -0.058594 */
+{'[', 0x003100dd, 0xfffffff5},/*kerning  Ý 1� : -0.042969 */
+{'[', 0x003200dd, 0xfffffff6},/*kerning  Ý 2� : -0.039062 */
+{'[', 0x003300dd, 0xfffffff6},/*kerning  Ý 3� : -0.039062 */
+{'[', 0x003400dd, 0xffffffec},/*kerning  Ý 4� : -0.078125 */
+{'[', 0x003500dd, 0xfffffff3},/*kerning  Ý 5� : -0.050781 */
+{'[', 0x003600dd, 0xfffffff8},/*kerning  Ý 6� : -0.031250 */
+{'[', 0x003800dd, 0xfffffffa},/*kerning  Ý 8� : -0.023438 */
+{'[', 0x003900dd, 0xfffffff2},/*kerning  Ý 9� : -0.054688 */
+{'[', 0x003a00dd, 0xfffffff9},/*kerning  Ý :� : -0.027344 */
+{'[', 0x003b00dd, 0xfffffff9},/*kerning  Ý ;� : -0.027344 */
+{'[', 0x004000dd, 0xffffffef},/*kerning  Ý @� : -0.066406 */
+{'[', 0x004100dd, 0xffffffed},/*kerning  Ý A� : -0.074219 */
+{'[', 0x004300dd, 0xfffffff5},/*kerning  Ý C� : -0.042969 */
+{'[', 0x004700dd, 0xfffffff5},/*kerning  Ý G� : -0.042969 */
+{'[', 0x004a00dd, 0xffffffea},/*kerning  Ý J� : -0.085938 */
+{'[', 0x004f00dd, 0xfffffff5},/*kerning  Ý O� : -0.042969 */
+{'[', 0x005100dd, 0xfffffff5},/*kerning  Ý Q� : -0.042969 */
+{'[', 0x005300dd, 0xfffffffa},/*kerning  Ý S� : -0.023438 */
+{'[', 0x006100dd, 0xffffffe9},/*kerning  Ý a� : -0.089844 */
+{'[', 0x006300dd, 0xffffffe9},/*kerning  Ý c� : -0.089844 */
+{'[', 0x006400dd, 0xffffffea},/*kerning  Ý d� : -0.085938 */
+{'[', 0x006500dd, 0xffffffe9},/*kerning  Ý e� : -0.089844 */
+{'[', 0x006600dd, 0xfffffff8},/*kerning  Ý f� : -0.031250 */
+{'[', 0x006700dd, 0xffffffea},/*kerning  Ý g� : -0.085938 */
+{'[', 0x006d00dd, 0xfffffff0},/*kerning  Ý m� : -0.062500 */
+{'[', 0x006e00dd, 0xfffffff0},/*kerning  Ý n� : -0.062500 */
+{'[', 0x006f00dd, 0xffffffe9},/*kerning  Ý o� : -0.089844 */
+{'[', 0x007000dd, 0xfffffff0},/*kerning  Ý p� : -0.062500 */
+{'[', 0x007100dd, 0xffffffea},/*kerning  Ý q� : -0.085938 */
+{'[', 0x007200dd, 0xfffffff0},/*kerning  Ý r� : -0.062500 */
+{'[', 0x007300dd, 0xffffffe8},/*kerning  Ý s� : -0.093750 */
+{'[', 0x007400dd, 0xfffffffb},/*kerning  Ý t� : -0.019531 */
+{'[', 0x007500dd, 0xfffffff1},/*kerning  Ý u� : -0.058594 */
+{'[', 0x007600dd, 0xfffffff7},/*kerning  Ý v� : -0.035156 */
+{'[', 0x007700dd, 0xfffffff8},/*kerning  Ý w� : -0.031250 */
+{'[', 0x007800dd, 0xfffffff9},/*kerning  Ý x� : -0.027344 */
+{'[', 0x007900dd, 0xfffffff8},/*kerning  Ý y� : -0.031250 */
+{'[', 0x007a00dd, 0xfffffff5},/*kerning  Ý z� : -0.042969 */
+{'[', 0x00a900dd, 0xfffffff6},/*kerning  Ý © : -0.039062 */
+{'[', 0x00ab00dd, 0xffffffec},/*kerning  Ý « : -0.078125 */
+{'[', 0x00ae00dd, 0xfffffff6},/*kerning  Ý ® : -0.039062 */
+{'[', 0x00bb00dd, 0xfffffff2},/*kerning  Ý » : -0.054688 */
+{'[', 0x00c000dd, 0xffffffed},/*kerning  Ý À : -0.074219 */
+{'[', 0x00c100dd, 0xffffffed},/*kerning  Ý Á : -0.074219 */
+{'[', 0x00c200dd, 0xffffffed},/*kerning  Ý Â : -0.074219 */
+{'[', 0x00c300dd, 0xffffffed},/*kerning  Ý Ã : -0.074219 */
+{'[', 0x00c400dd, 0xffffffed},/*kerning  Ý Ä : -0.074219 */
+{'[', 0x00c500dd, 0xffffffed},/*kerning  Ý Å : -0.074219 */
+{'[', 0x00c600dd, 0xffffffe5},/*kerning  Ý Æ : -0.105469 */
+{'[', 0x00c700dd, 0xfffffff5},/*kerning  Ý Ç : -0.042969 */
+{'[', 0x00d000dd, 0xfffffffe},/*kerning  Ý Ð : -0.007812 */
+{'[', 0x00d200dd, 0xfffffff5},/*kerning  Ý Ò : -0.042969 */
+{'[', 0x00d300dd, 0xfffffff5},/*kerning  Ý Ó : -0.042969 */
+{'[', 0x00d400dd, 0xfffffff5},/*kerning  Ý Ô : -0.042969 */
+{'[', 0x00d500dd, 0xfffffff5},/*kerning  Ý Õ : -0.042969 */
+{'[', 0x00d600dd, 0xfffffff5},/*kerning  Ý Ö : -0.042969 */
+{'[', 0x00d800dd, 0xfffffff5},/*kerning  Ý Ø : -0.042969 */
+{'[', 0x00df00dd, 0xfffffff6},/*kerning  Ý ß : -0.039062 */
+{'[', 0x00e000dd, 0xffffffe9},/*kerning  Ý à : -0.089844 */
+{'[', 0x00e100dd, 0xffffffe9},/*kerning  Ý á : -0.089844 */
+{'[', 0x00e200dd, 0xffffffe9},/*kerning  Ý â : -0.089844 */
+{'[', 0x00e300dd, 0xffffffe9},/*kerning  Ý ã : -0.089844 */
+{'[', 0x00e400dd, 0xffffffe9},/*kerning  Ý ä : -0.089844 */
+{'[', 0x00e500dd, 0xffffffe9},/*kerning  Ý å : -0.089844 */
+{'[', 0x00e600dd, 0xffffffe9},/*kerning  Ý æ : -0.089844 */
+{'[', 0x00e700dd, 0xffffffe9},/*kerning  Ý ç : -0.089844 */
+{'[', 0x00e800dd, 0xffffffe9},/*kerning  Ý è : -0.089844 */
+{'[', 0x00e900dd, 0xffffffe9},/*kerning  Ý é : -0.089844 */
+{'[', 0x00ea00dd, 0xffffffe9},/*kerning  Ý ê : -0.089844 */
+{'[', 0x00eb00dd, 0xffffffe9},/*kerning  Ý ë : -0.089844 */
+{'[', 0x00ed00dd, 0xfffffffd},/*kerning  Ý í : -0.011719 */
+{'[', 0x00ef00dd, 0x00000004},/*kerning  Ý ï : 0.015625 */
+{'[', 0x00f000dd, 0xffffffe8},/*kerning  Ý ð : -0.093750 */
+{'[', 0x00f100dd, 0xfffffff0},/*kerning  Ý ñ : -0.062500 */
+{'[', 0x00f200dd, 0xffffffe9},/*kerning  Ý ò : -0.089844 */
+{'[', 0x00f300dd, 0xffffffe9},/*kerning  Ý ó : -0.089844 */
+{'[', 0x00f400dd, 0xffffffe9},/*kerning  Ý ô : -0.089844 */
+{'[', 0x00f500dd, 0xffffffe9},/*kerning  Ý õ : -0.089844 */
+{'[', 0x00f600dd, 0xffffffe9},/*kerning  Ý ö : -0.089844 */
+{'[', 0x00f800dd, 0xffffffe9},/*kerning  Ý ø : -0.089844 */
+{'[', 0x00f900dd, 0xfffffff1},/*kerning  Ý ù : -0.058594 */
+{'[', 0x00fa00dd, 0xfffffff1},/*kerning  Ý ú : -0.058594 */
+{'[', 0x00fb00dd, 0xfffffff1},/*kerning  Ý û : -0.058594 */
+{'[', 0x00fc00dd, 0xfffffff1},/*kerning  Ý ü : -0.058594 */
+{'[', 0x00fd00dd, 0xfffffff8},/*kerning  Ý ý : -0.031250 */
+{'[', 0x00ff00dd, 0xfffffff8},/*kerning  Ý ÿ : -0.031250 */
+{'@', 0x000000de, 0x00006000},/*        Þ        x-advance: 96.000000 */
+{'M', 0x426851eb, 0xc2b75c29},
+{'8', 0x186e003c, 0x42571831},
+{'8', 0x5d392925, 0x69143314},
+{'q', 0x00000000, 0x41170a40},
+{0, 0xc0851ec0, 0x418e147c},
+{'q', 0xc0851eb0, 0x41051eb8},
+{0, 0xc13ae140, 0x415851ec},
+{'9', 0x0029ffc4, 0x0029ff74},
+{'l', 0xc1f851ea, 0x00000000},
+{'l', 0x00000000, 0x41970a3d},
+{'l', 0xc1666667, 0x80000000},
+{'l', 0x00000000, 0xc2e33333},
+{'4', 0x00000073, 0x00af0000},
+{'l', 0x41f0a3d6, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42699999, 0xc1fd70a3},
+{'8', 0xe6530030, 0xba36e623},
+{'8', 0xa413d513, 0xa2eacd00},
+{'8', 0xbcc4d6ea, 0xe7aee7db},
+{'4', 0x0000ff15, 0x01790000},
+{'l', 0x41f33332, 0x36000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200de, 0xfffffffe},/*kerning  Þ "� : -0.007812 */
+{'[', 0x002700de, 0xfffffffe},/*kerning  Þ '� : -0.007812 */
+{'[', 0x002900de, 0xfffffffb},/*kerning  Þ )� : -0.019531 */
+{'[', 0x002a00de, 0xfffffffc},/*kerning  Þ *� : -0.015625 */
+{'[', 0x002c00de, 0xfffffffa},/*kerning  Þ ,� : -0.023438 */
+{'[', 0x002e00de, 0xfffffffa},/*kerning  Þ .� : -0.023438 */
+{'[', 0x002f00de, 0xfffffff9},/*kerning  Þ /� : -0.027344 */
+{'[', 0x003f00de, 0xfffffffd},/*kerning  Þ ?� : -0.011719 */
+{'[', 0x004100de, 0xfffffffa},/*kerning  Þ A� : -0.023438 */
+{'[', 0x004a00de, 0xfffffff9},/*kerning  Þ J� : -0.027344 */
+{'[', 0x005400de, 0xfffffff5},/*kerning  Þ T� : -0.042969 */
+{'[', 0x005600de, 0xfffffff8},/*kerning  Þ V� : -0.031250 */
+{'[', 0x005700de, 0xfffffff8},/*kerning  Þ W� : -0.031250 */
+{'[', 0x005800de, 0xfffffff6},/*kerning  Þ X� : -0.039062 */
+{'[', 0x005900de, 0xfffffff1},/*kerning  Þ Y� : -0.058594 */
+{'[', 0x005a00de, 0xfffffffb},/*kerning  Þ Z� : -0.019531 */
+{'[', 0x005c00de, 0xfffffff8},/*kerning  Þ \� : -0.031250 */
+{'[', 0x007800de, 0xffffffff},/*kerning  Þ x� : -0.003906 */
+{'[', 0x007900de, 0xffffffff},/*kerning  Þ y� : -0.003906 */
+{'[', 0x00c000de, 0xfffffffa},/*kerning  Þ À : -0.023438 */
+{'[', 0x00c100de, 0xfffffffa},/*kerning  Þ Á : -0.023438 */
+{'[', 0x00c200de, 0xfffffffa},/*kerning  Þ Â : -0.023438 */
+{'[', 0x00c300de, 0xfffffffa},/*kerning  Þ Ã : -0.023438 */
+{'[', 0x00c400de, 0xfffffffa},/*kerning  Þ Ä : -0.023438 */
+{'[', 0x00c500de, 0xfffffffa},/*kerning  Þ Å : -0.023438 */
+{'[', 0x00c600de, 0xfffffff9},/*kerning  Þ Æ : -0.027344 */
+{'[', 0x00d000de, 0xffffffff},/*kerning  Þ Ð : -0.003906 */
+{'[', 0x00dd00de, 0xfffffff1},/*kerning  Þ Ý : -0.058594 */
+{'[', 0x00fd00de, 0xffffffff},/*kerning  Þ ý : -0.003906 */
+{'[', 0x00ff00de, 0xffffffff},/*kerning  Þ ÿ : -0.003906 */
+{'@', 0x000000df, 0x00005800},/*        ß        x-advance: 88.000000 */
+{'M', 0x421a3d70, 0xc1400000},
+{'q', 0x4151eb88, 0xbea3d700},
+{0, 0x41ab8520, 0xc0b0a3d8},
+{'q', 0x41051eb8, 0xc0a66664},
+{0, 0x41051eb8, 0xc1870a3c},
+{'q', 0x00000000, 0xc1266668},
+{0, 0xc0d47ae0, 0xc1847ae2},
+{'9', 0xffcfffcb, 0xffcfff74},
+{'4', 0x0000ffe8, 0xff9a0000},
+{'l', 0x403851f0, 0x00000000},
+{'8', 0xdc63003d, 0xa126dc26},
+{'8', 0xa2d7c000, 0xe2a0e2d7},
+{'8', 0x18a900cc, 0x3fce18de},
+{'9', 0x0027fff0, 0x0055fff0},
+{'4', 0x02830000, 0x0000ff95},
+{'l', 0x00000000, 0xc2a570a4},
+{'q', 0x00000000, 0xc1147ae0},
+{0, 0x408a3d72, 0xc1833330},
+{'q', 0x408a3d70, 0xc0e3d710},
+{0, 0x413c28f6, 0xc131eb88},
+{'q', 0x40ee147c, 0xc0800000},
+{0, 0x418851eb, 0xc0800000},
+{'q', 0x410a3d70, 0x00000000},
+{0, 0x41770a3c, 0x404ccce0},
+{'8', 0x48561936, 0x6c202e20},
+{'8', 0x55ef2c00, 0x45d228ef},
+{'q', 0xc0666680, 0x406147a0},
+{0, 0xc10147b4, 0x40999990},
+{'q', 0x4135c294, 0x401999a0},
+{0, 0x418e147a, 0x4130a3d8},
+{'q', 0x40ccccd0, 0x410a3d70},
+{0, 0x40ccccd0, 0x41a00000},
+{'q', 0x00000000, 0x412e147a},
+{0, 0xc0b5c290, 0x41933333},
+{'q', 0xc0b5c290, 0x40f0a3d6},
+{0, 0xc17ae148, 0x41370a3d},
+{'9', 0x001fffb1, 0x0023ff49},
+{'l', 0x00000000, 0xc14f5c29},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002900df, 0xfffffffe},/*kerning  ß )� : -0.007812 */
+{'[', 0x004100df, 0xfffffffd},/*kerning  ß A� : -0.011719 */
+{'[', 0x004200df, 0xfffffffe},/*kerning  ß B� : -0.007812 */
+{'[', 0x004400df, 0xfffffffe},/*kerning  ß D� : -0.007812 */
+{'[', 0x004500df, 0xfffffffe},/*kerning  ß E� : -0.007812 */
+{'[', 0x004600df, 0xfffffffe},/*kerning  ß F� : -0.007812 */
+{'[', 0x004800df, 0xfffffffe},/*kerning  ß H� : -0.007812 */
+{'[', 0x004900df, 0xfffffffe},/*kerning  ß I� : -0.007812 */
+{'[', 0x004b00df, 0xfffffffe},/*kerning  ß K� : -0.007812 */
+{'[', 0x004c00df, 0xfffffffe},/*kerning  ß L� : -0.007812 */
+{'[', 0x004d00df, 0xfffffffe},/*kerning  ß M� : -0.007812 */
+{'[', 0x004e00df, 0xfffffffe},/*kerning  ß N� : -0.007812 */
+{'[', 0x005000df, 0xfffffffe},/*kerning  ß P� : -0.007812 */
+{'[', 0x005200df, 0xfffffffe},/*kerning  ß R� : -0.007812 */
+{'[', 0x005300df, 0xffffffff},/*kerning  ß S� : -0.003906 */
+{'[', 0x005400df, 0xfffffffb},/*kerning  ß T� : -0.019531 */
+{'[', 0x005500df, 0xfffffffd},/*kerning  ß U� : -0.011719 */
+{'[', 0x005600df, 0xfffffff8},/*kerning  ß V� : -0.031250 */
+{'[', 0x005700df, 0xfffffff8},/*kerning  ß W� : -0.031250 */
+{'[', 0x005800df, 0xfffffffa},/*kerning  ß X� : -0.023438 */
+{'[', 0x005900df, 0xfffffff4},/*kerning  ß Y� : -0.046875 */
+{'[', 0x005a00df, 0xfffffffe},/*kerning  ß Z� : -0.007812 */
+{'[', 0x005c00df, 0xfffffffc},/*kerning  ß \� : -0.015625 */
+{'[', 0x006600df, 0xfffffffe},/*kerning  ß f� : -0.007812 */
+{'[', 0x007400df, 0xffffffff},/*kerning  ß t� : -0.003906 */
+{'[', 0x007600df, 0xfffffffc},/*kerning  ß v� : -0.015625 */
+{'[', 0x007700df, 0xfffffffc},/*kerning  ß w� : -0.015625 */
+{'[', 0x007800df, 0xfffffffc},/*kerning  ß x� : -0.015625 */
+{'[', 0x007900df, 0xfffffffc},/*kerning  ß y� : -0.015625 */
+{'[', 0x007a00df, 0xffffffff},/*kerning  ß z� : -0.003906 */
+{'[', 0x00c000df, 0xfffffffd},/*kerning  ß À : -0.011719 */
+{'[', 0x00c100df, 0xfffffffd},/*kerning  ß Á : -0.011719 */
+{'[', 0x00c200df, 0xfffffffd},/*kerning  ß Â : -0.011719 */
+{'[', 0x00c300df, 0xfffffffd},/*kerning  ß Ã : -0.011719 */
+{'[', 0x00c400df, 0xfffffffd},/*kerning  ß Ä : -0.011719 */
+{'[', 0x00c500df, 0xfffffffd},/*kerning  ß Å : -0.011719 */
+{'[', 0x00c600df, 0xfffffffe},/*kerning  ß Æ : -0.007812 */
+{'[', 0x00c800df, 0xfffffffe},/*kerning  ß È : -0.007812 */
+{'[', 0x00c900df, 0xfffffffe},/*kerning  ß É : -0.007812 */
+{'[', 0x00ca00df, 0xfffffffe},/*kerning  ß Ê : -0.007812 */
+{'[', 0x00cb00df, 0xfffffffe},/*kerning  ß Ë : -0.007812 */
+{'[', 0x00cc00df, 0xfffffffe},/*kerning  ß Ì : -0.007812 */
+{'[', 0x00cd00df, 0xfffffffe},/*kerning  ß Í : -0.007812 */
+{'[', 0x00ce00df, 0xfffffffe},/*kerning  ß Î : -0.007812 */
+{'[', 0x00cf00df, 0xfffffffe},/*kerning  ß Ï : -0.007812 */
+{'[', 0x00d000df, 0xfffffffc},/*kerning  ß Ð : -0.015625 */
+{'[', 0x00d100df, 0xfffffffe},/*kerning  ß Ñ : -0.007812 */
+{'[', 0x00d900df, 0xfffffffd},/*kerning  ß Ù : -0.011719 */
+{'[', 0x00da00df, 0xfffffffd},/*kerning  ß Ú : -0.011719 */
+{'[', 0x00db00df, 0xfffffffd},/*kerning  ß Û : -0.011719 */
+{'[', 0x00dc00df, 0xfffffffd},/*kerning  ß Ü : -0.011719 */
+{'[', 0x00dd00df, 0xfffffff4},/*kerning  ß Ý : -0.046875 */
+{'[', 0x00de00df, 0xfffffffe},/*kerning  ß Þ : -0.007812 */
+{'[', 0x00fd00df, 0xfffffffc},/*kerning  ß ý : -0.015625 */
+{'[', 0x00ff00df, 0xfffffffc},/*kerning  ß ÿ : -0.015625 */
+{'@', 0x000000e0, 0x00005800},/*        à        x-advance: 88.000000 */
+{'M', 0x40999999, 0xc1c147ae},
+{'8', 0x9224c000, 0xb864d224},
+{'q', 0x41000000, 0xc04cccc0},
+{0, 0x41947ae1, 0xc04cccc0},
+{'8', 0x075e002c, 0x15580731},
+{'l', 0x00000000, 0xc0c28f60},
+{'q', 0x00000000, 0xc1199998},
+{0, 0xc0b851e8, 0xc171eb84},
+{'q', 0xc0b851e8, 0xc0b0a3d0},
+{0, 0xc1828f5c, 0xc0b0a3d0},
+{'8', 0x139700c9, 0x389613ce},
+{'l', 0xc0a3d70a, 0xc11eb854},
+{'q', 0x41028f5d, 0xc0b33330},
+{0, 0x41828f5c, 0xc1066668},
+{'q', 0x41028f5c, 0xc0333320},
+{0, 0x4187ae14, 0xc0333320},
+{'q', 0x41800000, 0x00000000},
+{0, 0x41ca3d70, 0x410e1478},
+{'9', 0x0047004a, 0x00c5004a},
+{'l', 0x00000000, 0x420d70a4},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e402f0, 0x01ed01f4},
+{'8', 0xebc500d9, 0xd2eaebed},
+{'l', 0xbea3d700, 0xc0a8f5c3},
+{'q', 0xc0ae1478, 0x40e147ae},
+{0, 0xc163d708, 0x412e147b},
+{'q', 0xc10cccd0, 0x4075c28e},
+{0, 0xc18b8520, 0x4075c28e},
+{'q', 0xc1051eb8, 0x00000000},
+{0, 0xc16e147a, 0xc05c28f5},
+{'8', 0xb6afe5cc, 0x98e3d2e3},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x426ccccc, 0xc191eb85},
+{'8', 0xdc18ef0f, 0xe108ee08},
+{'l', 0x00000000, 0xc1266666},
+{'q', 0xc123d708, 0xc0800000},
+{0, 0xc1a8f5c2, 0xc0800000},
+{'q', 0xc12b851e, 0x00000000},
+{0, 0xc18ae147, 0x4087ae18},
+{'8', 0x5ccb21cb, 0x3e112000},
+{'8', 0x31331e11, 0x13531321},
+{'8', 0xeb630034, 0xcb4beb2f},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41cf5c29, 0xc2e9eb85},
+{'l', 0x415eb852, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d70a, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200e0, 0xfffffffd},/*kerning  à "� : -0.011719 */
+{'[', 0x002700e0, 0xfffffffd},/*kerning  à '� : -0.011719 */
+{'[', 0x002a00e0, 0xfffffffb},/*kerning  à *� : -0.019531 */
+{'[', 0x003f00e0, 0xfffffffb},/*kerning  à ?� : -0.019531 */
+{'[', 0x005400e0, 0xffffffe4},/*kerning  à T� : -0.109375 */
+{'[', 0x005500e0, 0xfffffffe},/*kerning  à U� : -0.007812 */
+{'[', 0x005600e0, 0xfffffff2},/*kerning  à V� : -0.054688 */
+{'[', 0x005700e0, 0xfffffff2},/*kerning  à W� : -0.054688 */
+{'[', 0x005900e0, 0xffffffe9},/*kerning  à Y� : -0.089844 */
+{'[', 0x005c00e0, 0xfffffff2},/*kerning  à \� : -0.054688 */
+{'[', 0x006600e0, 0xffffffff},/*kerning  à f� : -0.003906 */
+{'[', 0x007400e0, 0xffffffff},/*kerning  à t� : -0.003906 */
+{'[', 0x007600e0, 0xfffffffc},/*kerning  à v� : -0.015625 */
+{'[', 0x007700e0, 0xfffffffc},/*kerning  à w� : -0.015625 */
+{'[', 0x007900e0, 0xfffffffc},/*kerning  à y� : -0.015625 */
+{'[', 0x00ba00e0, 0xfffffffe},/*kerning  à º : -0.007812 */
+{'[', 0x00d000e0, 0xfffffffe},/*kerning  à Ð : -0.007812 */
+{'[', 0x00d900e0, 0xfffffffe},/*kerning  à Ù : -0.007812 */
+{'[', 0x00da00e0, 0xfffffffe},/*kerning  à Ú : -0.007812 */
+{'[', 0x00db00e0, 0xfffffffe},/*kerning  à Û : -0.007812 */
+{'[', 0x00dc00e0, 0xfffffffe},/*kerning  à Ü : -0.007812 */
+{'[', 0x00dd00e0, 0xffffffe9},/*kerning  à Ý : -0.089844 */
+{'[', 0x00fd00e0, 0xfffffffc},/*kerning  à ý : -0.015625 */
+{'[', 0x00ff00e0, 0xfffffffc},/*kerning  à ÿ : -0.015625 */
+{'@', 0x000000e1, 0x00005800},/*        á        x-advance: 88.000000 */
+{'M', 0x40999999, 0xc1c147ae},
+{'8', 0x9224c000, 0xb864d224},
+{'q', 0x41000000, 0xc04cccc0},
+{0, 0x41947ae1, 0xc04cccc0},
+{'8', 0x075e002c, 0x15580731},
+{'l', 0x00000000, 0xc0c28f60},
+{'q', 0x00000000, 0xc1199998},
+{0, 0xc0b851e8, 0xc171eb84},
+{'q', 0xc0b851e8, 0xc0b0a3d0},
+{0, 0xc1828f5c, 0xc0b0a3d0},
+{'8', 0x139700c9, 0x389613ce},
+{'l', 0xc0a3d70a, 0xc11eb854},
+{'q', 0x41028f5d, 0xc0b33330},
+{0, 0x41828f5c, 0xc1066668},
+{'q', 0x41028f5c, 0xc0333320},
+{0, 0x4187ae14, 0xc0333320},
+{'q', 0x41800000, 0x00000000},
+{0, 0x41ca3d70, 0x410e1478},
+{'9', 0x0047004a, 0x00c5004a},
+{'l', 0x00000000, 0x420d70a4},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e402f0, 0x01ed01f4},
+{'8', 0xebc500d9, 0xd2eaebed},
+{'l', 0xbea3d700, 0xc0a8f5c3},
+{'q', 0xc0ae1478, 0x40e147ae},
+{0, 0xc163d708, 0x412e147b},
+{'q', 0xc10cccd0, 0x4075c28e},
+{0, 0xc18b8520, 0x4075c28e},
+{'q', 0xc1051eb8, 0x00000000},
+{0, 0xc16e147a, 0xc05c28f5},
+{'8', 0xb6afe5cc, 0x98e3d2e3},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x426ccccc, 0xc191eb85},
+{'8', 0xdc18ef0f, 0xe108ee08},
+{'l', 0x00000000, 0xc1266666},
+{'q', 0xc123d708, 0xc0800000},
+{0, 0xc1a8f5c2, 0xc0800000},
+{'q', 0xc12b851e, 0x00000000},
+{0, 0xc18ae147, 0x4087ae18},
+{'8', 0x5ccb21cb, 0x3e112000},
+{'8', 0x31331e11, 0x13531321},
+{'8', 0xeb630034, 0xcb4beb2f},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x423e147b, 0xc2c2e147},
+{'l', 0xc1147ae4, 0xc04ccce0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147ac, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200e1, 0xfffffffd},/*kerning  á "� : -0.011719 */
+{'[', 0x002700e1, 0xfffffffd},/*kerning  á '� : -0.011719 */
+{'[', 0x002a00e1, 0xfffffffb},/*kerning  á *� : -0.019531 */
+{'[', 0x003f00e1, 0xfffffffb},/*kerning  á ?� : -0.019531 */
+{'[', 0x005400e1, 0xffffffe4},/*kerning  á T� : -0.109375 */
+{'[', 0x005500e1, 0xfffffffe},/*kerning  á U� : -0.007812 */
+{'[', 0x005600e1, 0xfffffff2},/*kerning  á V� : -0.054688 */
+{'[', 0x005700e1, 0xfffffff2},/*kerning  á W� : -0.054688 */
+{'[', 0x005900e1, 0xffffffe9},/*kerning  á Y� : -0.089844 */
+{'[', 0x005c00e1, 0xfffffff2},/*kerning  á \� : -0.054688 */
+{'[', 0x006600e1, 0xffffffff},/*kerning  á f� : -0.003906 */
+{'[', 0x007400e1, 0xffffffff},/*kerning  á t� : -0.003906 */
+{'[', 0x007600e1, 0xfffffffc},/*kerning  á v� : -0.015625 */
+{'[', 0x007700e1, 0xfffffffc},/*kerning  á w� : -0.015625 */
+{'[', 0x007900e1, 0xfffffffc},/*kerning  á y� : -0.015625 */
+{'[', 0x00ba00e1, 0xfffffffe},/*kerning  á º : -0.007812 */
+{'[', 0x00d000e1, 0xfffffffe},/*kerning  á Ð : -0.007812 */
+{'[', 0x00d900e1, 0xfffffffe},/*kerning  á Ù : -0.007812 */
+{'[', 0x00da00e1, 0xfffffffe},/*kerning  á Ú : -0.007812 */
+{'[', 0x00db00e1, 0xfffffffe},/*kerning  á Û : -0.007812 */
+{'[', 0x00dc00e1, 0xfffffffe},/*kerning  á Ü : -0.007812 */
+{'[', 0x00dd00e1, 0xffffffe9},/*kerning  á Ý : -0.089844 */
+{'[', 0x00fd00e1, 0xfffffffc},/*kerning  á ý : -0.015625 */
+{'[', 0x00ff00e1, 0xfffffffc},/*kerning  á ÿ : -0.015625 */
+{'@', 0x000000e2, 0x00005800},/*        â        x-advance: 88.000000 */
+{'M', 0x40999999, 0xc1c147ae},
+{'8', 0x9224c000, 0xb864d224},
+{'q', 0x41000000, 0xc04cccc0},
+{0, 0x41947ae1, 0xc04cccc0},
+{'8', 0x075e002c, 0x15580731},
+{'l', 0x00000000, 0xc0c28f60},
+{'q', 0x00000000, 0xc1199998},
+{0, 0xc0b851e8, 0xc171eb84},
+{'q', 0xc0b851e8, 0xc0b0a3d0},
+{0, 0xc1828f5c, 0xc0b0a3d0},
+{'8', 0x139700c9, 0x389613ce},
+{'l', 0xc0a3d70a, 0xc11eb854},
+{'q', 0x41028f5d, 0xc0b33330},
+{0, 0x41828f5c, 0xc1066668},
+{'q', 0x41028f5c, 0xc0333320},
+{0, 0x4187ae14, 0xc0333320},
+{'q', 0x41800000, 0x00000000},
+{0, 0x41ca3d70, 0x410e1478},
+{'9', 0x0047004a, 0x00c5004a},
+{'l', 0x00000000, 0x420d70a4},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e402f0, 0x01ed01f4},
+{'8', 0xebc500d9, 0xd2eaebed},
+{'l', 0xbea3d700, 0xc0a8f5c3},
+{'q', 0xc0ae1478, 0x40e147ae},
+{0, 0xc163d708, 0x412e147b},
+{'q', 0xc10cccd0, 0x4075c28e},
+{0, 0xc18b8520, 0x4075c28e},
+{'q', 0xc1051eb8, 0x00000000},
+{0, 0xc16e147a, 0xc05c28f5},
+{'8', 0xb6afe5cc, 0x98e3d2e3},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x426ccccc, 0xc191eb85},
+{'8', 0xdc18ef0f, 0xe108ee08},
+{'l', 0x00000000, 0xc1266666},
+{'q', 0xc123d708, 0xc0800000},
+{0, 0xc1a8f5c2, 0xc0800000},
+{'q', 0xc12b851e, 0x00000000},
+{0, 0xc18ae147, 0x4087ae18},
+{'8', 0x5ccb21cb, 0x3e112000},
+{'8', 0x31331e11, 0x13531321},
+{'8', 0xeb630034, 0xcb4beb2f},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41aa3d70, 0xc2cccccc},
+{'l', 0x418147ae, 0xc1666668},
+{'l', 0x4123d70c, 0x00000000},
+{'l', 0x418147ae, 0x41666668},
+{'0', 0xb0941ec3, 0xe2c35094},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200e2, 0xfffffffd},/*kerning  â "� : -0.011719 */
+{'[', 0x002700e2, 0xfffffffd},/*kerning  â '� : -0.011719 */
+{'[', 0x002a00e2, 0xfffffffb},/*kerning  â *� : -0.019531 */
+{'[', 0x003f00e2, 0xfffffffb},/*kerning  â ?� : -0.019531 */
+{'[', 0x005400e2, 0xffffffe4},/*kerning  â T� : -0.109375 */
+{'[', 0x005500e2, 0xfffffffe},/*kerning  â U� : -0.007812 */
+{'[', 0x005600e2, 0xfffffff2},/*kerning  â V� : -0.054688 */
+{'[', 0x005700e2, 0xfffffff2},/*kerning  â W� : -0.054688 */
+{'[', 0x005900e2, 0xffffffe9},/*kerning  â Y� : -0.089844 */
+{'[', 0x005c00e2, 0xfffffff2},/*kerning  â \� : -0.054688 */
+{'[', 0x006600e2, 0xffffffff},/*kerning  â f� : -0.003906 */
+{'[', 0x007400e2, 0xffffffff},/*kerning  â t� : -0.003906 */
+{'[', 0x007600e2, 0xfffffffc},/*kerning  â v� : -0.015625 */
+{'[', 0x007700e2, 0xfffffffc},/*kerning  â w� : -0.015625 */
+{'[', 0x007900e2, 0xfffffffc},/*kerning  â y� : -0.015625 */
+{'[', 0x00ba00e2, 0xfffffffe},/*kerning  â º : -0.007812 */
+{'[', 0x00d000e2, 0xfffffffe},/*kerning  â Ð : -0.007812 */
+{'[', 0x00d900e2, 0xfffffffe},/*kerning  â Ù : -0.007812 */
+{'[', 0x00da00e2, 0xfffffffe},/*kerning  â Ú : -0.007812 */
+{'[', 0x00db00e2, 0xfffffffe},/*kerning  â Û : -0.007812 */
+{'[', 0x00dc00e2, 0xfffffffe},/*kerning  â Ü : -0.007812 */
+{'[', 0x00dd00e2, 0xffffffe9},/*kerning  â Ý : -0.089844 */
+{'[', 0x00fd00e2, 0xfffffffc},/*kerning  â ý : -0.015625 */
+{'[', 0x00ff00e2, 0xfffffffc},/*kerning  â ÿ : -0.015625 */
+{'@', 0x000000e3, 0x00005800},/*        ã        x-advance: 88.000000 */
+{'M', 0x40999999, 0xc1c147ae},
+{'8', 0x9224c000, 0xb864d224},
+{'q', 0x41000000, 0xc04cccc0},
+{0, 0x41947ae1, 0xc04cccc0},
+{'8', 0x075e002c, 0x15580731},
+{'l', 0x00000000, 0xc0c28f60},
+{'q', 0x00000000, 0xc1199998},
+{0, 0xc0b851e8, 0xc171eb84},
+{'q', 0xc0b851e8, 0xc0b0a3d0},
+{0, 0xc1828f5c, 0xc0b0a3d0},
+{'8', 0x139700c9, 0x389613ce},
+{'l', 0xc0a3d70a, 0xc11eb854},
+{'q', 0x41028f5d, 0xc0b33330},
+{0, 0x41828f5c, 0xc1066668},
+{'q', 0x41028f5c, 0xc0333320},
+{0, 0x4187ae14, 0xc0333320},
+{'q', 0x41800000, 0x00000000},
+{0, 0x41ca3d70, 0x410e1478},
+{'9', 0x0047004a, 0x00c5004a},
+{'l', 0x00000000, 0x420d70a4},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e402f0, 0x01ed01f4},
+{'8', 0xebc500d9, 0xd2eaebed},
+{'l', 0xbea3d700, 0xc0a8f5c3},
+{'q', 0xc0ae1478, 0x40e147ae},
+{0, 0xc163d708, 0x412e147b},
+{'q', 0xc10cccd0, 0x4075c28e},
+{0, 0xc18b8520, 0x4075c28e},
+{'q', 0xc1051eb8, 0x00000000},
+{0, 0xc16e147a, 0xc05c28f5},
+{'8', 0xb6afe5cc, 0x98e3d2e3},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x426ccccc, 0xc191eb85},
+{'8', 0xdc18ef0f, 0xe108ee08},
+{'l', 0x00000000, 0xc1266666},
+{'q', 0xc123d708, 0xc0800000},
+{0, 0xc1a8f5c2, 0xc0800000},
+{'q', 0xc12b851e, 0x00000000},
+{0, 0xc18ae147, 0x4087ae18},
+{'8', 0x5ccb21cb, 0x3e112000},
+{'8', 0x31331e11, 0x13531321},
+{'8', 0xeb630034, 0xcb4beb2f},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4251eb85, 0xc2c8a3d7},
+{'8', 0xf3bf00da, 0xe6cff3e6},
+{'8', 0xf3cef3ea, 0x0ed700e4},
+{'8', 0x1def0ef3, 0x11fd0ffd},
+{'l', 0xc1051eb9, 0x00000000},
+{'8', 0xe405f900, 0xd413eb05},
+{'8', 0xd826e90e, 0xef3eef18},
+{'8', 0x0d3e0025, 0x1b300d18},
+{'8', 0x0e360e17, 0xf2300021},
+{'8', 0xe213f20e, 0xef04f104},
+{'l', 0x41051eb4, 0x00000000},
+{'8', 0x1cfb0700, 0x2ceb14fb},
+{'8', 0x29d718f1, 0x11bd11e6},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200e3, 0xfffffffd},/*kerning  ã "� : -0.011719 */
+{'[', 0x002700e3, 0xfffffffd},/*kerning  ã '� : -0.011719 */
+{'[', 0x002a00e3, 0xfffffffb},/*kerning  ã *� : -0.019531 */
+{'[', 0x003f00e3, 0xfffffffb},/*kerning  ã ?� : -0.019531 */
+{'[', 0x005400e3, 0xffffffe4},/*kerning  ã T� : -0.109375 */
+{'[', 0x005500e3, 0xfffffffe},/*kerning  ã U� : -0.007812 */
+{'[', 0x005600e3, 0xfffffff2},/*kerning  ã V� : -0.054688 */
+{'[', 0x005700e3, 0xfffffff2},/*kerning  ã W� : -0.054688 */
+{'[', 0x005900e3, 0xffffffe9},/*kerning  ã Y� : -0.089844 */
+{'[', 0x005c00e3, 0xfffffff2},/*kerning  ã \� : -0.054688 */
+{'[', 0x006600e3, 0xffffffff},/*kerning  ã f� : -0.003906 */
+{'[', 0x007400e3, 0xffffffff},/*kerning  ã t� : -0.003906 */
+{'[', 0x007600e3, 0xfffffffc},/*kerning  ã v� : -0.015625 */
+{'[', 0x007700e3, 0xfffffffc},/*kerning  ã w� : -0.015625 */
+{'[', 0x007900e3, 0xfffffffc},/*kerning  ã y� : -0.015625 */
+{'[', 0x00ba00e3, 0xfffffffe},/*kerning  ã º : -0.007812 */
+{'[', 0x00d000e3, 0xfffffffe},/*kerning  ã Ð : -0.007812 */
+{'[', 0x00d900e3, 0xfffffffe},/*kerning  ã Ù : -0.007812 */
+{'[', 0x00da00e3, 0xfffffffe},/*kerning  ã Ú : -0.007812 */
+{'[', 0x00db00e3, 0xfffffffe},/*kerning  ã Û : -0.007812 */
+{'[', 0x00dc00e3, 0xfffffffe},/*kerning  ã Ü : -0.007812 */
+{'[', 0x00dd00e3, 0xffffffe9},/*kerning  ã Ý : -0.089844 */
+{'[', 0x00fd00e3, 0xfffffffc},/*kerning  ã ý : -0.015625 */
+{'[', 0x00ff00e3, 0xfffffffc},/*kerning  ã ÿ : -0.015625 */
+{'@', 0x000000e4, 0x00005800},/*        ä        x-advance: 88.000000 */
+{'M', 0x40999999, 0xc1c147ae},
+{'8', 0x9224c000, 0xb864d224},
+{'q', 0x41000000, 0xc04cccc0},
+{0, 0x41947ae1, 0xc04cccc0},
+{'8', 0x075e002c, 0x15580731},
+{'l', 0x00000000, 0xc0c28f60},
+{'q', 0x00000000, 0xc1199998},
+{0, 0xc0b851e8, 0xc171eb84},
+{'q', 0xc0b851e8, 0xc0b0a3d0},
+{0, 0xc1828f5c, 0xc0b0a3d0},
+{'8', 0x139700c9, 0x389613ce},
+{'l', 0xc0a3d70a, 0xc11eb854},
+{'q', 0x41028f5d, 0xc0b33330},
+{0, 0x41828f5c, 0xc1066668},
+{'q', 0x41028f5c, 0xc0333320},
+{0, 0x4187ae14, 0xc0333320},
+{'q', 0x41800000, 0x00000000},
+{0, 0x41ca3d70, 0x410e1478},
+{'9', 0x0047004a, 0x00c5004a},
+{'l', 0x00000000, 0x420d70a4},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e402f0, 0x01ed01f4},
+{'8', 0xebc500d9, 0xd2eaebed},
+{'l', 0xbea3d700, 0xc0a8f5c3},
+{'q', 0xc0ae1478, 0x40e147ae},
+{0, 0xc163d708, 0x412e147b},
+{'q', 0xc10cccd0, 0x4075c28e},
+{0, 0xc18b8520, 0x4075c28e},
+{'q', 0xc1051eb8, 0x00000000},
+{0, 0xc16e147a, 0xc05c28f5},
+{'8', 0xb6afe5cc, 0x98e3d2e3},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x426ccccc, 0xc191eb85},
+{'8', 0xdc18ef0f, 0xe108ee08},
+{'l', 0x00000000, 0xc1266666},
+{'q', 0xc123d708, 0xc0800000},
+{0, 0xc1a8f5c2, 0xc0800000},
+{'q', 0xc12b851e, 0x00000000},
+{0, 0xc18ae147, 0x4087ae18},
+{'8', 0x5ccb21cb, 0x3e112000},
+{'8', 0x31331e11, 0x13531321},
+{'8', 0xeb630034, 0xcb4beb2f},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41bd70a4, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42466666, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200e4, 0xfffffffd},/*kerning  ä "� : -0.011719 */
+{'[', 0x002700e4, 0xfffffffd},/*kerning  ä '� : -0.011719 */
+{'[', 0x002a00e4, 0xfffffffb},/*kerning  ä *� : -0.019531 */
+{'[', 0x003f00e4, 0xfffffffb},/*kerning  ä ?� : -0.019531 */
+{'[', 0x005400e4, 0xffffffe4},/*kerning  ä T� : -0.109375 */
+{'[', 0x005500e4, 0xfffffffe},/*kerning  ä U� : -0.007812 */
+{'[', 0x005600e4, 0xfffffff2},/*kerning  ä V� : -0.054688 */
+{'[', 0x005700e4, 0xfffffff2},/*kerning  ä W� : -0.054688 */
+{'[', 0x005900e4, 0xffffffe9},/*kerning  ä Y� : -0.089844 */
+{'[', 0x005c00e4, 0xfffffff2},/*kerning  ä \� : -0.054688 */
+{'[', 0x006600e4, 0xffffffff},/*kerning  ä f� : -0.003906 */
+{'[', 0x007400e4, 0xffffffff},/*kerning  ä t� : -0.003906 */
+{'[', 0x007600e4, 0xfffffffc},/*kerning  ä v� : -0.015625 */
+{'[', 0x007700e4, 0xfffffffc},/*kerning  ä w� : -0.015625 */
+{'[', 0x007900e4, 0xfffffffc},/*kerning  ä y� : -0.015625 */
+{'[', 0x00ba00e4, 0xfffffffe},/*kerning  ä º : -0.007812 */
+{'[', 0x00d000e4, 0xfffffffe},/*kerning  ä Ð : -0.007812 */
+{'[', 0x00d900e4, 0xfffffffe},/*kerning  ä Ù : -0.007812 */
+{'[', 0x00da00e4, 0xfffffffe},/*kerning  ä Ú : -0.007812 */
+{'[', 0x00db00e4, 0xfffffffe},/*kerning  ä Û : -0.007812 */
+{'[', 0x00dc00e4, 0xfffffffe},/*kerning  ä Ü : -0.007812 */
+{'[', 0x00dd00e4, 0xffffffe9},/*kerning  ä Ý : -0.089844 */
+{'[', 0x00fd00e4, 0xfffffffc},/*kerning  ä ý : -0.015625 */
+{'[', 0x00ff00e4, 0xfffffffc},/*kerning  ä ÿ : -0.015625 */
+{'@', 0x000000e5, 0x00005800},/*        å        x-advance: 88.000000 */
+{'M', 0x40999999, 0xc1c147ae},
+{'8', 0x9224c000, 0xb864d224},
+{'q', 0x41000000, 0xc04cccc0},
+{0, 0x41947ae1, 0xc04cccc0},
+{'8', 0x075e002c, 0x15580731},
+{'l', 0x00000000, 0xc0c28f60},
+{'q', 0x00000000, 0xc1199998},
+{0, 0xc0b851e8, 0xc171eb84},
+{'q', 0xc0b851e8, 0xc0b0a3d0},
+{0, 0xc1828f5c, 0xc0b0a3d0},
+{'8', 0x139700c9, 0x389613ce},
+{'l', 0xc0a3d70a, 0xc11eb854},
+{'q', 0x41028f5d, 0xc0b33330},
+{0, 0x41828f5c, 0xc1066668},
+{'q', 0x41028f5c, 0xc0333320},
+{0, 0x4187ae14, 0xc0333320},
+{'q', 0x41800000, 0x00000000},
+{0, 0x41ca3d70, 0x410e1478},
+{'9', 0x0047004a, 0x00c5004a},
+{'l', 0x00000000, 0x420d70a4},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e402f0, 0x01ed01f4},
+{'8', 0xebc500d9, 0xd2eaebed},
+{'l', 0xbea3d700, 0xc0a8f5c3},
+{'q', 0xc0ae1478, 0x40e147ae},
+{0, 0xc163d708, 0x412e147b},
+{'q', 0xc10cccd0, 0x4075c28e},
+{0, 0xc18b8520, 0x4075c28e},
+{'q', 0xc1051eb8, 0x00000000},
+{0, 0xc16e147a, 0xc05c28f5},
+{'8', 0xb6afe5cc, 0x98e3d2e3},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x426ccccc, 0xc191eb85},
+{'8', 0xdc18ef0f, 0xe108ee08},
+{'l', 0x00000000, 0xc1266666},
+{'q', 0xc123d708, 0xc0800000},
+{0, 0xc1a8f5c2, 0xc0800000},
+{'q', 0xc12b851e, 0x00000000},
+{0, 0xc18ae147, 0x4087ae18},
+{'8', 0x5ccb21cb, 0x3e112000},
+{'8', 0x31331e11, 0x13531321},
+{'8', 0xeb630034, 0xcb4beb2f},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41dae147, 0xc2d4cccc},
+{'8', 0xaf22cd00, 0xe257e222},
+{'8', 0x1e570035, 0x51211e21},
+{'8', 0x50df3100, 0x1ea91edf},
+{'8', 0xe2a900cc, 0xb0dee2de},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x422a3d70, 0xc2e428f5},
+{'8', 0x10d600e8, 0x2def10ef},
+{'8', 0x2a111900, 0x112a1111},
+{'8', 0xf02a0018, 0xd512f012},
+{'8', 0xd3efe300, 0xf0d5f0ef},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200e5, 0xfffffffd},/*kerning  å "� : -0.011719 */
+{'[', 0x002700e5, 0xfffffffd},/*kerning  å '� : -0.011719 */
+{'[', 0x002a00e5, 0xfffffffb},/*kerning  å *� : -0.019531 */
+{'[', 0x003f00e5, 0xfffffffb},/*kerning  å ?� : -0.019531 */
+{'[', 0x005400e5, 0xffffffe4},/*kerning  å T� : -0.109375 */
+{'[', 0x005500e5, 0xfffffffe},/*kerning  å U� : -0.007812 */
+{'[', 0x005600e5, 0xfffffff2},/*kerning  å V� : -0.054688 */
+{'[', 0x005700e5, 0xfffffff2},/*kerning  å W� : -0.054688 */
+{'[', 0x005900e5, 0xffffffe9},/*kerning  å Y� : -0.089844 */
+{'[', 0x005c00e5, 0xfffffff2},/*kerning  å \� : -0.054688 */
+{'[', 0x006600e5, 0xffffffff},/*kerning  å f� : -0.003906 */
+{'[', 0x007400e5, 0xffffffff},/*kerning  å t� : -0.003906 */
+{'[', 0x007600e5, 0xfffffffc},/*kerning  å v� : -0.015625 */
+{'[', 0x007700e5, 0xfffffffc},/*kerning  å w� : -0.015625 */
+{'[', 0x007900e5, 0xfffffffc},/*kerning  å y� : -0.015625 */
+{'[', 0x00ba00e5, 0xfffffffe},/*kerning  å º : -0.007812 */
+{'[', 0x00d000e5, 0xfffffffe},/*kerning  å Ð : -0.007812 */
+{'[', 0x00d900e5, 0xfffffffe},/*kerning  å Ù : -0.007812 */
+{'[', 0x00da00e5, 0xfffffffe},/*kerning  å Ú : -0.007812 */
+{'[', 0x00db00e5, 0xfffffffe},/*kerning  å Û : -0.007812 */
+{'[', 0x00dc00e5, 0xfffffffe},/*kerning  å Ü : -0.007812 */
+{'[', 0x00dd00e5, 0xffffffe9},/*kerning  å Ý : -0.089844 */
+{'[', 0x00fd00e5, 0xfffffffc},/*kerning  å ý : -0.015625 */
+{'[', 0x00ff00e5, 0xfffffffc},/*kerning  å ÿ : -0.015625 */
+{'@', 0x000000e6, 0x00009500},/*        æ        x-advance: 149.000000 */
+{'M', 0x42028f5c, 0x3fcccccc},
+{'q', 0xc0fae148, 0x00000000},
+{0, 0xc1628f5c, 0xc05c28f5},
+{'8', 0xb6b0e5ce, 0x96e3d1e3},
+{'8', 0x9523c300, 0xb863d223},
+{'q', 0x40fd70a4, 0xc051eb80},
+{0, 0x419147af, 0xc051eb80},
+{'8', 0x0756002b, 0x124e072a},
+{'8', 0xd506ec02, 0xd80be903},
+{'q', 0xbf8f5c20, 0xc1000000},
+{0, 0xc0d70a38, 0xc148f5c8},
+{'q', 0xc0b33338, 0xc091eb80},
+{0, 0xc16e147c, 0xc091eb80},
+{'9', 0x0000ff9d, 0x004eff2c},
+{'l', 0xc0947ae0, 0xc111eb88},
+{'q', 0x4183d70a, 0xc12e1478},
+{0, 0x4201eb84, 0xc12e1478},
+{'q', 0x4123d710, 0x00000000},
+{0, 0x418cccd0, 0x40800000},
+{'8', 0x595a203a, 0xa86ac92a},
+{'q', 0x410147a8, 0xc0851eb0},
+{0, 0x418eb850, 0xc0851eb0},
+{'q', 0x414a3d70, 0x00000000},
+{0, 0x41b147ac, 0x40bd70b0},
+{'q', 0x411851e8, 0x40bd70a0},
+{0, 0x416e1478, 0x417ae144},
+{'q', 0x40ab8520, 0x411c28f4},
+{0, 0x40ab8520, 0x41accccc},
+{'8', 0x13000700, 0x12ff0c00},
+{'l', 0xc28dc28f, 0x00000000},
+{'q', 0x3f23d700, 0x41028f5c},
+{0, 0x40999990, 0x4167ae14},
+{'q', 0x40851ec0, 0x40ca3d70},
+{0, 0x412b8520, 0x411eb852},
+{'q', 0x40d1eb80, 0x40666664},
+{0, 0x4163d708, 0x40666664},
+{'q', 0x40f5c290, 0x00000000},
+{0, 0x4167ae18, 0xc075c28c},
+{'9', 0xffe20036, 0xffb0004a},
+{'l', 0x41428f60, 0x40570a38},
+{'q', 0xc0800000, 0x41147ae2},
+{0, 0xc15eb850, 0x41733334},
+{'q', 0xc11eb858, 0x40bd70a3},
+{0, 0xc1b47ae4, 0x40bd70a3},
+{'q', 0xc1333338, 0x00000000},
+{0, 0xc1a1eb84, 0xc09eb852},
+{'q', 0xc110a3d8, 0xc09eb851},
+{0, 0xc16a3d78, 0xc151eb84},
+{'8', 0x53b433e4, 0x2e9920d0},
+{'9', 0x000effc9, 0x000eff98},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4303851f, 0xc23851eb},
+{'q', 0xbf23d800, 0xc1051eb8},
+{0, 0xc091eba0, 0xc16b851c},
+{'q', 0xc07ae120, 0xc0ccccd0},
+{0, 0xc123d700, 0xc1200008},
+{'q', 0xc0ca3d80, 0xc0666660},
+{0, 0xc1651ec0, 0xc0666660},
+{'q', 0xc0fae140, 0x00000000},
+{0, 0xc163d708, 0x406b8520},
+{'q', 0xc0ccccd0, 0x406b8520},
+{0, 0xc123d708, 0x41200000},
+{'9', 0x0032ffe2, 0x0075ffde},
+{'l', 0x4267ae16, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x421147ae, 0xc10f5c29},
+{'q', 0x40f0a3d8, 0x00000000},
+{0, 0x41600000, 0xc0333334},
+{'8', 0xc550ea33, 0xd418eb15},
+{'8', 0xcaf1ebf6, 0xc8f9e0fb},
+{'q', 0xc111eb84, 0xc0428f60},
+{0, 0xc1947ae2, 0xc0428f60},
+{'q', 0xc128f5c2, 0x00000000},
+{0, 0xc1899999, 0x408f5c28},
+{'8', 0x5dcb23cb, 0x5e2a3800},
+{'q', 0x40a8f5c0, 0x4099999a},
+{0, 0x414f5c28, 0x4099999a},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200e6, 0xfffffffd},/*kerning  æ "� : -0.011719 */
+{'[', 0x002700e6, 0xfffffffd},/*kerning  æ '� : -0.011719 */
+{'[', 0x002900e6, 0xfffffffc},/*kerning  æ )� : -0.015625 */
+{'[', 0x002a00e6, 0xfffffffc},/*kerning  æ *� : -0.015625 */
+{'[', 0x003f00e6, 0xfffffffd},/*kerning  æ ?� : -0.011719 */
+{'[', 0x004100e6, 0xfffffffd},/*kerning  æ A� : -0.011719 */
+{'[', 0x004200e6, 0xffffffff},/*kerning  æ B� : -0.003906 */
+{'[', 0x004400e6, 0xffffffff},/*kerning  æ D� : -0.003906 */
+{'[', 0x004500e6, 0xffffffff},/*kerning  æ E� : -0.003906 */
+{'[', 0x004600e6, 0xffffffff},/*kerning  æ F� : -0.003906 */
+{'[', 0x004800e6, 0xffffffff},/*kerning  æ H� : -0.003906 */
+{'[', 0x004900e6, 0xffffffff},/*kerning  æ I� : -0.003906 */
+{'[', 0x004a00e6, 0xfffffffe},/*kerning  æ J� : -0.007812 */
+{'[', 0x004b00e6, 0xffffffff},/*kerning  æ K� : -0.003906 */
+{'[', 0x004c00e6, 0xffffffff},/*kerning  æ L� : -0.003906 */
+{'[', 0x004d00e6, 0xffffffff},/*kerning  æ M� : -0.003906 */
+{'[', 0x004e00e6, 0xffffffff},/*kerning  æ N� : -0.003906 */
+{'[', 0x005000e6, 0xffffffff},/*kerning  æ P� : -0.003906 */
+{'[', 0x005200e6, 0xffffffff},/*kerning  æ R� : -0.003906 */
+{'[', 0x005300e6, 0xffffffff},/*kerning  æ S� : -0.003906 */
+{'[', 0x005400e6, 0xffffffe6},/*kerning  æ T� : -0.101562 */
+{'[', 0x005500e6, 0xffffffff},/*kerning  æ U� : -0.003906 */
+{'[', 0x005600e6, 0xfffffff2},/*kerning  æ V� : -0.054688 */
+{'[', 0x005700e6, 0xfffffff2},/*kerning  æ W� : -0.054688 */
+{'[', 0x005800e6, 0xfffffffb},/*kerning  æ X� : -0.019531 */
+{'[', 0x005900e6, 0xffffffe6},/*kerning  æ Y� : -0.101562 */
+{'[', 0x005a00e6, 0xfffffffd},/*kerning  æ Z� : -0.011719 */
+{'[', 0x005c00e6, 0xfffffff5},/*kerning  æ \� : -0.042969 */
+{'[', 0x006600e6, 0xffffffff},/*kerning  æ f� : -0.003906 */
+{'[', 0x007400e6, 0xffffffff},/*kerning  æ t� : -0.003906 */
+{'[', 0x007600e6, 0xfffffffd},/*kerning  æ v� : -0.011719 */
+{'[', 0x007700e6, 0xfffffffd},/*kerning  æ w� : -0.011719 */
+{'[', 0x007800e6, 0xfffffffb},/*kerning  æ x� : -0.019531 */
+{'[', 0x007900e6, 0xfffffffd},/*kerning  æ y� : -0.011719 */
+{'[', 0x007a00e6, 0xffffffff},/*kerning  æ z� : -0.003906 */
+{'[', 0x00c000e6, 0xfffffffd},/*kerning  æ À : -0.011719 */
+{'[', 0x00c100e6, 0xfffffffd},/*kerning  æ Á : -0.011719 */
+{'[', 0x00c200e6, 0xfffffffd},/*kerning  æ Â : -0.011719 */
+{'[', 0x00c300e6, 0xfffffffd},/*kerning  æ Ã : -0.011719 */
+{'[', 0x00c400e6, 0xfffffffd},/*kerning  æ Ä : -0.011719 */
+{'[', 0x00c500e6, 0xfffffffd},/*kerning  æ Å : -0.011719 */
+{'[', 0x00c600e6, 0xfffffffd},/*kerning  æ Æ : -0.011719 */
+{'[', 0x00c800e6, 0xffffffff},/*kerning  æ È : -0.003906 */
+{'[', 0x00c900e6, 0xffffffff},/*kerning  æ É : -0.003906 */
+{'[', 0x00ca00e6, 0xffffffff},/*kerning  æ Ê : -0.003906 */
+{'[', 0x00cb00e6, 0xffffffff},/*kerning  æ Ë : -0.003906 */
+{'[', 0x00cc00e6, 0xffffffff},/*kerning  æ Ì : -0.003906 */
+{'[', 0x00cd00e6, 0xffffffff},/*kerning  æ Í : -0.003906 */
+{'[', 0x00ce00e6, 0xffffffff},/*kerning  æ Î : -0.003906 */
+{'[', 0x00cf00e6, 0xffffffff},/*kerning  æ Ï : -0.003906 */
+{'[', 0x00d000e6, 0xfffffffe},/*kerning  æ Ð : -0.007812 */
+{'[', 0x00d100e6, 0xffffffff},/*kerning  æ Ñ : -0.003906 */
+{'[', 0x00d900e6, 0xffffffff},/*kerning  æ Ù : -0.003906 */
+{'[', 0x00da00e6, 0xffffffff},/*kerning  æ Ú : -0.003906 */
+{'[', 0x00db00e6, 0xffffffff},/*kerning  æ Û : -0.003906 */
+{'[', 0x00dc00e6, 0xffffffff},/*kerning  æ Ü : -0.003906 */
+{'[', 0x00dd00e6, 0xffffffe6},/*kerning  æ Ý : -0.101562 */
+{'[', 0x00de00e6, 0xffffffff},/*kerning  æ Þ : -0.003906 */
+{'[', 0x00fd00e6, 0xfffffffd},/*kerning  æ ý : -0.011719 */
+{'[', 0x00ff00e6, 0xfffffffd},/*kerning  æ ÿ : -0.011719 */
+{'@', 0x000000e7, 0x00005800},/*        ç        x-advance: 88.000000 */
+{'M', 0x424147ae, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b0a3d7, 0xc0bfffff},
+{'q', 0xc119999a, 0xc0c00000},
+{0, 0xc170a3d7, 0xc17eb852},
+{'q', 0xc0ae147b, 0xc11eb852},
+{0, 0xc0ae147b, 0xc1accccc},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x40a8f5c3, 0xc1accccc},
+{'q', 0x40a8f5c2, 0xc11c28f8},
+{0, 0x416e147b, 0xc1799998},
+{'q', 0x4119999a, 0xc0bae150},
+{0, 0x41b1eb85, 0xc0bae150},
+{'q', 0x41451eb8, 0x00000000},
+{0, 0x41ac28f6, 0x40b0a3d0},
+{'9', 0x002c0049, 0x0076006d},
+{'l', 0xc15c28f8, 0x408a3d70},
+{'8', 0xb7b9d1e7, 0xe69ae6d2},
+{'q', 0xc0f5c290, 0x00000000},
+{0, 0xc1600000, 0x40800000},
+{'q', 0xc0ca3d74, 0x40800000},
+{0, 0xc1200000, 0x412f5c28},
+{'q', 0xc06b8520, 0x40deb850},
+{0, 0xc06b8520, 0x417eb850},
+{'q', 0x00000000, 0x410ccccc},
+{0, 0x4070a3d8, 0x417eb850},
+{'q', 0x4070a3d8, 0x40e3d70c},
+{0, 0x412147ae, 0x41347ae2},
+{'q', 0x40ca3d70, 0x40851eb8},
+{0, 0x41600000, 0x40851eb8},
+{'8', 0xf24c0027, 0xdb40f224},
+{'9', 0xffe9001b, 0xffcd0025},
+{'l', 0x415c28f8, 0x40851eb8},
+{'q', 0xc06b8520, 0x4111eb84},
+{0, 0xc155c290, 0x4170a3d6},
+{'9', 0x002fffb3, 0x002fff4e},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42399999, 0x41ee147b},
+{'8', 0xf8b800df, 0xe6b4f8d9},
+{'l', 0x4075c288, 0xc0fae144},
+{'8', 0x14300c19, 0x07320716},
+{'8', 0xf03d0027, 0xd215f015},
+{'8', 0xc8eae000, 0xd0c1e8ea},
+{'l', 0x40a3d708, 0xc06b851e},
+{'8', 0x42541f34, 0x571f221f},
+{'8', 0x53dd3400, 0x1e9d1edd},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002a00e7, 0xfffffffd},/*kerning  ç *� : -0.011719 */
+{'[', 0x004100e7, 0xffffffff},/*kerning  ç A� : -0.003906 */
+{'[', 0x004300e7, 0xffffffff},/*kerning  ç C� : -0.003906 */
+{'[', 0x004700e7, 0xffffffff},/*kerning  ç G� : -0.003906 */
+{'[', 0x004f00e7, 0xffffffff},/*kerning  ç O� : -0.003906 */
+{'[', 0x005100e7, 0xffffffff},/*kerning  ç Q� : -0.003906 */
+{'[', 0x005400e7, 0xffffffe7},/*kerning  ç T� : -0.097656 */
+{'[', 0x005500e7, 0xfffffffe},/*kerning  ç U� : -0.007812 */
+{'[', 0x005600e7, 0xfffffff2},/*kerning  ç V� : -0.054688 */
+{'[', 0x005700e7, 0xfffffff1},/*kerning  ç W� : -0.058594 */
+{'[', 0x005800e7, 0xffffffff},/*kerning  ç X� : -0.003906 */
+{'[', 0x005900e7, 0xffffffeb},/*kerning  ç Y� : -0.082031 */
+{'[', 0x005c00e7, 0xfffffff7},/*kerning  ç \� : -0.035156 */
+{'[', 0x006300e7, 0xffffffff},/*kerning  ç c� : -0.003906 */
+{'[', 0x006400e7, 0xffffffff},/*kerning  ç d� : -0.003906 */
+{'[', 0x006500e7, 0xffffffff},/*kerning  ç e� : -0.003906 */
+{'[', 0x006700e7, 0xffffffff},/*kerning  ç g� : -0.003906 */
+{'[', 0x006f00e7, 0xffffffff},/*kerning  ç o� : -0.003906 */
+{'[', 0x007100e7, 0xffffffff},/*kerning  ç q� : -0.003906 */
+{'[', 0x007600e7, 0xfffffffe},/*kerning  ç v� : -0.007812 */
+{'[', 0x007700e7, 0xffffffff},/*kerning  ç w� : -0.003906 */
+{'[', 0x007900e7, 0xfffffffe},/*kerning  ç y� : -0.007812 */
+{'[', 0x00ab00e7, 0xfffffffe},/*kerning  ç « : -0.007812 */
+{'[', 0x00c000e7, 0xffffffff},/*kerning  ç À : -0.003906 */
+{'[', 0x00c100e7, 0xffffffff},/*kerning  ç Á : -0.003906 */
+{'[', 0x00c200e7, 0xffffffff},/*kerning  ç Â : -0.003906 */
+{'[', 0x00c300e7, 0xffffffff},/*kerning  ç Ã : -0.003906 */
+{'[', 0x00c400e7, 0xffffffff},/*kerning  ç Ä : -0.003906 */
+{'[', 0x00c500e7, 0xffffffff},/*kerning  ç Å : -0.003906 */
+{'[', 0x00c600e7, 0xffffffff},/*kerning  ç Æ : -0.003906 */
+{'[', 0x00c700e7, 0xffffffff},/*kerning  ç Ç : -0.003906 */
+{'[', 0x00d000e7, 0xfffffffe},/*kerning  ç Ð : -0.007812 */
+{'[', 0x00d200e7, 0xffffffff},/*kerning  ç Ò : -0.003906 */
+{'[', 0x00d300e7, 0xffffffff},/*kerning  ç Ó : -0.003906 */
+{'[', 0x00d400e7, 0xffffffff},/*kerning  ç Ô : -0.003906 */
+{'[', 0x00d500e7, 0xffffffff},/*kerning  ç Õ : -0.003906 */
+{'[', 0x00d600e7, 0xffffffff},/*kerning  ç Ö : -0.003906 */
+{'[', 0x00d800e7, 0xffffffff},/*kerning  ç Ø : -0.003906 */
+{'[', 0x00d900e7, 0xfffffffe},/*kerning  ç Ù : -0.007812 */
+{'[', 0x00da00e7, 0xfffffffe},/*kerning  ç Ú : -0.007812 */
+{'[', 0x00db00e7, 0xfffffffe},/*kerning  ç Û : -0.007812 */
+{'[', 0x00dc00e7, 0xfffffffe},/*kerning  ç Ü : -0.007812 */
+{'[', 0x00dd00e7, 0xffffffeb},/*kerning  ç Ý : -0.082031 */
+{'[', 0x00e700e7, 0xffffffff},/*kerning  ç ç : -0.003906 */
+{'[', 0x00e800e7, 0xffffffff},/*kerning  ç è : -0.003906 */
+{'[', 0x00e900e7, 0xffffffff},/*kerning  ç é : -0.003906 */
+{'[', 0x00ea00e7, 0xffffffff},/*kerning  ç ê : -0.003906 */
+{'[', 0x00eb00e7, 0xffffffff},/*kerning  ç ë : -0.003906 */
+{'[', 0x00f000e7, 0xffffffff},/*kerning  ç ð : -0.003906 */
+{'[', 0x00f200e7, 0xffffffff},/*kerning  ç ò : -0.003906 */
+{'[', 0x00f300e7, 0xffffffff},/*kerning  ç ó : -0.003906 */
+{'[', 0x00f400e7, 0xffffffff},/*kerning  ç ô : -0.003906 */
+{'[', 0x00f500e7, 0xffffffff},/*kerning  ç õ : -0.003906 */
+{'[', 0x00f600e7, 0xffffffff},/*kerning  ç ö : -0.003906 */
+{'[', 0x00f800e7, 0xffffffff},/*kerning  ç ø : -0.003906 */
+{'[', 0x00fd00e7, 0xfffffffe},/*kerning  ç ý : -0.007812 */
+{'[', 0x00ff00e7, 0xfffffffe},/*kerning  ç ÿ : -0.007812 */
+{'@', 0x000000e8, 0x00005e00},/*        è        x-advance: 94.000000 */
+{'M', 0x424147ae, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b0a3d7, 0xc0bd70a3},
+{'q', 0xc119999a, 0xc0bd70a4},
+{0, 0xc170a3d7, 0xc17d70a4},
+{'q', 0xc0ae147b, 0xc11eb852},
+{0, 0xc0ae147b, 0xc1accccc},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x40ae147b, 0xc1accccc},
+{'q', 0x40ae147a, 0xc11c28f4},
+{0, 0x4171eb85, 0xc17ae144},
+{'q', 0x411ae148, 0xc0bd70b0},
+{0, 0x41b147ae, 0xc0bd70b0},
+{'q', 0x414a3d70, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x4115c290, 0x40c00000},
+{0, 0x4168f5c0, 0x417ae148},
+{'q', 0x40a66670, 0x411ae148},
+{0, 0x40a66670, 0x41a70a3e},
+{'9', 0x001c0000, 0x002bfffe},
+{'l', 0xc28a8f5c, 0x00000000},
+{'q', 0x3f23d700, 0x41028f5c},
+{0, 0x4091eb84, 0x4167ae14},
+{'8', 0x4f51321f, 0x1c6b1c31},
+{'q', 0x40f5c290, 0x00000000},
+{0, 0x4167ae14, 0xc075c28c},
+{'9', 0xffe20036, 0xffb0004a},
+{'l', 0x41428f58, 0x40570a38},
+{'q', 0xc0800000, 0x41147ae2},
+{0, 0xc15eb850, 0x41733334},
+{'9', 0x002fffb1, 0x002fff4c},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc23ae147},
+{'l', 0x4263d709, 0x00000000},
+{'q', 0xbf23d700, 0xc1028f5c},
+{0, 0xc0947ae0, 0xc1666668},
+{'8', 0xb2afcfe0, 0xe492e4cf},
+{'8', 0x1c9400c6, 0x4eaf1ccf},
+{'9', 0x0031ffe1, 0x0073ffdc},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41f99999, 0xc2e9eb85},
+{'l', 0x415eb852, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d70a, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200e8, 0xfffffffd},/*kerning  è "� : -0.011719 */
+{'[', 0x002700e8, 0xfffffffd},/*kerning  è '� : -0.011719 */
+{'[', 0x002900e8, 0xfffffffc},/*kerning  è )� : -0.015625 */
+{'[', 0x002a00e8, 0xfffffffc},/*kerning  è *� : -0.015625 */
+{'[', 0x003f00e8, 0xfffffffd},/*kerning  è ?� : -0.011719 */
+{'[', 0x004100e8, 0xfffffffd},/*kerning  è A� : -0.011719 */
+{'[', 0x004200e8, 0xffffffff},/*kerning  è B� : -0.003906 */
+{'[', 0x004400e8, 0xffffffff},/*kerning  è D� : -0.003906 */
+{'[', 0x004500e8, 0xffffffff},/*kerning  è E� : -0.003906 */
+{'[', 0x004600e8, 0xffffffff},/*kerning  è F� : -0.003906 */
+{'[', 0x004800e8, 0xffffffff},/*kerning  è H� : -0.003906 */
+{'[', 0x004900e8, 0xffffffff},/*kerning  è I� : -0.003906 */
+{'[', 0x004a00e8, 0xfffffffe},/*kerning  è J� : -0.007812 */
+{'[', 0x004b00e8, 0xffffffff},/*kerning  è K� : -0.003906 */
+{'[', 0x004c00e8, 0xffffffff},/*kerning  è L� : -0.003906 */
+{'[', 0x004d00e8, 0xffffffff},/*kerning  è M� : -0.003906 */
+{'[', 0x004e00e8, 0xffffffff},/*kerning  è N� : -0.003906 */
+{'[', 0x005000e8, 0xffffffff},/*kerning  è P� : -0.003906 */
+{'[', 0x005200e8, 0xffffffff},/*kerning  è R� : -0.003906 */
+{'[', 0x005300e8, 0xffffffff},/*kerning  è S� : -0.003906 */
+{'[', 0x005400e8, 0xffffffe6},/*kerning  è T� : -0.101562 */
+{'[', 0x005500e8, 0xffffffff},/*kerning  è U� : -0.003906 */
+{'[', 0x005600e8, 0xfffffff2},/*kerning  è V� : -0.054688 */
+{'[', 0x005700e8, 0xfffffff2},/*kerning  è W� : -0.054688 */
+{'[', 0x005800e8, 0xfffffffb},/*kerning  è X� : -0.019531 */
+{'[', 0x005900e8, 0xffffffe6},/*kerning  è Y� : -0.101562 */
+{'[', 0x005a00e8, 0xfffffffd},/*kerning  è Z� : -0.011719 */
+{'[', 0x005c00e8, 0xfffffff5},/*kerning  è \� : -0.042969 */
+{'[', 0x006600e8, 0xffffffff},/*kerning  è f� : -0.003906 */
+{'[', 0x007400e8, 0xffffffff},/*kerning  è t� : -0.003906 */
+{'[', 0x007600e8, 0xfffffffd},/*kerning  è v� : -0.011719 */
+{'[', 0x007700e8, 0xfffffffd},/*kerning  è w� : -0.011719 */
+{'[', 0x007800e8, 0xfffffffb},/*kerning  è x� : -0.019531 */
+{'[', 0x007900e8, 0xfffffffd},/*kerning  è y� : -0.011719 */
+{'[', 0x007a00e8, 0xffffffff},/*kerning  è z� : -0.003906 */
+{'[', 0x00c000e8, 0xfffffffd},/*kerning  è À : -0.011719 */
+{'[', 0x00c100e8, 0xfffffffd},/*kerning  è Á : -0.011719 */
+{'[', 0x00c200e8, 0xfffffffd},/*kerning  è Â : -0.011719 */
+{'[', 0x00c300e8, 0xfffffffd},/*kerning  è Ã : -0.011719 */
+{'[', 0x00c400e8, 0xfffffffd},/*kerning  è Ä : -0.011719 */
+{'[', 0x00c500e8, 0xfffffffd},/*kerning  è Å : -0.011719 */
+{'[', 0x00c600e8, 0xfffffffd},/*kerning  è Æ : -0.011719 */
+{'[', 0x00c800e8, 0xffffffff},/*kerning  è È : -0.003906 */
+{'[', 0x00c900e8, 0xffffffff},/*kerning  è É : -0.003906 */
+{'[', 0x00ca00e8, 0xffffffff},/*kerning  è Ê : -0.003906 */
+{'[', 0x00cb00e8, 0xffffffff},/*kerning  è Ë : -0.003906 */
+{'[', 0x00cc00e8, 0xffffffff},/*kerning  è Ì : -0.003906 */
+{'[', 0x00cd00e8, 0xffffffff},/*kerning  è Í : -0.003906 */
+{'[', 0x00ce00e8, 0xffffffff},/*kerning  è Î : -0.003906 */
+{'[', 0x00cf00e8, 0xffffffff},/*kerning  è Ï : -0.003906 */
+{'[', 0x00d000e8, 0xfffffffe},/*kerning  è Ð : -0.007812 */
+{'[', 0x00d100e8, 0xffffffff},/*kerning  è Ñ : -0.003906 */
+{'[', 0x00d900e8, 0xffffffff},/*kerning  è Ù : -0.003906 */
+{'[', 0x00da00e8, 0xffffffff},/*kerning  è Ú : -0.003906 */
+{'[', 0x00db00e8, 0xffffffff},/*kerning  è Û : -0.003906 */
+{'[', 0x00dc00e8, 0xffffffff},/*kerning  è Ü : -0.003906 */
+{'[', 0x00dd00e8, 0xffffffe6},/*kerning  è Ý : -0.101562 */
+{'[', 0x00de00e8, 0xffffffff},/*kerning  è Þ : -0.003906 */
+{'[', 0x00fd00e8, 0xfffffffd},/*kerning  è ý : -0.011719 */
+{'[', 0x00ff00e8, 0xfffffffd},/*kerning  è ÿ : -0.011719 */
+{'@', 0x000000e9, 0x00005e00},/*        é        x-advance: 94.000000 */
+{'M', 0x424147ae, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b0a3d7, 0xc0bd70a3},
+{'q', 0xc119999a, 0xc0bd70a4},
+{0, 0xc170a3d7, 0xc17d70a4},
+{'q', 0xc0ae147b, 0xc11eb852},
+{0, 0xc0ae147b, 0xc1accccc},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x40ae147b, 0xc1accccc},
+{'q', 0x40ae147a, 0xc11c28f4},
+{0, 0x4171eb85, 0xc17ae144},
+{'q', 0x411ae148, 0xc0bd70b0},
+{0, 0x41b147ae, 0xc0bd70b0},
+{'q', 0x414a3d70, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x4115c290, 0x40c00000},
+{0, 0x4168f5c0, 0x417ae148},
+{'q', 0x40a66670, 0x411ae148},
+{0, 0x40a66670, 0x41a70a3e},
+{'9', 0x001c0000, 0x002bfffe},
+{'l', 0xc28a8f5c, 0x00000000},
+{'q', 0x3f23d700, 0x41028f5c},
+{0, 0x4091eb84, 0x4167ae14},
+{'8', 0x4f51321f, 0x1c6b1c31},
+{'q', 0x40f5c290, 0x00000000},
+{0, 0x4167ae14, 0xc075c28c},
+{'9', 0xffe20036, 0xffb0004a},
+{'l', 0x41428f58, 0x40570a38},
+{'q', 0xc0800000, 0x41147ae2},
+{0, 0xc15eb850, 0x41733334},
+{'9', 0x002fffb1, 0x002fff4c},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc23ae147},
+{'l', 0x4263d709, 0x00000000},
+{'q', 0xbf23d700, 0xc1028f5c},
+{0, 0xc0947ae0, 0xc1666668},
+{'8', 0xb2afcfe0, 0xe492e4cf},
+{'8', 0x1c9400c6, 0x4eaf1ccf},
+{'9', 0x0031ffe1, 0x0073ffdc},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42533333, 0xc2c2e147},
+{'l', 0xc1147ae0, 0xc04ccce0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147ac, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200e9, 0xfffffffd},/*kerning  é "� : -0.011719 */
+{'[', 0x002700e9, 0xfffffffd},/*kerning  é '� : -0.011719 */
+{'[', 0x002900e9, 0xfffffffc},/*kerning  é )� : -0.015625 */
+{'[', 0x002a00e9, 0xfffffffc},/*kerning  é *� : -0.015625 */
+{'[', 0x003f00e9, 0xfffffffd},/*kerning  é ?� : -0.011719 */
+{'[', 0x004100e9, 0xfffffffd},/*kerning  é A� : -0.011719 */
+{'[', 0x004200e9, 0xffffffff},/*kerning  é B� : -0.003906 */
+{'[', 0x004400e9, 0xffffffff},/*kerning  é D� : -0.003906 */
+{'[', 0x004500e9, 0xffffffff},/*kerning  é E� : -0.003906 */
+{'[', 0x004600e9, 0xffffffff},/*kerning  é F� : -0.003906 */
+{'[', 0x004800e9, 0xffffffff},/*kerning  é H� : -0.003906 */
+{'[', 0x004900e9, 0xffffffff},/*kerning  é I� : -0.003906 */
+{'[', 0x004a00e9, 0xfffffffe},/*kerning  é J� : -0.007812 */
+{'[', 0x004b00e9, 0xffffffff},/*kerning  é K� : -0.003906 */
+{'[', 0x004c00e9, 0xffffffff},/*kerning  é L� : -0.003906 */
+{'[', 0x004d00e9, 0xffffffff},/*kerning  é M� : -0.003906 */
+{'[', 0x004e00e9, 0xffffffff},/*kerning  é N� : -0.003906 */
+{'[', 0x005000e9, 0xffffffff},/*kerning  é P� : -0.003906 */
+{'[', 0x005200e9, 0xffffffff},/*kerning  é R� : -0.003906 */
+{'[', 0x005300e9, 0xffffffff},/*kerning  é S� : -0.003906 */
+{'[', 0x005400e9, 0xffffffe6},/*kerning  é T� : -0.101562 */
+{'[', 0x005500e9, 0xffffffff},/*kerning  é U� : -0.003906 */
+{'[', 0x005600e9, 0xfffffff2},/*kerning  é V� : -0.054688 */
+{'[', 0x005700e9, 0xfffffff2},/*kerning  é W� : -0.054688 */
+{'[', 0x005800e9, 0xfffffffb},/*kerning  é X� : -0.019531 */
+{'[', 0x005900e9, 0xffffffe6},/*kerning  é Y� : -0.101562 */
+{'[', 0x005a00e9, 0xfffffffd},/*kerning  é Z� : -0.011719 */
+{'[', 0x005c00e9, 0xfffffff5},/*kerning  é \� : -0.042969 */
+{'[', 0x006600e9, 0xffffffff},/*kerning  é f� : -0.003906 */
+{'[', 0x007400e9, 0xffffffff},/*kerning  é t� : -0.003906 */
+{'[', 0x007600e9, 0xfffffffd},/*kerning  é v� : -0.011719 */
+{'[', 0x007700e9, 0xfffffffd},/*kerning  é w� : -0.011719 */
+{'[', 0x007800e9, 0xfffffffb},/*kerning  é x� : -0.019531 */
+{'[', 0x007900e9, 0xfffffffd},/*kerning  é y� : -0.011719 */
+{'[', 0x007a00e9, 0xffffffff},/*kerning  é z� : -0.003906 */
+{'[', 0x00c000e9, 0xfffffffd},/*kerning  é À : -0.011719 */
+{'[', 0x00c100e9, 0xfffffffd},/*kerning  é Á : -0.011719 */
+{'[', 0x00c200e9, 0xfffffffd},/*kerning  é Â : -0.011719 */
+{'[', 0x00c300e9, 0xfffffffd},/*kerning  é Ã : -0.011719 */
+{'[', 0x00c400e9, 0xfffffffd},/*kerning  é Ä : -0.011719 */
+{'[', 0x00c500e9, 0xfffffffd},/*kerning  é Å : -0.011719 */
+{'[', 0x00c600e9, 0xfffffffd},/*kerning  é Æ : -0.011719 */
+{'[', 0x00c800e9, 0xffffffff},/*kerning  é È : -0.003906 */
+{'[', 0x00c900e9, 0xffffffff},/*kerning  é É : -0.003906 */
+{'[', 0x00ca00e9, 0xffffffff},/*kerning  é Ê : -0.003906 */
+{'[', 0x00cb00e9, 0xffffffff},/*kerning  é Ë : -0.003906 */
+{'[', 0x00cc00e9, 0xffffffff},/*kerning  é Ì : -0.003906 */
+{'[', 0x00cd00e9, 0xffffffff},/*kerning  é Í : -0.003906 */
+{'[', 0x00ce00e9, 0xffffffff},/*kerning  é Î : -0.003906 */
+{'[', 0x00cf00e9, 0xffffffff},/*kerning  é Ï : -0.003906 */
+{'[', 0x00d000e9, 0xfffffffe},/*kerning  é Ð : -0.007812 */
+{'[', 0x00d100e9, 0xffffffff},/*kerning  é Ñ : -0.003906 */
+{'[', 0x00d900e9, 0xffffffff},/*kerning  é Ù : -0.003906 */
+{'[', 0x00da00e9, 0xffffffff},/*kerning  é Ú : -0.003906 */
+{'[', 0x00db00e9, 0xffffffff},/*kerning  é Û : -0.003906 */
+{'[', 0x00dc00e9, 0xffffffff},/*kerning  é Ü : -0.003906 */
+{'[', 0x00dd00e9, 0xffffffe6},/*kerning  é Ý : -0.101562 */
+{'[', 0x00de00e9, 0xffffffff},/*kerning  é Þ : -0.003906 */
+{'[', 0x00fd00e9, 0xfffffffd},/*kerning  é ý : -0.011719 */
+{'[', 0x00ff00e9, 0xfffffffd},/*kerning  é ÿ : -0.011719 */
+{'@', 0x000000ea, 0x00005e00},/*        ê        x-advance: 94.000000 */
+{'M', 0x424147ae, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b0a3d7, 0xc0bd70a3},
+{'q', 0xc119999a, 0xc0bd70a4},
+{0, 0xc170a3d7, 0xc17d70a4},
+{'q', 0xc0ae147b, 0xc11eb852},
+{0, 0xc0ae147b, 0xc1accccc},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x40ae147b, 0xc1accccc},
+{'q', 0x40ae147a, 0xc11c28f4},
+{0, 0x4171eb85, 0xc17ae144},
+{'q', 0x411ae148, 0xc0bd70b0},
+{0, 0x41b147ae, 0xc0bd70b0},
+{'q', 0x414a3d70, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x4115c290, 0x40c00000},
+{0, 0x4168f5c0, 0x417ae148},
+{'q', 0x40a66670, 0x411ae148},
+{0, 0x40a66670, 0x41a70a3e},
+{'9', 0x001c0000, 0x002bfffe},
+{'l', 0xc28a8f5c, 0x00000000},
+{'q', 0x3f23d700, 0x41028f5c},
+{0, 0x4091eb84, 0x4167ae14},
+{'8', 0x4f51321f, 0x1c6b1c31},
+{'q', 0x40f5c290, 0x00000000},
+{0, 0x4167ae14, 0xc075c28c},
+{'9', 0xffe20036, 0xffb0004a},
+{'l', 0x41428f58, 0x40570a38},
+{'q', 0xc0800000, 0x41147ae2},
+{0, 0xc15eb850, 0x41733334},
+{'9', 0x002fffb1, 0x002fff4c},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc23ae147},
+{'l', 0x4263d709, 0x00000000},
+{'q', 0xbf23d700, 0xc1028f5c},
+{0, 0xc0947ae0, 0xc1666668},
+{'8', 0xb2afcfe0, 0xe492e4cf},
+{'8', 0x1c9400c6, 0x4eaf1ccf},
+{'9', 0x0031ffe1, 0x0073ffdc},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41d47ae1, 0xc2cccccc},
+{'l', 0x418147ad, 0xc1666668},
+{'l', 0x4123d70c, 0x00000000},
+{'l', 0x418147ac, 0x41666668},
+{'0', 0xb0941ec3, 0xe2c35094},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200ea, 0xfffffffd},/*kerning  ê "� : -0.011719 */
+{'[', 0x002700ea, 0xfffffffd},/*kerning  ê '� : -0.011719 */
+{'[', 0x002900ea, 0xfffffffc},/*kerning  ê )� : -0.015625 */
+{'[', 0x002a00ea, 0xfffffffc},/*kerning  ê *� : -0.015625 */
+{'[', 0x003f00ea, 0xfffffffd},/*kerning  ê ?� : -0.011719 */
+{'[', 0x004100ea, 0xfffffffd},/*kerning  ê A� : -0.011719 */
+{'[', 0x004200ea, 0xffffffff},/*kerning  ê B� : -0.003906 */
+{'[', 0x004400ea, 0xffffffff},/*kerning  ê D� : -0.003906 */
+{'[', 0x004500ea, 0xffffffff},/*kerning  ê E� : -0.003906 */
+{'[', 0x004600ea, 0xffffffff},/*kerning  ê F� : -0.003906 */
+{'[', 0x004800ea, 0xffffffff},/*kerning  ê H� : -0.003906 */
+{'[', 0x004900ea, 0xffffffff},/*kerning  ê I� : -0.003906 */
+{'[', 0x004a00ea, 0xfffffffe},/*kerning  ê J� : -0.007812 */
+{'[', 0x004b00ea, 0xffffffff},/*kerning  ê K� : -0.003906 */
+{'[', 0x004c00ea, 0xffffffff},/*kerning  ê L� : -0.003906 */
+{'[', 0x004d00ea, 0xffffffff},/*kerning  ê M� : -0.003906 */
+{'[', 0x004e00ea, 0xffffffff},/*kerning  ê N� : -0.003906 */
+{'[', 0x005000ea, 0xffffffff},/*kerning  ê P� : -0.003906 */
+{'[', 0x005200ea, 0xffffffff},/*kerning  ê R� : -0.003906 */
+{'[', 0x005300ea, 0xffffffff},/*kerning  ê S� : -0.003906 */
+{'[', 0x005400ea, 0xffffffe6},/*kerning  ê T� : -0.101562 */
+{'[', 0x005500ea, 0xffffffff},/*kerning  ê U� : -0.003906 */
+{'[', 0x005600ea, 0xfffffff2},/*kerning  ê V� : -0.054688 */
+{'[', 0x005700ea, 0xfffffff2},/*kerning  ê W� : -0.054688 */
+{'[', 0x005800ea, 0xfffffffb},/*kerning  ê X� : -0.019531 */
+{'[', 0x005900ea, 0xffffffe6},/*kerning  ê Y� : -0.101562 */
+{'[', 0x005a00ea, 0xfffffffd},/*kerning  ê Z� : -0.011719 */
+{'[', 0x005c00ea, 0xfffffff5},/*kerning  ê \� : -0.042969 */
+{'[', 0x006600ea, 0xffffffff},/*kerning  ê f� : -0.003906 */
+{'[', 0x007400ea, 0xffffffff},/*kerning  ê t� : -0.003906 */
+{'[', 0x007600ea, 0xfffffffd},/*kerning  ê v� : -0.011719 */
+{'[', 0x007700ea, 0xfffffffd},/*kerning  ê w� : -0.011719 */
+{'[', 0x007800ea, 0xfffffffb},/*kerning  ê x� : -0.019531 */
+{'[', 0x007900ea, 0xfffffffd},/*kerning  ê y� : -0.011719 */
+{'[', 0x007a00ea, 0xffffffff},/*kerning  ê z� : -0.003906 */
+{'[', 0x00c000ea, 0xfffffffd},/*kerning  ê À : -0.011719 */
+{'[', 0x00c100ea, 0xfffffffd},/*kerning  ê Á : -0.011719 */
+{'[', 0x00c200ea, 0xfffffffd},/*kerning  ê Â : -0.011719 */
+{'[', 0x00c300ea, 0xfffffffd},/*kerning  ê Ã : -0.011719 */
+{'[', 0x00c400ea, 0xfffffffd},/*kerning  ê Ä : -0.011719 */
+{'[', 0x00c500ea, 0xfffffffd},/*kerning  ê Å : -0.011719 */
+{'[', 0x00c600ea, 0xfffffffd},/*kerning  ê Æ : -0.011719 */
+{'[', 0x00c800ea, 0xffffffff},/*kerning  ê È : -0.003906 */
+{'[', 0x00c900ea, 0xffffffff},/*kerning  ê É : -0.003906 */
+{'[', 0x00ca00ea, 0xffffffff},/*kerning  ê Ê : -0.003906 */
+{'[', 0x00cb00ea, 0xffffffff},/*kerning  ê Ë : -0.003906 */
+{'[', 0x00cc00ea, 0xffffffff},/*kerning  ê Ì : -0.003906 */
+{'[', 0x00cd00ea, 0xffffffff},/*kerning  ê Í : -0.003906 */
+{'[', 0x00ce00ea, 0xffffffff},/*kerning  ê Î : -0.003906 */
+{'[', 0x00cf00ea, 0xffffffff},/*kerning  ê Ï : -0.003906 */
+{'[', 0x00d000ea, 0xfffffffe},/*kerning  ê Ð : -0.007812 */
+{'[', 0x00d100ea, 0xffffffff},/*kerning  ê Ñ : -0.003906 */
+{'[', 0x00d900ea, 0xffffffff},/*kerning  ê Ù : -0.003906 */
+{'[', 0x00da00ea, 0xffffffff},/*kerning  ê Ú : -0.003906 */
+{'[', 0x00db00ea, 0xffffffff},/*kerning  ê Û : -0.003906 */
+{'[', 0x00dc00ea, 0xffffffff},/*kerning  ê Ü : -0.003906 */
+{'[', 0x00dd00ea, 0xffffffe6},/*kerning  ê Ý : -0.101562 */
+{'[', 0x00de00ea, 0xffffffff},/*kerning  ê Þ : -0.003906 */
+{'[', 0x00fd00ea, 0xfffffffd},/*kerning  ê ý : -0.011719 */
+{'[', 0x00ff00ea, 0xfffffffd},/*kerning  ê ÿ : -0.011719 */
+{'@', 0x000000eb, 0x00005e00},/*        ë        x-advance: 94.000000 */
+{'M', 0x424147ae, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b0a3d7, 0xc0bd70a3},
+{'q', 0xc119999a, 0xc0bd70a4},
+{0, 0xc170a3d7, 0xc17d70a4},
+{'q', 0xc0ae147b, 0xc11eb852},
+{0, 0xc0ae147b, 0xc1accccc},
+{'q', 0x00000000, 0xc13d70a4},
+{0, 0x40ae147b, 0xc1accccc},
+{'q', 0x40ae147a, 0xc11c28f4},
+{0, 0x4171eb85, 0xc17ae144},
+{'q', 0x411ae148, 0xc0bd70b0},
+{0, 0x41b147ae, 0xc0bd70b0},
+{'q', 0x414a3d70, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x4115c290, 0x40c00000},
+{0, 0x4168f5c0, 0x417ae148},
+{'q', 0x40a66670, 0x411ae148},
+{0, 0x40a66670, 0x41a70a3e},
+{'9', 0x001c0000, 0x002bfffe},
+{'l', 0xc28a8f5c, 0x00000000},
+{'q', 0x3f23d700, 0x41028f5c},
+{0, 0x4091eb84, 0x4167ae14},
+{'8', 0x4f51321f, 0x1c6b1c31},
+{'q', 0x40f5c290, 0x00000000},
+{0, 0x4167ae14, 0xc075c28c},
+{'9', 0xffe20036, 0xffb0004a},
+{'l', 0x41428f58, 0x40570a38},
+{'q', 0xc0800000, 0x41147ae2},
+{0, 0xc15eb850, 0x41733334},
+{'9', 0x002fffb1, 0x002fff4c},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc23ae147},
+{'l', 0x4263d709, 0x00000000},
+{'q', 0xbf23d700, 0xc1028f5c},
+{0, 0xc0947ae0, 0xc1666668},
+{'8', 0xb2afcfe0, 0xe492e4cf},
+{'8', 0x1c9400c6, 0x4eaf1ccf},
+{'9', 0x0031ffe1, 0x0073ffdc},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41e7ae14, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x425b851e, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a8, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200eb, 0xfffffffd},/*kerning  ë "� : -0.011719 */
+{'[', 0x002700eb, 0xfffffffd},/*kerning  ë '� : -0.011719 */
+{'[', 0x002900eb, 0xfffffffc},/*kerning  ë )� : -0.015625 */
+{'[', 0x002a00eb, 0xfffffffc},/*kerning  ë *� : -0.015625 */
+{'[', 0x003f00eb, 0xfffffffd},/*kerning  ë ?� : -0.011719 */
+{'[', 0x004100eb, 0xfffffffd},/*kerning  ë A� : -0.011719 */
+{'[', 0x004200eb, 0xffffffff},/*kerning  ë B� : -0.003906 */
+{'[', 0x004400eb, 0xffffffff},/*kerning  ë D� : -0.003906 */
+{'[', 0x004500eb, 0xffffffff},/*kerning  ë E� : -0.003906 */
+{'[', 0x004600eb, 0xffffffff},/*kerning  ë F� : -0.003906 */
+{'[', 0x004800eb, 0xffffffff},/*kerning  ë H� : -0.003906 */
+{'[', 0x004900eb, 0xffffffff},/*kerning  ë I� : -0.003906 */
+{'[', 0x004a00eb, 0xfffffffe},/*kerning  ë J� : -0.007812 */
+{'[', 0x004b00eb, 0xffffffff},/*kerning  ë K� : -0.003906 */
+{'[', 0x004c00eb, 0xffffffff},/*kerning  ë L� : -0.003906 */
+{'[', 0x004d00eb, 0xffffffff},/*kerning  ë M� : -0.003906 */
+{'[', 0x004e00eb, 0xffffffff},/*kerning  ë N� : -0.003906 */
+{'[', 0x005000eb, 0xffffffff},/*kerning  ë P� : -0.003906 */
+{'[', 0x005200eb, 0xffffffff},/*kerning  ë R� : -0.003906 */
+{'[', 0x005300eb, 0xffffffff},/*kerning  ë S� : -0.003906 */
+{'[', 0x005400eb, 0xffffffe6},/*kerning  ë T� : -0.101562 */
+{'[', 0x005500eb, 0xffffffff},/*kerning  ë U� : -0.003906 */
+{'[', 0x005600eb, 0xfffffff2},/*kerning  ë V� : -0.054688 */
+{'[', 0x005700eb, 0xfffffff2},/*kerning  ë W� : -0.054688 */
+{'[', 0x005800eb, 0xfffffffb},/*kerning  ë X� : -0.019531 */
+{'[', 0x005900eb, 0xffffffe6},/*kerning  ë Y� : -0.101562 */
+{'[', 0x005a00eb, 0xfffffffd},/*kerning  ë Z� : -0.011719 */
+{'[', 0x005c00eb, 0xfffffff5},/*kerning  ë \� : -0.042969 */
+{'[', 0x006600eb, 0xffffffff},/*kerning  ë f� : -0.003906 */
+{'[', 0x007400eb, 0xffffffff},/*kerning  ë t� : -0.003906 */
+{'[', 0x007600eb, 0xfffffffd},/*kerning  ë v� : -0.011719 */
+{'[', 0x007700eb, 0xfffffffd},/*kerning  ë w� : -0.011719 */
+{'[', 0x007800eb, 0xfffffffb},/*kerning  ë x� : -0.019531 */
+{'[', 0x007900eb, 0xfffffffd},/*kerning  ë y� : -0.011719 */
+{'[', 0x007a00eb, 0xffffffff},/*kerning  ë z� : -0.003906 */
+{'[', 0x00c000eb, 0xfffffffd},/*kerning  ë À : -0.011719 */
+{'[', 0x00c100eb, 0xfffffffd},/*kerning  ë Á : -0.011719 */
+{'[', 0x00c200eb, 0xfffffffd},/*kerning  ë Â : -0.011719 */
+{'[', 0x00c300eb, 0xfffffffd},/*kerning  ë Ã : -0.011719 */
+{'[', 0x00c400eb, 0xfffffffd},/*kerning  ë Ä : -0.011719 */
+{'[', 0x00c500eb, 0xfffffffd},/*kerning  ë Å : -0.011719 */
+{'[', 0x00c600eb, 0xfffffffd},/*kerning  ë Æ : -0.011719 */
+{'[', 0x00c800eb, 0xffffffff},/*kerning  ë È : -0.003906 */
+{'[', 0x00c900eb, 0xffffffff},/*kerning  ë É : -0.003906 */
+{'[', 0x00ca00eb, 0xffffffff},/*kerning  ë Ê : -0.003906 */
+{'[', 0x00cb00eb, 0xffffffff},/*kerning  ë Ë : -0.003906 */
+{'[', 0x00cc00eb, 0xffffffff},/*kerning  ë Ì : -0.003906 */
+{'[', 0x00cd00eb, 0xffffffff},/*kerning  ë Í : -0.003906 */
+{'[', 0x00ce00eb, 0xffffffff},/*kerning  ë Î : -0.003906 */
+{'[', 0x00cf00eb, 0xffffffff},/*kerning  ë Ï : -0.003906 */
+{'[', 0x00d000eb, 0xfffffffe},/*kerning  ë Ð : -0.007812 */
+{'[', 0x00d100eb, 0xffffffff},/*kerning  ë Ñ : -0.003906 */
+{'[', 0x00d900eb, 0xffffffff},/*kerning  ë Ù : -0.003906 */
+{'[', 0x00da00eb, 0xffffffff},/*kerning  ë Ú : -0.003906 */
+{'[', 0x00db00eb, 0xffffffff},/*kerning  ë Û : -0.003906 */
+{'[', 0x00dc00eb, 0xffffffff},/*kerning  ë Ü : -0.003906 */
+{'[', 0x00dd00eb, 0xffffffe6},/*kerning  ë Ý : -0.101562 */
+{'[', 0x00de00eb, 0xffffffff},/*kerning  ë Þ : -0.003906 */
+{'[', 0x00fd00eb, 0xfffffffd},/*kerning  ë ý : -0.011719 */
+{'[', 0x00ff00eb, 0xfffffffd},/*kerning  ë ÿ : -0.011719 */
+{'@', 0x000000ec, 0x00002400},/*        ì        x-advance: 36.000000 */
+{'M', 0x4135c28f, 0x80000000},
+{'l', 0x00000000, 0xc2a70a3d},
+{'4', 0x00000070, 0x029c0000},
+{'l', 0xc16147ad, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x3fe147ae, 0xc2e9eb85},
+{'l', 0x415eb851, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d70a, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x005500ec, 0xfffffffe},/*kerning  ì U� : -0.007812 */
+{'[', 0x005a00ec, 0xfffffffe},/*kerning  ì Z� : -0.007812 */
+{'[', 0x00d900ec, 0xfffffffe},/*kerning  ì Ù : -0.007812 */
+{'[', 0x00da00ec, 0xfffffffe},/*kerning  ì Ú : -0.007812 */
+{'[', 0x00db00ec, 0xfffffffe},/*kerning  ì Û : -0.007812 */
+{'[', 0x00dc00ec, 0xfffffffe},/*kerning  ì Ü : -0.007812 */
+{'@', 0x000000ed, 0x00002400},/*        í        x-advance: 36.000000 */
+{'M', 0x4135c28f, 0x80000000},
+{'l', 0x00000000, 0xc2a70a3d},
+{'4', 0x00000070, 0x029c0000},
+{'l', 0xc16147ad, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41bae147, 0xc2c2e147},
+{'l', 0xc1147ae0, 0xc04ccce0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147ae, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x005500ed, 0xfffffffe},/*kerning  í U� : -0.007812 */
+{'[', 0x005a00ed, 0xfffffffe},/*kerning  í Z� : -0.007812 */
+{'[', 0x00d900ed, 0xfffffffe},/*kerning  í Ù : -0.007812 */
+{'[', 0x00da00ed, 0xfffffffe},/*kerning  í Ú : -0.007812 */
+{'[', 0x00db00ed, 0xfffffffe},/*kerning  í Û : -0.007812 */
+{'[', 0x00dc00ed, 0xfffffffe},/*kerning  í Ü : -0.007812 */
+{'@', 0x000000ee, 0x00002400},/*        î        x-advance: 36.000000 */
+{'M', 0x4135c28f, 0x80000000},
+{'l', 0x00000000, 0xc2a70a3d},
+{'4', 0x00000070, 0x029c0000},
+{'l', 0xc16147ad, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0xc03851eb, 0xc2cccccc},
+{'l', 0x418147ae, 0xc1666668},
+{'l', 0x4123d709, 0x00000000},
+{'l', 0x418147af, 0x41666668},
+{'0', 0xb0941ec3, 0xe2c35094},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002a00ee, 0x00000006},/*kerning  î *� : 0.023438 */
+{'[', 0x005500ee, 0xfffffffe},/*kerning  î U� : -0.007812 */
+{'[', 0x005a00ee, 0xfffffffe},/*kerning  î Z� : -0.007812 */
+{'[', 0x00d900ee, 0xfffffffe},/*kerning  î Ù : -0.007812 */
+{'[', 0x00da00ee, 0xfffffffe},/*kerning  î Ú : -0.007812 */
+{'[', 0x00db00ee, 0xfffffffe},/*kerning  î Û : -0.007812 */
+{'[', 0x00dc00ee, 0xfffffffe},/*kerning  î Ü : -0.007812 */
+{'@', 0x000000ef, 0x00002400},/*        ï        x-advance: 36.000000 */
+{'M', 0x4135c28f, 0x80000000},
+{'l', 0x00000000, 0xc2a70a3d},
+{'4', 0x00000070, 0x029c0000},
+{'l', 0xc16147ad, 0x80000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0xbef5c28f, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a3, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41cb851e, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002a00ef, 0x00000002},/*kerning  ï *� : 0.007812 */
+{'[', 0x005500ef, 0xfffffffe},/*kerning  ï U� : -0.007812 */
+{'[', 0x005a00ef, 0xfffffffe},/*kerning  ï Z� : -0.007812 */
+{'[', 0x005c00ef, 0x00000001},/*kerning  ï \� : 0.003906 */
+{'[', 0x00d900ef, 0xfffffffe},/*kerning  ï Ù : -0.007812 */
+{'[', 0x00da00ef, 0xfffffffe},/*kerning  ï Ú : -0.007812 */
+{'[', 0x00db00ef, 0xfffffffe},/*kerning  ï Û : -0.007812 */
+{'[', 0x00dc00ef, 0xfffffffe},/*kerning  ï Ü : -0.007812 */
+{'@', 0x000000f0, 0x00006000},/*        ð        x-advance: 96.000000 */
+{'M', 0x42b51eb8, 0xc2399999},
+{'q', 0x00000000, 0x416e147a},
+{0, 0xc0bd70a0, 0x41cd70a3},
+{'q', 0xc0bd70a0, 0x412ccccc},
+{0, 0xc17ae148, 0x41847ae1},
+{'q', 0xc11c28f8, 0x40b851eb},
+{0, 0xc1ab851e, 0x40b851eb},
+{'q', 0xc1333334, 0x00000000},
+{0, 0xc1a51eb8, 0xc0a66666},
+{'q', 0xc1170a3e, 0xc0a66667},
+{0, 0xc170a3d8, 0xc1600000},
+{'q', 0xc0b33334, 0xc10ccccc},
+{0, 0xc0b33334, 0xc19d70a3},
+{'q', 0x00000000, 0xc128f5c4},
+{0, 0x40a8f5c2, 0xc19a3d70},
+{'q', 0x40a8f5c2, 0xc10b8520},
+{0, 0x41628f5b, 0xc15eb850},
+{'q', 0x410e147a, 0xc0a66670},
+{0, 0x419ccccd, 0xc0a66670},
+{'q', 0x411eb850, 0x00000000},
+{0, 0x4191eb84, 0x40947ae0},
+{'q', 0x41051eb8, 0x40947ae0},
+{0, 0x414a3d70, 0x41428f60},
+{'q', 0xbfccccc0, 0xc1170a40},
+{0, 0xc0b851f0, 0xc1947ae4},
+{'9', 0xffb8ffdf, 0xff70ff9a},
+{'4', 0x0053ff78, 0xffd1ffde},
+{'l', 0x41800000, 0xc1199998},
+{'8', 0xc0abe0da, 0xc098e0d1},
+{'l', 0x419eb852, 0x00000000},
+{'9', 0x00260041, 0x00570077},
+{'4', 0xffbf006b, 0x002f0022},
+{'l', 0xc1451eb8, 0x40eb8520},
+{'q', 0x41028f60, 0x410a3d70},
+{0, 0x4150a3e0, 0x4191eb84},
+{'q', 0x409c28f0, 0x41199998},
+{0, 0x40deb840, 0x41970a3c},
+{'9', 0x004a0010, 0x008a0010},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a51eb8, 0xc2151eb8},
+{'8', 0x6b1d3a00, 0x4d4e301d},
+{'q', 0x40c51eb8, 0x40666668},
+{0, 0x415d70a4, 0x40666668},
+{'q', 0x41000000, 0x00000000},
+{0, 0x41651eb8, 0xc075c290},
+{'8', 0xaf50e232, 0x931ece1e},
+{'8', 0x97e3c600, 0xb6b1d2e3},
+{'q', 0xc0c7ae10, 0xc05c28f0},
+{0, 0xc15eb850, 0xc05c28f0},
+{'q', 0xc0fae148, 0x00000000},
+{0, 0xc1628f5c, 0x40666660},
+{'8', 0x4db01cce, 0x6ce230e2},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002900f0, 0xfffffffd},/*kerning  ð )� : -0.011719 */
+{'[', 0x002f00f0, 0xfffffffd},/*kerning  ð /� : -0.011719 */
+{'[', 0x004100f0, 0xfffffffc},/*kerning  ð A� : -0.015625 */
+{'[', 0x004200f0, 0xffffffff},/*kerning  ð B� : -0.003906 */
+{'[', 0x004400f0, 0xffffffff},/*kerning  ð D� : -0.003906 */
+{'[', 0x004500f0, 0xffffffff},/*kerning  ð E� : -0.003906 */
+{'[', 0x004600f0, 0xffffffff},/*kerning  ð F� : -0.003906 */
+{'[', 0x004800f0, 0xffffffff},/*kerning  ð H� : -0.003906 */
+{'[', 0x004900f0, 0xffffffff},/*kerning  ð I� : -0.003906 */
+{'[', 0x004a00f0, 0xfffffffd},/*kerning  ð J� : -0.011719 */
+{'[', 0x004b00f0, 0xffffffff},/*kerning  ð K� : -0.003906 */
+{'[', 0x004c00f0, 0xffffffff},/*kerning  ð L� : -0.003906 */
+{'[', 0x004d00f0, 0xffffffff},/*kerning  ð M� : -0.003906 */
+{'[', 0x004e00f0, 0xffffffff},/*kerning  ð N� : -0.003906 */
+{'[', 0x005000f0, 0xffffffff},/*kerning  ð P� : -0.003906 */
+{'[', 0x005200f0, 0xffffffff},/*kerning  ð R� : -0.003906 */
+{'[', 0x005300f0, 0xffffffff},/*kerning  ð S� : -0.003906 */
+{'[', 0x005400f0, 0xfffffffa},/*kerning  ð T� : -0.023438 */
+{'[', 0x005500f0, 0xfffffffe},/*kerning  ð U� : -0.007812 */
+{'[', 0x005600f0, 0xfffffffa},/*kerning  ð V� : -0.023438 */
+{'[', 0x005700f0, 0xfffffffa},/*kerning  ð W� : -0.023438 */
+{'[', 0x005800f0, 0xfffffff9},/*kerning  ð X� : -0.027344 */
+{'[', 0x005900f0, 0xfffffff8},/*kerning  ð Y� : -0.031250 */
+{'[', 0x005a00f0, 0xfffffff7},/*kerning  ð Z� : -0.035156 */
+{'[', 0x006600f0, 0xffffffff},/*kerning  ð f� : -0.003906 */
+{'[', 0x007600f0, 0xfffffffe},/*kerning  ð v� : -0.007812 */
+{'[', 0x007700f0, 0xfffffffe},/*kerning  ð w� : -0.007812 */
+{'[', 0x007800f0, 0xfffffffc},/*kerning  ð x� : -0.015625 */
+{'[', 0x007900f0, 0xfffffffd},/*kerning  ð y� : -0.011719 */
+{'[', 0x007a00f0, 0xffffffff},/*kerning  ð z� : -0.003906 */
+{'[', 0x00c000f0, 0xfffffffc},/*kerning  ð À : -0.015625 */
+{'[', 0x00c100f0, 0xfffffffc},/*kerning  ð Á : -0.015625 */
+{'[', 0x00c200f0, 0xfffffffc},/*kerning  ð Â : -0.015625 */
+{'[', 0x00c300f0, 0xfffffffc},/*kerning  ð Ã : -0.015625 */
+{'[', 0x00c400f0, 0xfffffffc},/*kerning  ð Ä : -0.015625 */
+{'[', 0x00c500f0, 0xfffffffc},/*kerning  ð Å : -0.015625 */
+{'[', 0x00c600f0, 0xfffffffc},/*kerning  ð Æ : -0.015625 */
+{'[', 0x00c800f0, 0xffffffff},/*kerning  ð È : -0.003906 */
+{'[', 0x00c900f0, 0xffffffff},/*kerning  ð É : -0.003906 */
+{'[', 0x00ca00f0, 0xffffffff},/*kerning  ð Ê : -0.003906 */
+{'[', 0x00cb00f0, 0xffffffff},/*kerning  ð Ë : -0.003906 */
+{'[', 0x00cc00f0, 0xffffffff},/*kerning  ð Ì : -0.003906 */
+{'[', 0x00cd00f0, 0xffffffff},/*kerning  ð Í : -0.003906 */
+{'[', 0x00ce00f0, 0xffffffff},/*kerning  ð Î : -0.003906 */
+{'[', 0x00cf00f0, 0xffffffff},/*kerning  ð Ï : -0.003906 */
+{'[', 0x00d000f0, 0xfffffffd},/*kerning  ð Ð : -0.011719 */
+{'[', 0x00d100f0, 0xffffffff},/*kerning  ð Ñ : -0.003906 */
+{'[', 0x00d900f0, 0xfffffffe},/*kerning  ð Ù : -0.007812 */
+{'[', 0x00da00f0, 0xfffffffe},/*kerning  ð Ú : -0.007812 */
+{'[', 0x00db00f0, 0xfffffffe},/*kerning  ð Û : -0.007812 */
+{'[', 0x00dc00f0, 0xfffffffe},/*kerning  ð Ü : -0.007812 */
+{'[', 0x00dd00f0, 0xfffffff8},/*kerning  ð Ý : -0.031250 */
+{'[', 0x00de00f0, 0xffffffff},/*kerning  ð Þ : -0.003906 */
+{'[', 0x00fd00f0, 0xfffffffd},/*kerning  ð ý : -0.011719 */
+{'[', 0x00ff00f0, 0xfffffffd},/*kerning  ð ÿ : -0.011719 */
+{'@', 0x000000f1, 0x00005e00},/*        ñ        x-advance: 94.000000 */
+{'M', 0x42a7ae14, 0x80000000},
+{'4', 0x0000ff90, 0xfe8b0000},
+{'q', 0x00000000, 0xc1547ae4},
+{0, 0xc0828f60, 0xc19b8522},
+{'8', 0xcf9dcfe0, 0x17a500d2},
+{'8', 0x3eb017d3, 0x5ace27dd},
+{'l', 0x00000000, 0x42499999},
+{'l', 0xc16147ad, 0x80000000},
+{'4', 0xfd640000, 0x00000066},
+{'l', 0x00000000, 0x418f5c28},
+{'q', 0x409eb850, 0xc10cccd0},
+{0, 0x41651eb8, 0xc16147b0},
+{'q', 0x4115c290, 0xc0a8f5c0},
+{0, 0x41a33332, 0xc0a8f5c0},
+{'q', 0x411c28f8, 0x00000000},
+{0, 0x4171eb88, 0x4091eb90},
+{'q', 0x40ab8520, 0x4091eb80},
+{0, 0x40f33330, 0x4147ae10},
+{'9', 0x003f0011, 0x00900011},
+{'l', 0x00000000, 0x4247ae14},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42699999, 0xc2c8a3d7},
+{'8', 0xf3bf00da, 0xe6cff3e6},
+{'8', 0xf3cef3ea, 0x0ed700e4},
+{'8', 0x1def0ef3, 0x11fd0ffd},
+{'l', 0xc1051eb8, 0x00000000},
+{'8', 0xe405f900, 0xd413eb05},
+{'8', 0xd826e90e, 0xef3eef18},
+{'8', 0x0d3e0025, 0x1b300d18},
+{'8', 0x0e360e17, 0xf2300021},
+{'8', 0xe213f20e, 0xef04f104},
+{'l', 0x41051eb8, 0x00000000},
+{'8', 0x1cfb0700, 0x2ceb14fb},
+{'8', 0x29d718f1, 0x11bd11e6},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200f1, 0xfffffffe},/*kerning  ñ "� : -0.007812 */
+{'[', 0x002700f1, 0xfffffffe},/*kerning  ñ '� : -0.007812 */
+{'[', 0x002a00f1, 0xfffffffd},/*kerning  ñ *� : -0.011719 */
+{'[', 0x003f00f1, 0xfffffffc},/*kerning  ñ ?� : -0.015625 */
+{'[', 0x004300f1, 0xffffffff},/*kerning  ñ C� : -0.003906 */
+{'[', 0x004700f1, 0xffffffff},/*kerning  ñ G� : -0.003906 */
+{'[', 0x004f00f1, 0xffffffff},/*kerning  ñ O� : -0.003906 */
+{'[', 0x005100f1, 0xffffffff},/*kerning  ñ Q� : -0.003906 */
+{'[', 0x005400f1, 0xffffffe4},/*kerning  ñ T� : -0.109375 */
+{'[', 0x005500f1, 0xfffffffe},/*kerning  ñ U� : -0.007812 */
+{'[', 0x005600f1, 0xfffffff2},/*kerning  ñ V� : -0.054688 */
+{'[', 0x005700f1, 0xfffffff2},/*kerning  ñ W� : -0.054688 */
+{'[', 0x005800f1, 0xffffffff},/*kerning  ñ X� : -0.003906 */
+{'[', 0x005900f1, 0xffffffec},/*kerning  ñ Y� : -0.078125 */
+{'[', 0x005a00f1, 0xfffffffe},/*kerning  ñ Z� : -0.007812 */
+{'[', 0x005c00f1, 0xfffffff5},/*kerning  ñ \� : -0.042969 */
+{'[', 0x006600f1, 0xffffffff},/*kerning  ñ f� : -0.003906 */
+{'[', 0x007400f1, 0xffffffff},/*kerning  ñ t� : -0.003906 */
+{'[', 0x007600f1, 0xfffffffe},/*kerning  ñ v� : -0.007812 */
+{'[', 0x007700f1, 0xfffffffe},/*kerning  ñ w� : -0.007812 */
+{'[', 0x007900f1, 0xfffffffe},/*kerning  ñ y� : -0.007812 */
+{'[', 0x00c700f1, 0xffffffff},/*kerning  ñ Ç : -0.003906 */
+{'[', 0x00d000f1, 0xfffffffe},/*kerning  ñ Ð : -0.007812 */
+{'[', 0x00d200f1, 0xffffffff},/*kerning  ñ Ò : -0.003906 */
+{'[', 0x00d300f1, 0xffffffff},/*kerning  ñ Ó : -0.003906 */
+{'[', 0x00d400f1, 0xffffffff},/*kerning  ñ Ô : -0.003906 */
+{'[', 0x00d500f1, 0xffffffff},/*kerning  ñ Õ : -0.003906 */
+{'[', 0x00d600f1, 0xffffffff},/*kerning  ñ Ö : -0.003906 */
+{'[', 0x00d800f1, 0xffffffff},/*kerning  ñ Ø : -0.003906 */
+{'[', 0x00d900f1, 0xfffffffe},/*kerning  ñ Ù : -0.007812 */
+{'[', 0x00da00f1, 0xfffffffe},/*kerning  ñ Ú : -0.007812 */
+{'[', 0x00db00f1, 0xfffffffe},/*kerning  ñ Û : -0.007812 */
+{'[', 0x00dc00f1, 0xfffffffe},/*kerning  ñ Ü : -0.007812 */
+{'[', 0x00dd00f1, 0xffffffec},/*kerning  ñ Ý : -0.078125 */
+{'[', 0x00fd00f1, 0xfffffffe},/*kerning  ñ ý : -0.007812 */
+{'[', 0x00ff00f1, 0xfffffffe},/*kerning  ñ ÿ : -0.007812 */
+{'@', 0x000000f2, 0x00005f00},/*        ò        x-advance: 95.000000 */
+{'M', 0x423f5c29, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b00000, 0xc0bfffff},
+{'q', 0xc11851ec, 0xc0c00000},
+{0, 0xc16ccccd, 0xc17d70a4},
+{'q', 0xc0a8f5c3, 0xc11d70a4},
+{0, 0xc0a8f5c3, 0xc1aae147},
+{'q', 0x00000000, 0xc13ae148},
+{0, 0x40ab851f, 0xc1ac28f6},
+{'q', 0x40ab851e, 0xc11d70a4},
+{0, 0x416e147b, 0xc17d70a4},
+{'q', 0x411851ec, 0xc0c00000},
+{0, 0x41aeb852, 0xc0c00000},
+{'q', 0x4147ae14, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x411851f0, 0x40c00000},
+{0, 0x416e1480, 0x417d70a4},
+{'q', 0x40ab8510, 0x411d70a4},
+{0, 0x40ab8510, 0x41ac28f6},
+{'q', 0x00000000, 0x413851ea},
+{0, 0xc0ab8510, 0x41aae147},
+{'q', 0xc0ab8520, 0x411d70a4},
+{0, 0xc16cccd0, 0x417d70a4},
+{'9', 0x002fffb5, 0x002fff50},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc225c28f},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x4070a3d8, 0x417ae148},
+{'8', 0x584f381e, 0x206f2031},
+{'8', 0xdf6f003d, 0xa650df32},
+{'q', 0x4070a3e0, 0xc0e3d708},
+{0, 0x4070a3e0, 0xc17c28f4},
+{'q', 0x00000000, 0xc10a3d70},
+{0, 0xc070a3e0, 0xc17ae144},
+{'8', 0xa7b0c8e2, 0xdf91dfce},
+{'8', 0x219100c3, 0x5ab121cf},
+{'9', 0x0038ffe2, 0x007effe2},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41f99999, 0xc2e9eb85},
+{'l', 0x415eb852, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d70a, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200f2, 0xfffffffc},/*kerning  ò "� : -0.015625 */
+{'[', 0x002700f2, 0xfffffffc},/*kerning  ò '� : -0.015625 */
+{'[', 0x002900f2, 0xfffffffb},/*kerning  ò )� : -0.019531 */
+{'[', 0x002a00f2, 0xfffffffb},/*kerning  ò *� : -0.019531 */
+{'[', 0x002c00f2, 0xfffffffb},/*kerning  ò ,� : -0.019531 */
+{'[', 0x002e00f2, 0xfffffffb},/*kerning  ò .� : -0.019531 */
+{'[', 0x003f00f2, 0xfffffffb},/*kerning  ò ?� : -0.019531 */
+{'[', 0x004100f2, 0xfffffffc},/*kerning  ò A� : -0.015625 */
+{'[', 0x004200f2, 0xfffffffe},/*kerning  ò B� : -0.007812 */
+{'[', 0x004400f2, 0xfffffffe},/*kerning  ò D� : -0.007812 */
+{'[', 0x004500f2, 0xfffffffe},/*kerning  ò E� : -0.007812 */
+{'[', 0x004600f2, 0xfffffffe},/*kerning  ò F� : -0.007812 */
+{'[', 0x004800f2, 0xfffffffe},/*kerning  ò H� : -0.007812 */
+{'[', 0x004900f2, 0xfffffffe},/*kerning  ò I� : -0.007812 */
+{'[', 0x004a00f2, 0xfffffffe},/*kerning  ò J� : -0.007812 */
+{'[', 0x004b00f2, 0xfffffffe},/*kerning  ò K� : -0.007812 */
+{'[', 0x004c00f2, 0xfffffffe},/*kerning  ò L� : -0.007812 */
+{'[', 0x004d00f2, 0xfffffffe},/*kerning  ò M� : -0.007812 */
+{'[', 0x004e00f2, 0xfffffffe},/*kerning  ò N� : -0.007812 */
+{'[', 0x005000f2, 0xfffffffe},/*kerning  ò P� : -0.007812 */
+{'[', 0x005200f2, 0xfffffffe},/*kerning  ò R� : -0.007812 */
+{'[', 0x005300f2, 0xffffffff},/*kerning  ò S� : -0.003906 */
+{'[', 0x005400f2, 0xffffffe4},/*kerning  ò T� : -0.109375 */
+{'[', 0x005500f2, 0xfffffffe},/*kerning  ò U� : -0.007812 */
+{'[', 0x005600f2, 0xffffffef},/*kerning  ò V� : -0.066406 */
+{'[', 0x005700f2, 0xffffffef},/*kerning  ò W� : -0.066406 */
+{'[', 0x005800f2, 0xfffffff7},/*kerning  ò X� : -0.035156 */
+{'[', 0x005900f2, 0xffffffe9},/*kerning  ò Y� : -0.089844 */
+{'[', 0x005a00f2, 0xfffffffb},/*kerning  ò Z� : -0.019531 */
+{'[', 0x005c00f2, 0xfffffff4},/*kerning  ò \� : -0.046875 */
+{'[', 0x006600f2, 0xfffffffe},/*kerning  ò f� : -0.007812 */
+{'[', 0x007400f2, 0xfffffffe},/*kerning  ò t� : -0.007812 */
+{'[', 0x007600f2, 0xfffffffc},/*kerning  ò v� : -0.015625 */
+{'[', 0x007700f2, 0xfffffffc},/*kerning  ò w� : -0.015625 */
+{'[', 0x007800f2, 0xfffffffa},/*kerning  ò x� : -0.023438 */
+{'[', 0x007900f2, 0xfffffffc},/*kerning  ò y� : -0.015625 */
+{'[', 0x007a00f2, 0xfffffffe},/*kerning  ò z� : -0.007812 */
+{'[', 0x00c000f2, 0xfffffffc},/*kerning  ò À : -0.015625 */
+{'[', 0x00c100f2, 0xfffffffc},/*kerning  ò Á : -0.015625 */
+{'[', 0x00c200f2, 0xfffffffc},/*kerning  ò Â : -0.015625 */
+{'[', 0x00c300f2, 0xfffffffc},/*kerning  ò Ã : -0.015625 */
+{'[', 0x00c400f2, 0xfffffffc},/*kerning  ò Ä : -0.015625 */
+{'[', 0x00c500f2, 0xfffffffc},/*kerning  ò Å : -0.015625 */
+{'[', 0x00c600f2, 0xfffffffd},/*kerning  ò Æ : -0.011719 */
+{'[', 0x00c800f2, 0xfffffffe},/*kerning  ò È : -0.007812 */
+{'[', 0x00c900f2, 0xfffffffe},/*kerning  ò É : -0.007812 */
+{'[', 0x00ca00f2, 0xfffffffe},/*kerning  ò Ê : -0.007812 */
+{'[', 0x00cb00f2, 0xfffffffe},/*kerning  ò Ë : -0.007812 */
+{'[', 0x00cc00f2, 0xfffffffe},/*kerning  ò Ì : -0.007812 */
+{'[', 0x00cd00f2, 0xfffffffe},/*kerning  ò Í : -0.007812 */
+{'[', 0x00ce00f2, 0xfffffffe},/*kerning  ò Î : -0.007812 */
+{'[', 0x00cf00f2, 0xfffffffe},/*kerning  ò Ï : -0.007812 */
+{'[', 0x00d000f2, 0xfffffffc},/*kerning  ò Ð : -0.015625 */
+{'[', 0x00d100f2, 0xfffffffe},/*kerning  ò Ñ : -0.007812 */
+{'[', 0x00d900f2, 0xfffffffe},/*kerning  ò Ù : -0.007812 */
+{'[', 0x00da00f2, 0xfffffffe},/*kerning  ò Ú : -0.007812 */
+{'[', 0x00db00f2, 0xfffffffe},/*kerning  ò Û : -0.007812 */
+{'[', 0x00dc00f2, 0xfffffffe},/*kerning  ò Ü : -0.007812 */
+{'[', 0x00dd00f2, 0xffffffe9},/*kerning  ò Ý : -0.089844 */
+{'[', 0x00de00f2, 0xfffffffe},/*kerning  ò Þ : -0.007812 */
+{'[', 0x00fd00f2, 0xfffffffc},/*kerning  ò ý : -0.015625 */
+{'[', 0x00ff00f2, 0xfffffffc},/*kerning  ò ÿ : -0.015625 */
+{'@', 0x000000f3, 0x00005f00},/*        ó        x-advance: 95.000000 */
+{'M', 0x423f5c29, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b00000, 0xc0bfffff},
+{'q', 0xc11851ec, 0xc0c00000},
+{0, 0xc16ccccd, 0xc17d70a4},
+{'q', 0xc0a8f5c3, 0xc11d70a4},
+{0, 0xc0a8f5c3, 0xc1aae147},
+{'q', 0x00000000, 0xc13ae148},
+{0, 0x40ab851f, 0xc1ac28f6},
+{'q', 0x40ab851e, 0xc11d70a4},
+{0, 0x416e147b, 0xc17d70a4},
+{'q', 0x411851ec, 0xc0c00000},
+{0, 0x41aeb852, 0xc0c00000},
+{'q', 0x4147ae14, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x411851f0, 0x40c00000},
+{0, 0x416e1480, 0x417d70a4},
+{'q', 0x40ab8510, 0x411d70a4},
+{0, 0x40ab8510, 0x41ac28f6},
+{'q', 0x00000000, 0x413851ea},
+{0, 0xc0ab8510, 0x41aae147},
+{'q', 0xc0ab8520, 0x411d70a4},
+{0, 0xc16cccd0, 0x417d70a4},
+{'9', 0x002fffb5, 0x002fff50},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc225c28f},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x4070a3d8, 0x417ae148},
+{'8', 0x584f381e, 0x206f2031},
+{'8', 0xdf6f003d, 0xa650df32},
+{'q', 0x4070a3e0, 0xc0e3d708},
+{0, 0x4070a3e0, 0xc17c28f4},
+{'q', 0x00000000, 0xc10a3d70},
+{0, 0xc070a3e0, 0xc17ae144},
+{'8', 0xa7b0c8e2, 0xdf91dfce},
+{'8', 0x219100c3, 0x5ab121cf},
+{'9', 0x0038ffe2, 0x007effe2},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42533333, 0xc2c2e147},
+{'l', 0xc1147ae0, 0xc04ccce0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147ac, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200f3, 0xfffffffc},/*kerning  ó "� : -0.015625 */
+{'[', 0x002700f3, 0xfffffffc},/*kerning  ó '� : -0.015625 */
+{'[', 0x002900f3, 0xfffffffb},/*kerning  ó )� : -0.019531 */
+{'[', 0x002a00f3, 0xfffffffb},/*kerning  ó *� : -0.019531 */
+{'[', 0x002c00f3, 0xfffffffb},/*kerning  ó ,� : -0.019531 */
+{'[', 0x002e00f3, 0xfffffffb},/*kerning  ó .� : -0.019531 */
+{'[', 0x003f00f3, 0xfffffffb},/*kerning  ó ?� : -0.019531 */
+{'[', 0x004100f3, 0xfffffffc},/*kerning  ó A� : -0.015625 */
+{'[', 0x004200f3, 0xfffffffe},/*kerning  ó B� : -0.007812 */
+{'[', 0x004400f3, 0xfffffffe},/*kerning  ó D� : -0.007812 */
+{'[', 0x004500f3, 0xfffffffe},/*kerning  ó E� : -0.007812 */
+{'[', 0x004600f3, 0xfffffffe},/*kerning  ó F� : -0.007812 */
+{'[', 0x004800f3, 0xfffffffe},/*kerning  ó H� : -0.007812 */
+{'[', 0x004900f3, 0xfffffffe},/*kerning  ó I� : -0.007812 */
+{'[', 0x004a00f3, 0xfffffffe},/*kerning  ó J� : -0.007812 */
+{'[', 0x004b00f3, 0xfffffffe},/*kerning  ó K� : -0.007812 */
+{'[', 0x004c00f3, 0xfffffffe},/*kerning  ó L� : -0.007812 */
+{'[', 0x004d00f3, 0xfffffffe},/*kerning  ó M� : -0.007812 */
+{'[', 0x004e00f3, 0xfffffffe},/*kerning  ó N� : -0.007812 */
+{'[', 0x005000f3, 0xfffffffe},/*kerning  ó P� : -0.007812 */
+{'[', 0x005200f3, 0xfffffffe},/*kerning  ó R� : -0.007812 */
+{'[', 0x005300f3, 0xffffffff},/*kerning  ó S� : -0.003906 */
+{'[', 0x005400f3, 0xffffffe4},/*kerning  ó T� : -0.109375 */
+{'[', 0x005500f3, 0xfffffffe},/*kerning  ó U� : -0.007812 */
+{'[', 0x005600f3, 0xffffffef},/*kerning  ó V� : -0.066406 */
+{'[', 0x005700f3, 0xffffffef},/*kerning  ó W� : -0.066406 */
+{'[', 0x005800f3, 0xfffffff7},/*kerning  ó X� : -0.035156 */
+{'[', 0x005900f3, 0xffffffe9},/*kerning  ó Y� : -0.089844 */
+{'[', 0x005a00f3, 0xfffffffb},/*kerning  ó Z� : -0.019531 */
+{'[', 0x005c00f3, 0xfffffff4},/*kerning  ó \� : -0.046875 */
+{'[', 0x006600f3, 0xfffffffe},/*kerning  ó f� : -0.007812 */
+{'[', 0x007400f3, 0xfffffffe},/*kerning  ó t� : -0.007812 */
+{'[', 0x007600f3, 0xfffffffc},/*kerning  ó v� : -0.015625 */
+{'[', 0x007700f3, 0xfffffffc},/*kerning  ó w� : -0.015625 */
+{'[', 0x007800f3, 0xfffffffa},/*kerning  ó x� : -0.023438 */
+{'[', 0x007900f3, 0xfffffffc},/*kerning  ó y� : -0.015625 */
+{'[', 0x007a00f3, 0xfffffffe},/*kerning  ó z� : -0.007812 */
+{'[', 0x00c000f3, 0xfffffffc},/*kerning  ó À : -0.015625 */
+{'[', 0x00c100f3, 0xfffffffc},/*kerning  ó Á : -0.015625 */
+{'[', 0x00c200f3, 0xfffffffc},/*kerning  ó Â : -0.015625 */
+{'[', 0x00c300f3, 0xfffffffc},/*kerning  ó Ã : -0.015625 */
+{'[', 0x00c400f3, 0xfffffffc},/*kerning  ó Ä : -0.015625 */
+{'[', 0x00c500f3, 0xfffffffc},/*kerning  ó Å : -0.015625 */
+{'[', 0x00c600f3, 0xfffffffd},/*kerning  ó Æ : -0.011719 */
+{'[', 0x00c800f3, 0xfffffffe},/*kerning  ó È : -0.007812 */
+{'[', 0x00c900f3, 0xfffffffe},/*kerning  ó É : -0.007812 */
+{'[', 0x00ca00f3, 0xfffffffe},/*kerning  ó Ê : -0.007812 */
+{'[', 0x00cb00f3, 0xfffffffe},/*kerning  ó Ë : -0.007812 */
+{'[', 0x00cc00f3, 0xfffffffe},/*kerning  ó Ì : -0.007812 */
+{'[', 0x00cd00f3, 0xfffffffe},/*kerning  ó Í : -0.007812 */
+{'[', 0x00ce00f3, 0xfffffffe},/*kerning  ó Î : -0.007812 */
+{'[', 0x00cf00f3, 0xfffffffe},/*kerning  ó Ï : -0.007812 */
+{'[', 0x00d000f3, 0xfffffffc},/*kerning  ó Ð : -0.015625 */
+{'[', 0x00d100f3, 0xfffffffe},/*kerning  ó Ñ : -0.007812 */
+{'[', 0x00d900f3, 0xfffffffe},/*kerning  ó Ù : -0.007812 */
+{'[', 0x00da00f3, 0xfffffffe},/*kerning  ó Ú : -0.007812 */
+{'[', 0x00db00f3, 0xfffffffe},/*kerning  ó Û : -0.007812 */
+{'[', 0x00dc00f3, 0xfffffffe},/*kerning  ó Ü : -0.007812 */
+{'[', 0x00dd00f3, 0xffffffe9},/*kerning  ó Ý : -0.089844 */
+{'[', 0x00de00f3, 0xfffffffe},/*kerning  ó Þ : -0.007812 */
+{'[', 0x00fd00f3, 0xfffffffc},/*kerning  ó ý : -0.015625 */
+{'[', 0x00ff00f3, 0xfffffffc},/*kerning  ó ÿ : -0.015625 */
+{'@', 0x000000f4, 0x00005f00},/*        ô        x-advance: 95.000000 */
+{'M', 0x423f5c29, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b00000, 0xc0bfffff},
+{'q', 0xc11851ec, 0xc0c00000},
+{0, 0xc16ccccd, 0xc17d70a4},
+{'q', 0xc0a8f5c3, 0xc11d70a4},
+{0, 0xc0a8f5c3, 0xc1aae147},
+{'q', 0x00000000, 0xc13ae148},
+{0, 0x40ab851f, 0xc1ac28f6},
+{'q', 0x40ab851e, 0xc11d70a4},
+{0, 0x416e147b, 0xc17d70a4},
+{'q', 0x411851ec, 0xc0c00000},
+{0, 0x41aeb852, 0xc0c00000},
+{'q', 0x4147ae14, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x411851f0, 0x40c00000},
+{0, 0x416e1480, 0x417d70a4},
+{'q', 0x40ab8510, 0x411d70a4},
+{0, 0x40ab8510, 0x41ac28f6},
+{'q', 0x00000000, 0x413851ea},
+{0, 0xc0ab8510, 0x41aae147},
+{'q', 0xc0ab8520, 0x411d70a4},
+{0, 0xc16cccd0, 0x417d70a4},
+{'9', 0x002fffb5, 0x002fff50},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc225c28f},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x4070a3d8, 0x417ae148},
+{'8', 0x584f381e, 0x206f2031},
+{'8', 0xdf6f003d, 0xa650df32},
+{'q', 0x4070a3e0, 0xc0e3d708},
+{0, 0x4070a3e0, 0xc17c28f4},
+{'q', 0x00000000, 0xc10a3d70},
+{0, 0xc070a3e0, 0xc17ae144},
+{'8', 0xa7b0c8e2, 0xdf91dfce},
+{'8', 0x219100c3, 0x5ab121cf},
+{'9', 0x0038ffe2, 0x007effe2},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41d47ae1, 0xc2cccccc},
+{'l', 0x418147ad, 0xc1666668},
+{'l', 0x4123d70c, 0x00000000},
+{'l', 0x418147ac, 0x41666668},
+{'0', 0xb0941ec3, 0xe2c35094},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200f4, 0xfffffffc},/*kerning  ô "� : -0.015625 */
+{'[', 0x002700f4, 0xfffffffc},/*kerning  ô '� : -0.015625 */
+{'[', 0x002900f4, 0xfffffffb},/*kerning  ô )� : -0.019531 */
+{'[', 0x002a00f4, 0xfffffffb},/*kerning  ô *� : -0.019531 */
+{'[', 0x002c00f4, 0xfffffffb},/*kerning  ô ,� : -0.019531 */
+{'[', 0x002e00f4, 0xfffffffb},/*kerning  ô .� : -0.019531 */
+{'[', 0x003f00f4, 0xfffffffb},/*kerning  ô ?� : -0.019531 */
+{'[', 0x004100f4, 0xfffffffc},/*kerning  ô A� : -0.015625 */
+{'[', 0x004200f4, 0xfffffffe},/*kerning  ô B� : -0.007812 */
+{'[', 0x004400f4, 0xfffffffe},/*kerning  ô D� : -0.007812 */
+{'[', 0x004500f4, 0xfffffffe},/*kerning  ô E� : -0.007812 */
+{'[', 0x004600f4, 0xfffffffe},/*kerning  ô F� : -0.007812 */
+{'[', 0x004800f4, 0xfffffffe},/*kerning  ô H� : -0.007812 */
+{'[', 0x004900f4, 0xfffffffe},/*kerning  ô I� : -0.007812 */
+{'[', 0x004a00f4, 0xfffffffe},/*kerning  ô J� : -0.007812 */
+{'[', 0x004b00f4, 0xfffffffe},/*kerning  ô K� : -0.007812 */
+{'[', 0x004c00f4, 0xfffffffe},/*kerning  ô L� : -0.007812 */
+{'[', 0x004d00f4, 0xfffffffe},/*kerning  ô M� : -0.007812 */
+{'[', 0x004e00f4, 0xfffffffe},/*kerning  ô N� : -0.007812 */
+{'[', 0x005000f4, 0xfffffffe},/*kerning  ô P� : -0.007812 */
+{'[', 0x005200f4, 0xfffffffe},/*kerning  ô R� : -0.007812 */
+{'[', 0x005300f4, 0xffffffff},/*kerning  ô S� : -0.003906 */
+{'[', 0x005400f4, 0xffffffe4},/*kerning  ô T� : -0.109375 */
+{'[', 0x005500f4, 0xfffffffe},/*kerning  ô U� : -0.007812 */
+{'[', 0x005600f4, 0xffffffef},/*kerning  ô V� : -0.066406 */
+{'[', 0x005700f4, 0xffffffef},/*kerning  ô W� : -0.066406 */
+{'[', 0x005800f4, 0xfffffff7},/*kerning  ô X� : -0.035156 */
+{'[', 0x005900f4, 0xffffffe9},/*kerning  ô Y� : -0.089844 */
+{'[', 0x005a00f4, 0xfffffffb},/*kerning  ô Z� : -0.019531 */
+{'[', 0x005c00f4, 0xfffffff4},/*kerning  ô \� : -0.046875 */
+{'[', 0x006600f4, 0xfffffffe},/*kerning  ô f� : -0.007812 */
+{'[', 0x007400f4, 0xfffffffe},/*kerning  ô t� : -0.007812 */
+{'[', 0x007600f4, 0xfffffffc},/*kerning  ô v� : -0.015625 */
+{'[', 0x007700f4, 0xfffffffc},/*kerning  ô w� : -0.015625 */
+{'[', 0x007800f4, 0xfffffffa},/*kerning  ô x� : -0.023438 */
+{'[', 0x007900f4, 0xfffffffc},/*kerning  ô y� : -0.015625 */
+{'[', 0x007a00f4, 0xfffffffe},/*kerning  ô z� : -0.007812 */
+{'[', 0x00c000f4, 0xfffffffc},/*kerning  ô À : -0.015625 */
+{'[', 0x00c100f4, 0xfffffffc},/*kerning  ô Á : -0.015625 */
+{'[', 0x00c200f4, 0xfffffffc},/*kerning  ô Â : -0.015625 */
+{'[', 0x00c300f4, 0xfffffffc},/*kerning  ô Ã : -0.015625 */
+{'[', 0x00c400f4, 0xfffffffc},/*kerning  ô Ä : -0.015625 */
+{'[', 0x00c500f4, 0xfffffffc},/*kerning  ô Å : -0.015625 */
+{'[', 0x00c600f4, 0xfffffffd},/*kerning  ô Æ : -0.011719 */
+{'[', 0x00c800f4, 0xfffffffe},/*kerning  ô È : -0.007812 */
+{'[', 0x00c900f4, 0xfffffffe},/*kerning  ô É : -0.007812 */
+{'[', 0x00ca00f4, 0xfffffffe},/*kerning  ô Ê : -0.007812 */
+{'[', 0x00cb00f4, 0xfffffffe},/*kerning  ô Ë : -0.007812 */
+{'[', 0x00cc00f4, 0xfffffffe},/*kerning  ô Ì : -0.007812 */
+{'[', 0x00cd00f4, 0xfffffffe},/*kerning  ô Í : -0.007812 */
+{'[', 0x00ce00f4, 0xfffffffe},/*kerning  ô Î : -0.007812 */
+{'[', 0x00cf00f4, 0xfffffffe},/*kerning  ô Ï : -0.007812 */
+{'[', 0x00d000f4, 0xfffffffc},/*kerning  ô Ð : -0.015625 */
+{'[', 0x00d100f4, 0xfffffffe},/*kerning  ô Ñ : -0.007812 */
+{'[', 0x00d900f4, 0xfffffffe},/*kerning  ô Ù : -0.007812 */
+{'[', 0x00da00f4, 0xfffffffe},/*kerning  ô Ú : -0.007812 */
+{'[', 0x00db00f4, 0xfffffffe},/*kerning  ô Û : -0.007812 */
+{'[', 0x00dc00f4, 0xfffffffe},/*kerning  ô Ü : -0.007812 */
+{'[', 0x00dd00f4, 0xffffffe9},/*kerning  ô Ý : -0.089844 */
+{'[', 0x00de00f4, 0xfffffffe},/*kerning  ô Þ : -0.007812 */
+{'[', 0x00fd00f4, 0xfffffffc},/*kerning  ô ý : -0.015625 */
+{'[', 0x00ff00f4, 0xfffffffc},/*kerning  ô ÿ : -0.015625 */
+{'@', 0x000000f5, 0x00005f00},/*        õ        x-advance: 95.000000 */
+{'M', 0x423f5c29, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b00000, 0xc0bfffff},
+{'q', 0xc11851ec, 0xc0c00000},
+{0, 0xc16ccccd, 0xc17d70a4},
+{'q', 0xc0a8f5c3, 0xc11d70a4},
+{0, 0xc0a8f5c3, 0xc1aae147},
+{'q', 0x00000000, 0xc13ae148},
+{0, 0x40ab851f, 0xc1ac28f6},
+{'q', 0x40ab851e, 0xc11d70a4},
+{0, 0x416e147b, 0xc17d70a4},
+{'q', 0x411851ec, 0xc0c00000},
+{0, 0x41aeb852, 0xc0c00000},
+{'q', 0x4147ae14, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x411851f0, 0x40c00000},
+{0, 0x416e1480, 0x417d70a4},
+{'q', 0x40ab8510, 0x411d70a4},
+{0, 0x40ab8510, 0x41ac28f6},
+{'q', 0x00000000, 0x413851ea},
+{0, 0xc0ab8510, 0x41aae147},
+{'q', 0xc0ab8520, 0x411d70a4},
+{0, 0xc16cccd0, 0x417d70a4},
+{'9', 0x002fffb5, 0x002fff50},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc225c28f},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x4070a3d8, 0x417ae148},
+{'8', 0x584f381e, 0x206f2031},
+{'8', 0xdf6f003d, 0xa650df32},
+{'q', 0x4070a3e0, 0xc0e3d708},
+{0, 0x4070a3e0, 0xc17c28f4},
+{'q', 0x00000000, 0xc10a3d70},
+{0, 0xc070a3e0, 0xc17ae144},
+{'8', 0xa7b0c8e2, 0xdf91dfce},
+{'8', 0x219100c3, 0x5ab121cf},
+{'9', 0x0038ffe2, 0x007effe2},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42670a3d, 0xc2c8a3d7},
+{'8', 0xf3bf00da, 0xe6cff3e6},
+{'8', 0xf3cef3ea, 0x0ed700e4},
+{'8', 0x1def0ef3, 0x11fd0ffd},
+{'l', 0xc1051eb8, 0x00000000},
+{'8', 0xe405f900, 0xd413eb05},
+{'8', 0xd826e90e, 0xef3eef18},
+{'8', 0x0d3e0025, 0x1b300d18},
+{'8', 0x0e360e17, 0xf2300021},
+{'8', 0xe213f20e, 0xef04f104},
+{'l', 0x41051eb8, 0x00000000},
+{'8', 0x1cfb0700, 0x2ceb14fb},
+{'8', 0x29d718f1, 0x11bd11e6},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200f5, 0xfffffffc},/*kerning  õ "� : -0.015625 */
+{'[', 0x002700f5, 0xfffffffc},/*kerning  õ '� : -0.015625 */
+{'[', 0x002900f5, 0xfffffffb},/*kerning  õ )� : -0.019531 */
+{'[', 0x002a00f5, 0xfffffffb},/*kerning  õ *� : -0.019531 */
+{'[', 0x002c00f5, 0xfffffffb},/*kerning  õ ,� : -0.019531 */
+{'[', 0x002e00f5, 0xfffffffb},/*kerning  õ .� : -0.019531 */
+{'[', 0x003f00f5, 0xfffffffb},/*kerning  õ ?� : -0.019531 */
+{'[', 0x004100f5, 0xfffffffc},/*kerning  õ A� : -0.015625 */
+{'[', 0x004200f5, 0xfffffffe},/*kerning  õ B� : -0.007812 */
+{'[', 0x004400f5, 0xfffffffe},/*kerning  õ D� : -0.007812 */
+{'[', 0x004500f5, 0xfffffffe},/*kerning  õ E� : -0.007812 */
+{'[', 0x004600f5, 0xfffffffe},/*kerning  õ F� : -0.007812 */
+{'[', 0x004800f5, 0xfffffffe},/*kerning  õ H� : -0.007812 */
+{'[', 0x004900f5, 0xfffffffe},/*kerning  õ I� : -0.007812 */
+{'[', 0x004a00f5, 0xfffffffe},/*kerning  õ J� : -0.007812 */
+{'[', 0x004b00f5, 0xfffffffe},/*kerning  õ K� : -0.007812 */
+{'[', 0x004c00f5, 0xfffffffe},/*kerning  õ L� : -0.007812 */
+{'[', 0x004d00f5, 0xfffffffe},/*kerning  õ M� : -0.007812 */
+{'[', 0x004e00f5, 0xfffffffe},/*kerning  õ N� : -0.007812 */
+{'[', 0x005000f5, 0xfffffffe},/*kerning  õ P� : -0.007812 */
+{'[', 0x005200f5, 0xfffffffe},/*kerning  õ R� : -0.007812 */
+{'[', 0x005300f5, 0xffffffff},/*kerning  õ S� : -0.003906 */
+{'[', 0x005400f5, 0xffffffe4},/*kerning  õ T� : -0.109375 */
+{'[', 0x005500f5, 0xfffffffe},/*kerning  õ U� : -0.007812 */
+{'[', 0x005600f5, 0xffffffef},/*kerning  õ V� : -0.066406 */
+{'[', 0x005700f5, 0xffffffef},/*kerning  õ W� : -0.066406 */
+{'[', 0x005800f5, 0xfffffff7},/*kerning  õ X� : -0.035156 */
+{'[', 0x005900f5, 0xffffffe9},/*kerning  õ Y� : -0.089844 */
+{'[', 0x005a00f5, 0xfffffffb},/*kerning  õ Z� : -0.019531 */
+{'[', 0x005c00f5, 0xfffffff4},/*kerning  õ \� : -0.046875 */
+{'[', 0x006600f5, 0xfffffffe},/*kerning  õ f� : -0.007812 */
+{'[', 0x007400f5, 0xfffffffe},/*kerning  õ t� : -0.007812 */
+{'[', 0x007600f5, 0xfffffffc},/*kerning  õ v� : -0.015625 */
+{'[', 0x007700f5, 0xfffffffc},/*kerning  õ w� : -0.015625 */
+{'[', 0x007800f5, 0xfffffffa},/*kerning  õ x� : -0.023438 */
+{'[', 0x007900f5, 0xfffffffc},/*kerning  õ y� : -0.015625 */
+{'[', 0x007a00f5, 0xfffffffe},/*kerning  õ z� : -0.007812 */
+{'[', 0x00c000f5, 0xfffffffc},/*kerning  õ À : -0.015625 */
+{'[', 0x00c100f5, 0xfffffffc},/*kerning  õ Á : -0.015625 */
+{'[', 0x00c200f5, 0xfffffffc},/*kerning  õ Â : -0.015625 */
+{'[', 0x00c300f5, 0xfffffffc},/*kerning  õ Ã : -0.015625 */
+{'[', 0x00c400f5, 0xfffffffc},/*kerning  õ Ä : -0.015625 */
+{'[', 0x00c500f5, 0xfffffffc},/*kerning  õ Å : -0.015625 */
+{'[', 0x00c600f5, 0xfffffffd},/*kerning  õ Æ : -0.011719 */
+{'[', 0x00c800f5, 0xfffffffe},/*kerning  õ È : -0.007812 */
+{'[', 0x00c900f5, 0xfffffffe},/*kerning  õ É : -0.007812 */
+{'[', 0x00ca00f5, 0xfffffffe},/*kerning  õ Ê : -0.007812 */
+{'[', 0x00cb00f5, 0xfffffffe},/*kerning  õ Ë : -0.007812 */
+{'[', 0x00cc00f5, 0xfffffffe},/*kerning  õ Ì : -0.007812 */
+{'[', 0x00cd00f5, 0xfffffffe},/*kerning  õ Í : -0.007812 */
+{'[', 0x00ce00f5, 0xfffffffe},/*kerning  õ Î : -0.007812 */
+{'[', 0x00cf00f5, 0xfffffffe},/*kerning  õ Ï : -0.007812 */
+{'[', 0x00d000f5, 0xfffffffc},/*kerning  õ Ð : -0.015625 */
+{'[', 0x00d100f5, 0xfffffffe},/*kerning  õ Ñ : -0.007812 */
+{'[', 0x00d900f5, 0xfffffffe},/*kerning  õ Ù : -0.007812 */
+{'[', 0x00da00f5, 0xfffffffe},/*kerning  õ Ú : -0.007812 */
+{'[', 0x00db00f5, 0xfffffffe},/*kerning  õ Û : -0.007812 */
+{'[', 0x00dc00f5, 0xfffffffe},/*kerning  õ Ü : -0.007812 */
+{'[', 0x00dd00f5, 0xffffffe9},/*kerning  õ Ý : -0.089844 */
+{'[', 0x00de00f5, 0xfffffffe},/*kerning  õ Þ : -0.007812 */
+{'[', 0x00fd00f5, 0xfffffffc},/*kerning  õ ý : -0.015625 */
+{'[', 0x00ff00f5, 0xfffffffc},/*kerning  õ ÿ : -0.015625 */
+{'@', 0x000000f6, 0x00005f00},/*        ö        x-advance: 95.000000 */
+{'M', 0x423f5c29, 0x3fcccccc},
+{'q', 0xc147ae14, 0x00000000},
+{0, 0xc1b00000, 0xc0bfffff},
+{'q', 0xc11851ec, 0xc0c00000},
+{0, 0xc16ccccd, 0xc17d70a4},
+{'q', 0xc0a8f5c3, 0xc11d70a4},
+{0, 0xc0a8f5c3, 0xc1aae147},
+{'q', 0x00000000, 0xc13ae148},
+{0, 0x40ab851f, 0xc1ac28f6},
+{'q', 0x40ab851e, 0xc11d70a4},
+{0, 0x416e147b, 0xc17d70a4},
+{'q', 0x411851ec, 0xc0c00000},
+{0, 0x41aeb852, 0xc0c00000},
+{'q', 0x4147ae14, 0x00000000},
+{0, 0x41affffe, 0x40c00000},
+{'q', 0x411851f0, 0x40c00000},
+{0, 0x416e1480, 0x417d70a4},
+{'q', 0x40ab8510, 0x411d70a4},
+{0, 0x40ab8510, 0x41ac28f6},
+{'q', 0x00000000, 0x413851ea},
+{0, 0xc0ab8510, 0x41aae147},
+{'q', 0xc0ab8520, 0x411d70a4},
+{0, 0xc16cccd0, 0x417d70a4},
+{'9', 0x002fffb5, 0x002fff50},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc225c28f},
+{'q', 0x00000000, 0x410a3d70},
+{0, 0x4070a3d8, 0x417ae148},
+{'8', 0x584f381e, 0x206f2031},
+{'8', 0xdf6f003d, 0xa650df32},
+{'q', 0x4070a3e0, 0xc0e3d708},
+{0, 0x4070a3e0, 0xc17c28f4},
+{'q', 0x00000000, 0xc10a3d70},
+{0, 0xc070a3e0, 0xc17ae144},
+{'8', 0xa7b0c8e2, 0xdf91dfce},
+{'8', 0x219100c3, 0x5ab121cf},
+{'9', 0x0038ffe2, 0x007effe2},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41e7ae14, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x425b851e, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a8, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200f6, 0xfffffffc},/*kerning  ö "� : -0.015625 */
+{'[', 0x002700f6, 0xfffffffc},/*kerning  ö '� : -0.015625 */
+{'[', 0x002900f6, 0xfffffffb},/*kerning  ö )� : -0.019531 */
+{'[', 0x002a00f6, 0xfffffffb},/*kerning  ö *� : -0.019531 */
+{'[', 0x002c00f6, 0xfffffffb},/*kerning  ö ,� : -0.019531 */
+{'[', 0x002e00f6, 0xfffffffb},/*kerning  ö .� : -0.019531 */
+{'[', 0x003f00f6, 0xfffffffb},/*kerning  ö ?� : -0.019531 */
+{'[', 0x004100f6, 0xfffffffc},/*kerning  ö A� : -0.015625 */
+{'[', 0x004200f6, 0xfffffffe},/*kerning  ö B� : -0.007812 */
+{'[', 0x004400f6, 0xfffffffe},/*kerning  ö D� : -0.007812 */
+{'[', 0x004500f6, 0xfffffffe},/*kerning  ö E� : -0.007812 */
+{'[', 0x004600f6, 0xfffffffe},/*kerning  ö F� : -0.007812 */
+{'[', 0x004800f6, 0xfffffffe},/*kerning  ö H� : -0.007812 */
+{'[', 0x004900f6, 0xfffffffe},/*kerning  ö I� : -0.007812 */
+{'[', 0x004a00f6, 0xfffffffe},/*kerning  ö J� : -0.007812 */
+{'[', 0x004b00f6, 0xfffffffe},/*kerning  ö K� : -0.007812 */
+{'[', 0x004c00f6, 0xfffffffe},/*kerning  ö L� : -0.007812 */
+{'[', 0x004d00f6, 0xfffffffe},/*kerning  ö M� : -0.007812 */
+{'[', 0x004e00f6, 0xfffffffe},/*kerning  ö N� : -0.007812 */
+{'[', 0x005000f6, 0xfffffffe},/*kerning  ö P� : -0.007812 */
+{'[', 0x005200f6, 0xfffffffe},/*kerning  ö R� : -0.007812 */
+{'[', 0x005300f6, 0xffffffff},/*kerning  ö S� : -0.003906 */
+{'[', 0x005400f6, 0xffffffe4},/*kerning  ö T� : -0.109375 */
+{'[', 0x005500f6, 0xfffffffe},/*kerning  ö U� : -0.007812 */
+{'[', 0x005600f6, 0xffffffef},/*kerning  ö V� : -0.066406 */
+{'[', 0x005700f6, 0xffffffef},/*kerning  ö W� : -0.066406 */
+{'[', 0x005800f6, 0xfffffff7},/*kerning  ö X� : -0.035156 */
+{'[', 0x005900f6, 0xffffffe9},/*kerning  ö Y� : -0.089844 */
+{'[', 0x005a00f6, 0xfffffffb},/*kerning  ö Z� : -0.019531 */
+{'[', 0x005c00f6, 0xfffffff4},/*kerning  ö \� : -0.046875 */
+{'[', 0x006600f6, 0xfffffffe},/*kerning  ö f� : -0.007812 */
+{'[', 0x007400f6, 0xfffffffe},/*kerning  ö t� : -0.007812 */
+{'[', 0x007600f6, 0xfffffffc},/*kerning  ö v� : -0.015625 */
+{'[', 0x007700f6, 0xfffffffc},/*kerning  ö w� : -0.015625 */
+{'[', 0x007800f6, 0xfffffffa},/*kerning  ö x� : -0.023438 */
+{'[', 0x007900f6, 0xfffffffc},/*kerning  ö y� : -0.015625 */
+{'[', 0x007a00f6, 0xfffffffe},/*kerning  ö z� : -0.007812 */
+{'[', 0x00c000f6, 0xfffffffc},/*kerning  ö À : -0.015625 */
+{'[', 0x00c100f6, 0xfffffffc},/*kerning  ö Á : -0.015625 */
+{'[', 0x00c200f6, 0xfffffffc},/*kerning  ö Â : -0.015625 */
+{'[', 0x00c300f6, 0xfffffffc},/*kerning  ö Ã : -0.015625 */
+{'[', 0x00c400f6, 0xfffffffc},/*kerning  ö Ä : -0.015625 */
+{'[', 0x00c500f6, 0xfffffffc},/*kerning  ö Å : -0.015625 */
+{'[', 0x00c600f6, 0xfffffffd},/*kerning  ö Æ : -0.011719 */
+{'[', 0x00c800f6, 0xfffffffe},/*kerning  ö È : -0.007812 */
+{'[', 0x00c900f6, 0xfffffffe},/*kerning  ö É : -0.007812 */
+{'[', 0x00ca00f6, 0xfffffffe},/*kerning  ö Ê : -0.007812 */
+{'[', 0x00cb00f6, 0xfffffffe},/*kerning  ö Ë : -0.007812 */
+{'[', 0x00cc00f6, 0xfffffffe},/*kerning  ö Ì : -0.007812 */
+{'[', 0x00cd00f6, 0xfffffffe},/*kerning  ö Í : -0.007812 */
+{'[', 0x00ce00f6, 0xfffffffe},/*kerning  ö Î : -0.007812 */
+{'[', 0x00cf00f6, 0xfffffffe},/*kerning  ö Ï : -0.007812 */
+{'[', 0x00d000f6, 0xfffffffc},/*kerning  ö Ð : -0.015625 */
+{'[', 0x00d100f6, 0xfffffffe},/*kerning  ö Ñ : -0.007812 */
+{'[', 0x00d900f6, 0xfffffffe},/*kerning  ö Ù : -0.007812 */
+{'[', 0x00da00f6, 0xfffffffe},/*kerning  ö Ú : -0.007812 */
+{'[', 0x00db00f6, 0xfffffffe},/*kerning  ö Û : -0.007812 */
+{'[', 0x00dc00f6, 0xfffffffe},/*kerning  ö Ü : -0.007812 */
+{'[', 0x00dd00f6, 0xffffffe9},/*kerning  ö Ý : -0.089844 */
+{'[', 0x00de00f6, 0xfffffffe},/*kerning  ö Þ : -0.007812 */
+{'[', 0x00fd00f6, 0xfffffffc},/*kerning  ö ý : -0.015625 */
+{'[', 0x00ff00f6, 0xfffffffc},/*kerning  ö ÿ : -0.015625 */
+{'@', 0x000000f7, 0x00005500},/*        ÷        x-advance: 85.000000 */
+{'M', 0x42128f5c, 0xc2819999},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x00000060, 0x00820000},
+{'l', 0xc1400000, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41266666, 0xc220a3d7},
+{'l', 0x00000000, 0xc13851ec},
+{'4', 0x00000203, 0x005c0000},
+{'l', 0xc280f5c2, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42128f5c, 0xc128f5c2},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x00000060, 0x00820000},
+{'l', 0xc1400000, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x003100f7, 0xfffffffe},/*kerning  ÷ 1� : -0.007812 */
+{'[', 0x003200f7, 0xfffffffb},/*kerning  ÷ 2� : -0.019531 */
+{'[', 0x003300f7, 0xfffffff8},/*kerning  ÷ 3� : -0.031250 */
+{'[', 0x003400f7, 0xfffffffd},/*kerning  ÷ 4� : -0.011719 */
+{'[', 0x003700f7, 0xfffffff7},/*kerning  ÷ 7� : -0.035156 */
+{'@', 0x000000f8, 0x00005f00},/*        ø        x-advance: 95.000000 */
+{'M', 0x41266666, 0x3ea3d70a},
+{'l', 0x41051eb8, 0xc123d70a},
+{'q', 0xc0c7ae14, 0xc0c28f5c},
+{0, 0xc1199999, 0xc1651eb8},
+{'q', 0xc0570a3e, 0xc103d70a},
+{0, 0xc0570a3e, 0xc18ae147},
+{'q', 0x00000000, 0xc13ae148},
+{0, 0x40ab851f, 0xc1ac28f6},
+{'q', 0x40ab851e, 0xc11d70a4},
+{0, 0x416e147b, 0xc17d70a4},
+{'q', 0x411851ec, 0xc0c00000},
+{0, 0x41aeb852, 0xc0c00000},
+{'8', 0x0c5c0030, 0x21500c2b},
+{'4', 0xffdb001c, 0x00000061},
+{'l', 0xc1028f58, 0x41266668},
+{'q', 0x40c7ae10, 0x40bd70a0},
+{0, 0x411ae148, 0x4163d708},
+{'q', 0x405c28e0, 0x41051eb8},
+{0, 0x405c28e0, 0x418ccccc},
+{'q', 0x00000000, 0x413851ea},
+{0, 0xc0ab8510, 0x41aae147},
+{'q', 0xc0ab8520, 0x411d70a4},
+{0, 0xc16cccd0, 0x417d70a4},
+{'q', 0xc1170a3c, 0x40bfffff},
+{0, 0xc1b0a3d6, 0x40bfffff},
+{'8', 0xf4a300cf, 0xddb0f4d5},
+{'4', 0x0025ffe3, 0x0000ffa0},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41a147ae, 0xc225c28f},
+{'8', 0x5d103100, 0x4c2a2b10},
+{'l', 0x42066666, 0xc243d709},
+{'8', 0xe396e3cf, 0x219100c3},
+{'q', 0xc0c7ae10, 0x4087ae10},
+{0, 0xc11ffffe, 0x41347ae0},
+{'9', 0x0038ffe2, 0x007effe2},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x423f5c29, 0xc128f5c2},
+{'8', 0xdf6f003d, 0xa650df32},
+{'q', 0x4070a3e0, 0xc0e3d708},
+{0, 0x4070a3e0, 0xc17c28f4},
+{'8', 0xa3f0cf00, 0xb4d4d5f0},
+{'l', 0xc2070a3d, 0x42428f5c},
+{'q', 0x40c7ae18, 0x4075c288},
+{0, 0x41570a40, 0x4075c288},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200f8, 0xfffffffc},/*kerning  ø "� : -0.015625 */
+{'[', 0x002700f8, 0xfffffffc},/*kerning  ø '� : -0.015625 */
+{'[', 0x002900f8, 0xfffffffb},/*kerning  ø )� : -0.019531 */
+{'[', 0x002a00f8, 0xfffffffb},/*kerning  ø *� : -0.019531 */
+{'[', 0x002c00f8, 0xfffffffb},/*kerning  ø ,� : -0.019531 */
+{'[', 0x002e00f8, 0xfffffffb},/*kerning  ø .� : -0.019531 */
+{'[', 0x003f00f8, 0xfffffffb},/*kerning  ø ?� : -0.019531 */
+{'[', 0x004100f8, 0xfffffffc},/*kerning  ø A� : -0.015625 */
+{'[', 0x004200f8, 0xfffffffe},/*kerning  ø B� : -0.007812 */
+{'[', 0x004400f8, 0xfffffffe},/*kerning  ø D� : -0.007812 */
+{'[', 0x004500f8, 0xfffffffe},/*kerning  ø E� : -0.007812 */
+{'[', 0x004600f8, 0xfffffffe},/*kerning  ø F� : -0.007812 */
+{'[', 0x004800f8, 0xfffffffe},/*kerning  ø H� : -0.007812 */
+{'[', 0x004900f8, 0xfffffffe},/*kerning  ø I� : -0.007812 */
+{'[', 0x004a00f8, 0xfffffffe},/*kerning  ø J� : -0.007812 */
+{'[', 0x004b00f8, 0xfffffffe},/*kerning  ø K� : -0.007812 */
+{'[', 0x004c00f8, 0xfffffffe},/*kerning  ø L� : -0.007812 */
+{'[', 0x004d00f8, 0xfffffffe},/*kerning  ø M� : -0.007812 */
+{'[', 0x004e00f8, 0xfffffffe},/*kerning  ø N� : -0.007812 */
+{'[', 0x005000f8, 0xfffffffe},/*kerning  ø P� : -0.007812 */
+{'[', 0x005200f8, 0xfffffffe},/*kerning  ø R� : -0.007812 */
+{'[', 0x005300f8, 0xffffffff},/*kerning  ø S� : -0.003906 */
+{'[', 0x005400f8, 0xffffffe4},/*kerning  ø T� : -0.109375 */
+{'[', 0x005500f8, 0xfffffffe},/*kerning  ø U� : -0.007812 */
+{'[', 0x005600f8, 0xffffffef},/*kerning  ø V� : -0.066406 */
+{'[', 0x005700f8, 0xffffffef},/*kerning  ø W� : -0.066406 */
+{'[', 0x005800f8, 0xfffffff7},/*kerning  ø X� : -0.035156 */
+{'[', 0x005900f8, 0xffffffe9},/*kerning  ø Y� : -0.089844 */
+{'[', 0x005a00f8, 0xfffffffb},/*kerning  ø Z� : -0.019531 */
+{'[', 0x005c00f8, 0xfffffff4},/*kerning  ø \� : -0.046875 */
+{'[', 0x006600f8, 0xfffffffe},/*kerning  ø f� : -0.007812 */
+{'[', 0x007400f8, 0xfffffffe},/*kerning  ø t� : -0.007812 */
+{'[', 0x007600f8, 0xfffffffc},/*kerning  ø v� : -0.015625 */
+{'[', 0x007700f8, 0xfffffffc},/*kerning  ø w� : -0.015625 */
+{'[', 0x007800f8, 0xfffffffa},/*kerning  ø x� : -0.023438 */
+{'[', 0x007900f8, 0xfffffffc},/*kerning  ø y� : -0.015625 */
+{'[', 0x007a00f8, 0xfffffffe},/*kerning  ø z� : -0.007812 */
+{'[', 0x00c000f8, 0xfffffffc},/*kerning  ø À : -0.015625 */
+{'[', 0x00c100f8, 0xfffffffc},/*kerning  ø Á : -0.015625 */
+{'[', 0x00c200f8, 0xfffffffc},/*kerning  ø Â : -0.015625 */
+{'[', 0x00c300f8, 0xfffffffc},/*kerning  ø Ã : -0.015625 */
+{'[', 0x00c400f8, 0xfffffffc},/*kerning  ø Ä : -0.015625 */
+{'[', 0x00c500f8, 0xfffffffc},/*kerning  ø Å : -0.015625 */
+{'[', 0x00c600f8, 0xfffffffd},/*kerning  ø Æ : -0.011719 */
+{'[', 0x00c800f8, 0xfffffffe},/*kerning  ø È : -0.007812 */
+{'[', 0x00c900f8, 0xfffffffe},/*kerning  ø É : -0.007812 */
+{'[', 0x00ca00f8, 0xfffffffe},/*kerning  ø Ê : -0.007812 */
+{'[', 0x00cb00f8, 0xfffffffe},/*kerning  ø Ë : -0.007812 */
+{'[', 0x00cc00f8, 0xfffffffe},/*kerning  ø Ì : -0.007812 */
+{'[', 0x00cd00f8, 0xfffffffe},/*kerning  ø Í : -0.007812 */
+{'[', 0x00ce00f8, 0xfffffffe},/*kerning  ø Î : -0.007812 */
+{'[', 0x00cf00f8, 0xfffffffe},/*kerning  ø Ï : -0.007812 */
+{'[', 0x00d000f8, 0xfffffffc},/*kerning  ø Ð : -0.015625 */
+{'[', 0x00d100f8, 0xfffffffe},/*kerning  ø Ñ : -0.007812 */
+{'[', 0x00d900f8, 0xfffffffe},/*kerning  ø Ù : -0.007812 */
+{'[', 0x00da00f8, 0xfffffffe},/*kerning  ø Ú : -0.007812 */
+{'[', 0x00db00f8, 0xfffffffe},/*kerning  ø Û : -0.007812 */
+{'[', 0x00dc00f8, 0xfffffffe},/*kerning  ø Ü : -0.007812 */
+{'[', 0x00dd00f8, 0xffffffe9},/*kerning  ø Ý : -0.089844 */
+{'[', 0x00de00f8, 0xfffffffe},/*kerning  ø Þ : -0.007812 */
+{'[', 0x00fd00f8, 0xfffffffc},/*kerning  ø ý : -0.015625 */
+{'[', 0x00ff00f8, 0xfffffffc},/*kerning  ø ÿ : -0.015625 */
+{'@', 0x000000f9, 0x00006000},/*        ù        x-advance: 96.000000 */
+{'M', 0x4128f5c2, 0xc205c28f},
+{'4', 0xfe700000, 0x00000070},
+{'l', 0x00000000, 0x423d70a3},
+{'q', 0x00000000, 0x41cccccd},
+{0, 0x418e147a, 0x41cccccd},
+{'q', 0x410a3d70, 0x00000000},
+{0, 0x4181eb86, 0xc0b0a3d8},
+{'9', 0xffd4003c, 0xff88005a},
+{'4', 0xfe5e0000, 0x00000070},
+{'l', 0x00000000, 0x42870a3d},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e202ed, 0x00eb00f6},
+{'8', 0xedc900e0, 0xcfe8ede9},
+{'l', 0xbea3d700, 0xc11c28f6},
+{'q', 0xc0ae1470, 0x41147ae2},
+{0, 0xc16a3d6c, 0x41666667},
+{'q', 0xc1133334, 0x40a3d709},
+{0, 0xc1a0a3d8, 0x40a3d709},
+{'9', 0x0000ff2c, 0xfee8ff2c},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41f33333, 0xc2e9eb85},
+{'l', 0x415eb852, 0x00000000},
+{'4', 0x0081004b, 0x0019ffb8},
+{'l', 0xc163d70a, 0xc19ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004300f9, 0xffffffff},/*kerning  ù C� : -0.003906 */
+{'[', 0x004700f9, 0xffffffff},/*kerning  ù G� : -0.003906 */
+{'[', 0x004f00f9, 0xffffffff},/*kerning  ù O� : -0.003906 */
+{'[', 0x005100f9, 0xffffffff},/*kerning  ù Q� : -0.003906 */
+{'[', 0x005400f9, 0xffffffeb},/*kerning  ù T� : -0.082031 */
+{'[', 0x005500f9, 0xfffffffe},/*kerning  ù U� : -0.007812 */
+{'[', 0x005600f9, 0xfffffff5},/*kerning  ù V� : -0.042969 */
+{'[', 0x005700f9, 0xfffffff5},/*kerning  ù W� : -0.042969 */
+{'[', 0x005900f9, 0xffffffee},/*kerning  ù Y� : -0.070312 */
+{'[', 0x005c00f9, 0xfffffff8},/*kerning  ù \� : -0.031250 */
+{'[', 0x00c700f9, 0xffffffff},/*kerning  ù Ç : -0.003906 */
+{'[', 0x00d000f9, 0xfffffffe},/*kerning  ù Ð : -0.007812 */
+{'[', 0x00d200f9, 0xffffffff},/*kerning  ù Ò : -0.003906 */
+{'[', 0x00d300f9, 0xffffffff},/*kerning  ù Ó : -0.003906 */
+{'[', 0x00d400f9, 0xffffffff},/*kerning  ù Ô : -0.003906 */
+{'[', 0x00d500f9, 0xffffffff},/*kerning  ù Õ : -0.003906 */
+{'[', 0x00d600f9, 0xffffffff},/*kerning  ù Ö : -0.003906 */
+{'[', 0x00d800f9, 0xffffffff},/*kerning  ù Ø : -0.003906 */
+{'[', 0x00d900f9, 0xfffffffe},/*kerning  ù Ù : -0.007812 */
+{'[', 0x00da00f9, 0xfffffffe},/*kerning  ù Ú : -0.007812 */
+{'[', 0x00db00f9, 0xfffffffe},/*kerning  ù Û : -0.007812 */
+{'[', 0x00dc00f9, 0xfffffffe},/*kerning  ù Ü : -0.007812 */
+{'[', 0x00dd00f9, 0xffffffee},/*kerning  ù Ý : -0.070312 */
+{'@', 0x000000fa, 0x00006000},/*        ú        x-advance: 96.000000 */
+{'M', 0x4128f5c2, 0xc205c28f},
+{'4', 0xfe700000, 0x00000070},
+{'l', 0x00000000, 0x423d70a3},
+{'q', 0x00000000, 0x41cccccd},
+{0, 0x418e147a, 0x41cccccd},
+{'q', 0x410a3d70, 0x00000000},
+{0, 0x4181eb86, 0xc0b0a3d8},
+{'9', 0xffd4003c, 0xff88005a},
+{'4', 0xfe5e0000, 0x00000070},
+{'l', 0x00000000, 0x42870a3d},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e202ed, 0x00eb00f6},
+{'8', 0xedc900e0, 0xcfe8ede9},
+{'l', 0xbea3d700, 0xc11c28f6},
+{'q', 0xc0ae1470, 0x41147ae2},
+{0, 0xc16a3d6c, 0x41666667},
+{'q', 0xc1133334, 0x40a3d709},
+{0, 0xc1a0a3d8, 0x40a3d709},
+{'9', 0x0000ff2c, 0xfee8ff2c},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42500000, 0xc2c2e147},
+{'l', 0xc1147ae4, 0xc04ccce0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147b0, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004300fa, 0xffffffff},/*kerning  ú C� : -0.003906 */
+{'[', 0x004700fa, 0xffffffff},/*kerning  ú G� : -0.003906 */
+{'[', 0x004f00fa, 0xffffffff},/*kerning  ú O� : -0.003906 */
+{'[', 0x005100fa, 0xffffffff},/*kerning  ú Q� : -0.003906 */
+{'[', 0x005400fa, 0xffffffeb},/*kerning  ú T� : -0.082031 */
+{'[', 0x005500fa, 0xfffffffe},/*kerning  ú U� : -0.007812 */
+{'[', 0x005600fa, 0xfffffff5},/*kerning  ú V� : -0.042969 */
+{'[', 0x005700fa, 0xfffffff5},/*kerning  ú W� : -0.042969 */
+{'[', 0x005900fa, 0xffffffee},/*kerning  ú Y� : -0.070312 */
+{'[', 0x005c00fa, 0xfffffff8},/*kerning  ú \� : -0.031250 */
+{'[', 0x00c700fa, 0xffffffff},/*kerning  ú Ç : -0.003906 */
+{'[', 0x00d000fa, 0xfffffffe},/*kerning  ú Ð : -0.007812 */
+{'[', 0x00d200fa, 0xffffffff},/*kerning  ú Ò : -0.003906 */
+{'[', 0x00d300fa, 0xffffffff},/*kerning  ú Ó : -0.003906 */
+{'[', 0x00d400fa, 0xffffffff},/*kerning  ú Ô : -0.003906 */
+{'[', 0x00d500fa, 0xffffffff},/*kerning  ú Õ : -0.003906 */
+{'[', 0x00d600fa, 0xffffffff},/*kerning  ú Ö : -0.003906 */
+{'[', 0x00d800fa, 0xffffffff},/*kerning  ú Ø : -0.003906 */
+{'[', 0x00d900fa, 0xfffffffe},/*kerning  ú Ù : -0.007812 */
+{'[', 0x00da00fa, 0xfffffffe},/*kerning  ú Ú : -0.007812 */
+{'[', 0x00db00fa, 0xfffffffe},/*kerning  ú Û : -0.007812 */
+{'[', 0x00dc00fa, 0xfffffffe},/*kerning  ú Ü : -0.007812 */
+{'[', 0x00dd00fa, 0xffffffee},/*kerning  ú Ý : -0.070312 */
+{'@', 0x000000fb, 0x00006000},/*        û        x-advance: 96.000000 */
+{'M', 0x4128f5c2, 0xc205c28f},
+{'4', 0xfe700000, 0x00000070},
+{'l', 0x00000000, 0x423d70a3},
+{'q', 0x00000000, 0x41cccccd},
+{0, 0x418e147a, 0x41cccccd},
+{'q', 0x410a3d70, 0x00000000},
+{0, 0x4181eb86, 0xc0b0a3d8},
+{'9', 0xffd4003c, 0xff88005a},
+{'4', 0xfe5e0000, 0x00000070},
+{'l', 0x00000000, 0x42870a3d},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e202ed, 0x00eb00f6},
+{'8', 0xedc900e0, 0xcfe8ede9},
+{'l', 0xbea3d700, 0xc11c28f6},
+{'q', 0xc0ae1470, 0x41147ae2},
+{0, 0xc16a3d6c, 0x41666667},
+{'q', 0xc1133334, 0x40a3d709},
+{0, 0xc1a0a3d8, 0x40a3d709},
+{'9', 0x0000ff2c, 0xfee8ff2c},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41ce147b, 0xc2cccccc},
+{'l', 0x418147ad, 0xc1666668},
+{'l', 0x4123d70c, 0x00000000},
+{'l', 0x418147ae, 0x41666668},
+{'0', 0xb0941ec3, 0xe2c35094},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004300fb, 0xffffffff},/*kerning  û C� : -0.003906 */
+{'[', 0x004700fb, 0xffffffff},/*kerning  û G� : -0.003906 */
+{'[', 0x004f00fb, 0xffffffff},/*kerning  û O� : -0.003906 */
+{'[', 0x005100fb, 0xffffffff},/*kerning  û Q� : -0.003906 */
+{'[', 0x005400fb, 0xffffffeb},/*kerning  û T� : -0.082031 */
+{'[', 0x005500fb, 0xfffffffe},/*kerning  û U� : -0.007812 */
+{'[', 0x005600fb, 0xfffffff5},/*kerning  û V� : -0.042969 */
+{'[', 0x005700fb, 0xfffffff5},/*kerning  û W� : -0.042969 */
+{'[', 0x005900fb, 0xffffffee},/*kerning  û Y� : -0.070312 */
+{'[', 0x005c00fb, 0xfffffff8},/*kerning  û \� : -0.031250 */
+{'[', 0x00c700fb, 0xffffffff},/*kerning  û Ç : -0.003906 */
+{'[', 0x00d000fb, 0xfffffffe},/*kerning  û Ð : -0.007812 */
+{'[', 0x00d200fb, 0xffffffff},/*kerning  û Ò : -0.003906 */
+{'[', 0x00d300fb, 0xffffffff},/*kerning  û Ó : -0.003906 */
+{'[', 0x00d400fb, 0xffffffff},/*kerning  û Ô : -0.003906 */
+{'[', 0x00d500fb, 0xffffffff},/*kerning  û Õ : -0.003906 */
+{'[', 0x00d600fb, 0xffffffff},/*kerning  û Ö : -0.003906 */
+{'[', 0x00d800fb, 0xffffffff},/*kerning  û Ø : -0.003906 */
+{'[', 0x00d900fb, 0xfffffffe},/*kerning  û Ù : -0.007812 */
+{'[', 0x00da00fb, 0xfffffffe},/*kerning  û Ú : -0.007812 */
+{'[', 0x00db00fb, 0xfffffffe},/*kerning  û Û : -0.007812 */
+{'[', 0x00dc00fb, 0xfffffffe},/*kerning  û Ü : -0.007812 */
+{'[', 0x00dd00fb, 0xffffffee},/*kerning  û Ý : -0.070312 */
+{'@', 0x000000fc, 0x00006000},/*        ü        x-advance: 96.000000 */
+{'M', 0x4128f5c2, 0xc205c28f},
+{'4', 0xfe700000, 0x00000070},
+{'l', 0x00000000, 0x423d70a3},
+{'q', 0x00000000, 0x41cccccd},
+{0, 0x418e147a, 0x41cccccd},
+{'q', 0x410a3d70, 0x00000000},
+{0, 0x4181eb86, 0xc0b0a3d8},
+{'9', 0xffd4003c, 0xff88005a},
+{'4', 0xfe5e0000, 0x00000070},
+{'l', 0x00000000, 0x42870a3d},
+{'9', 0x00270000, 0x00280023},
+{'l', 0x00000000, 0x412e147b},
+{'8', 0x03e202ed, 0x00eb00f6},
+{'8', 0xedc900e0, 0xcfe8ede9},
+{'l', 0xbea3d700, 0xc11c28f6},
+{'q', 0xc0ae1470, 0x41147ae2},
+{0, 0xc16a3d6c, 0x41666667},
+{'q', 0xc1133334, 0x40a3d709},
+{0, 0xc1a0a3d8, 0x40a3d709},
+{'9', 0x0000ff2c, 0xfee8ff2c},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41e147ae, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x425851eb, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x004300fc, 0xffffffff},/*kerning  ü C� : -0.003906 */
+{'[', 0x004700fc, 0xffffffff},/*kerning  ü G� : -0.003906 */
+{'[', 0x004f00fc, 0xffffffff},/*kerning  ü O� : -0.003906 */
+{'[', 0x005100fc, 0xffffffff},/*kerning  ü Q� : -0.003906 */
+{'[', 0x005400fc, 0xffffffeb},/*kerning  ü T� : -0.082031 */
+{'[', 0x005500fc, 0xfffffffe},/*kerning  ü U� : -0.007812 */
+{'[', 0x005600fc, 0xfffffff5},/*kerning  ü V� : -0.042969 */
+{'[', 0x005700fc, 0xfffffff5},/*kerning  ü W� : -0.042969 */
+{'[', 0x005900fc, 0xffffffee},/*kerning  ü Y� : -0.070312 */
+{'[', 0x005c00fc, 0xfffffff8},/*kerning  ü \� : -0.031250 */
+{'[', 0x00c700fc, 0xffffffff},/*kerning  ü Ç : -0.003906 */
+{'[', 0x00d000fc, 0xfffffffe},/*kerning  ü Ð : -0.007812 */
+{'[', 0x00d200fc, 0xffffffff},/*kerning  ü Ò : -0.003906 */
+{'[', 0x00d300fc, 0xffffffff},/*kerning  ü Ó : -0.003906 */
+{'[', 0x00d400fc, 0xffffffff},/*kerning  ü Ô : -0.003906 */
+{'[', 0x00d500fc, 0xffffffff},/*kerning  ü Õ : -0.003906 */
+{'[', 0x00d600fc, 0xffffffff},/*kerning  ü Ö : -0.003906 */
+{'[', 0x00d800fc, 0xffffffff},/*kerning  ü Ø : -0.003906 */
+{'[', 0x00d900fc, 0xfffffffe},/*kerning  ü Ù : -0.007812 */
+{'[', 0x00da00fc, 0xfffffffe},/*kerning  ü Ú : -0.007812 */
+{'[', 0x00db00fc, 0xfffffffe},/*kerning  ü Û : -0.007812 */
+{'[', 0x00dc00fc, 0xfffffffe},/*kerning  ü Ü : -0.007812 */
+{'[', 0x00dd00fc, 0xffffffee},/*kerning  ü Ý : -0.070312 */
+{'@', 0x000000fd, 0x00005700},/*        ý        x-advance: 87.000000 */
+{'M', 0x41733333, 0x41b5c28f},
+{'8', 0x03210110, 0x01190110},
+{'8', 0xf2230014, 0xca21f20f},
+{'9', 0xffd80012, 0xff8a0030},
+{'l', 0xc20d70a4, 0xc2a70a3d},
+{'l', 0x416e147c, 0x00000000},
+{'l', 0x41e147ae, 0x428a8f5c},
+{'4', 0xfdd600cb, 0x0000006f},
+{'l', 0xc2228f5c, 0x42d2e147},
+{'q', 0xc0051ec0, 0x40b33334},
+{0, 0xc0ee1480, 0x411d70a4},
+{'q', 0xc0ab851c, 0x4087ae18},
+{0, 0xc1651eb6, 0x4087ae18},
+{'8', 0xffe900f5, 0xfbe2fff4},
+{'l', 0x00000000, 0xc147ae16},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4247ae14, 0xc2c2e147},
+{'l', 0xc1147ae0, 0xc04ccce0},
+{'4', 0xff7f004a, 0x00000070},
+{'l', 0xc16147b0, 0x419ae148},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002000fd, 0xfffffffa},/*kerning  ý  � : -0.023438 */
+{'[', 0x002900fd, 0xfffffffc},/*kerning  ý )� : -0.015625 */
+{'[', 0x002c00fd, 0xffffffee},/*kerning  ý ,� : -0.070312 */
+{'[', 0x002d00fd, 0xfffffffe},/*kerning  ý -� : -0.007812 */
+{'[', 0x002e00fd, 0xffffffee},/*kerning  ý .� : -0.070312 */
+{'[', 0x002f00fd, 0xfffffff6},/*kerning  ý /� : -0.039062 */
+{'[', 0x004000fd, 0xfffffffe},/*kerning  ý @� : -0.007812 */
+{'[', 0x004100fd, 0xfffffff8},/*kerning  ý A� : -0.031250 */
+{'[', 0x004a00fd, 0xffffffee},/*kerning  ý J� : -0.070312 */
+{'[', 0x005400fd, 0xffffffeb},/*kerning  ý T� : -0.082031 */
+{'[', 0x005600fd, 0xfffffffd},/*kerning  ý V� : -0.011719 */
+{'[', 0x005700fd, 0xfffffffd},/*kerning  ý W� : -0.011719 */
+{'[', 0x005800fd, 0xfffffff9},/*kerning  ý X� : -0.027344 */
+{'[', 0x005900fd, 0xfffffff7},/*kerning  ý Y� : -0.035156 */
+{'[', 0x005a00fd, 0xfffffffc},/*kerning  ý Z� : -0.015625 */
+{'[', 0x005c00fd, 0xfffffffd},/*kerning  ý \� : -0.011719 */
+{'[', 0x006100fd, 0xfffffffd},/*kerning  ý a� : -0.011719 */
+{'[', 0x006300fd, 0xfffffffc},/*kerning  ý c� : -0.015625 */
+{'[', 0x006400fd, 0xfffffffc},/*kerning  ý d� : -0.015625 */
+{'[', 0x006500fd, 0xfffffffc},/*kerning  ý e� : -0.015625 */
+{'[', 0x006700fd, 0xfffffffc},/*kerning  ý g� : -0.015625 */
+{'[', 0x006f00fd, 0xfffffffc},/*kerning  ý o� : -0.015625 */
+{'[', 0x007100fd, 0xfffffffc},/*kerning  ý q� : -0.015625 */
+{'[', 0x007300fd, 0xfffffffd},/*kerning  ý s� : -0.011719 */
+{'[', 0x00ab00fd, 0xfffffffa},/*kerning  ý « : -0.023438 */
+{'[', 0x00c000fd, 0xfffffff8},/*kerning  ý À : -0.031250 */
+{'[', 0x00c100fd, 0xfffffff8},/*kerning  ý Á : -0.031250 */
+{'[', 0x00c200fd, 0xfffffff8},/*kerning  ý Â : -0.031250 */
+{'[', 0x00c300fd, 0xfffffff8},/*kerning  ý Ã : -0.031250 */
+{'[', 0x00c400fd, 0xfffffff8},/*kerning  ý Ä : -0.031250 */
+{'[', 0x00c500fd, 0xfffffff8},/*kerning  ý Å : -0.031250 */
+{'[', 0x00c600fd, 0xfffffff3},/*kerning  ý Æ : -0.050781 */
+{'[', 0x00d000fd, 0xfffffffe},/*kerning  ý Ð : -0.007812 */
+{'[', 0x00dd00fd, 0xfffffff7},/*kerning  ý Ý : -0.035156 */
+{'[', 0x00e000fd, 0xfffffffd},/*kerning  ý à : -0.011719 */
+{'[', 0x00e100fd, 0xfffffffd},/*kerning  ý á : -0.011719 */
+{'[', 0x00e200fd, 0xfffffffd},/*kerning  ý â : -0.011719 */
+{'[', 0x00e300fd, 0xfffffffd},/*kerning  ý ã : -0.011719 */
+{'[', 0x00e400fd, 0xfffffffd},/*kerning  ý ä : -0.011719 */
+{'[', 0x00e500fd, 0xfffffffd},/*kerning  ý å : -0.011719 */
+{'[', 0x00e600fd, 0xfffffffd},/*kerning  ý æ : -0.011719 */
+{'[', 0x00e700fd, 0xfffffffc},/*kerning  ý ç : -0.015625 */
+{'[', 0x00e800fd, 0xfffffffc},/*kerning  ý è : -0.015625 */
+{'[', 0x00e900fd, 0xfffffffc},/*kerning  ý é : -0.015625 */
+{'[', 0x00ea00fd, 0xfffffffc},/*kerning  ý ê : -0.015625 */
+{'[', 0x00eb00fd, 0xfffffffc},/*kerning  ý ë : -0.015625 */
+{'[', 0x00f000fd, 0xfffffffa},/*kerning  ý ð : -0.023438 */
+{'[', 0x00f200fd, 0xfffffffc},/*kerning  ý ò : -0.015625 */
+{'[', 0x00f300fd, 0xfffffffc},/*kerning  ý ó : -0.015625 */
+{'[', 0x00f400fd, 0xfffffffc},/*kerning  ý ô : -0.015625 */
+{'[', 0x00f500fd, 0xfffffffc},/*kerning  ý õ : -0.015625 */
+{'[', 0x00f600fd, 0xfffffffc},/*kerning  ý ö : -0.015625 */
+{'[', 0x00f800fd, 0xfffffffc},/*kerning  ý ø : -0.015625 */
+{'@', 0x000000fe, 0x00006000},/*        þ        x-advance: 96.000000 */
+{'M', 0x42b5c28f, 0xc2247ae1},
+{'q', 0xbe23d600, 0x410a3d70},
+{0, 0xc0570a20, 0x41847ae1},
+{'q', 0xc04ccce0, 0x40fd70a4},
+{0, 0xc10cccd0, 0x416147ae},
+{'q', 0xc0b33340, 0x40c51eb8},
+{0, 0xc150a3e0, 0x411c28f5},
+{'q', 0xc0ee1470, 0x40666667},
+{0, 0xc180a3d4, 0x40666667},
+{'q', 0xc1051eb8, 0x00000000},
+{0, 0xc168f5c0, 0xc070a3d6},
+{'9', 0xffe2ffcf, 0xffbbffb6},
+{'l', 0x00000000, 0x422eb851},
+{'l', 0xc1666667, 0x00000000},
+{'4', 0xfb630000, 0x00000073},
+{'l', 0x00000000, 0x42270a3e},
+{'q', 0x4075c288, 0xc0ae1480},
+{0, 0x411eb852, 0xc11851f0},
+{'q', 0x40c28f58, 0xc0828f50},
+{0, 0x4175c28c, 0xc0828f50},
+{'q', 0x41147ae4, 0x00000000},
+{0, 0x41851eba, 0x407ae140},
+{'q', 0x40eb8520, 0x407ae140},
+{0, 0x4148f5c0, 0x41251eb8},
+{'q', 0x40a66660, 0x40ccccd0},
+{0, 0x40fd70a0, 0x4163d708},
+{'9', 0x003e0015, 0x007e0015},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4298f5c2, 0xc2251eb8},
+{'q', 0x00000000, 0xc1051eb8},
+{0, 0xc051eb80, 0xc1770a40},
+{'8', 0xa4b8c8e6, 0xdd92ddd2},
+{'q', 0xc10a3d70, 0x00000000},
+{0, 0xc16b8520, 0x40a8f5c0},
+{'9', 0x002affd0, 0x0062ffb2},
+{'l', 0x00000000, 0x41dae146},
+{'8', 0x441e2300, 0x354a201e},
+{'q', 0x40b0a3d8, 0x4023d708},
+{0, 0x4127ae14, 0x4023d708},
+{'q', 0x41000000, 0x00000000},
+{0, 0x416147ac, 0xc08f5c28},
+{'q', 0x40c28f58, 0xc08f5c28},
+{0, 0x41199994, 0xc139999a},
+{'q', 0x406147c0, 0xc0e3d708},
+{0, 0x406147c0, 0xc1747ae0},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002200fe, 0xfffffffc},/*kerning  þ "� : -0.015625 */
+{'[', 0x002700fe, 0xfffffffc},/*kerning  þ '� : -0.015625 */
+{'[', 0x002900fe, 0xfffffffb},/*kerning  þ )� : -0.019531 */
+{'[', 0x002a00fe, 0xfffffffa},/*kerning  þ *� : -0.023438 */
+{'[', 0x002f00fe, 0xfffffffe},/*kerning  þ /� : -0.007812 */
+{'[', 0x003f00fe, 0xfffffffb},/*kerning  þ ?� : -0.019531 */
+{'[', 0x004100fe, 0xfffffffc},/*kerning  þ A� : -0.015625 */
+{'[', 0x004200fe, 0xfffffffe},/*kerning  þ B� : -0.007812 */
+{'[', 0x004400fe, 0xfffffffe},/*kerning  þ D� : -0.007812 */
+{'[', 0x004500fe, 0xfffffffe},/*kerning  þ E� : -0.007812 */
+{'[', 0x004600fe, 0xfffffffe},/*kerning  þ F� : -0.007812 */
+{'[', 0x004800fe, 0xfffffffe},/*kerning  þ H� : -0.007812 */
+{'[', 0x004900fe, 0xfffffffe},/*kerning  þ I� : -0.007812 */
+{'[', 0x004a00fe, 0xfffffffe},/*kerning  þ J� : -0.007812 */
+{'[', 0x004b00fe, 0xfffffffe},/*kerning  þ K� : -0.007812 */
+{'[', 0x004c00fe, 0xfffffffe},/*kerning  þ L� : -0.007812 */
+{'[', 0x004d00fe, 0xfffffffe},/*kerning  þ M� : -0.007812 */
+{'[', 0x004e00fe, 0xfffffffe},/*kerning  þ N� : -0.007812 */
+{'[', 0x005000fe, 0xfffffffe},/*kerning  þ P� : -0.007812 */
+{'[', 0x005200fe, 0xfffffffe},/*kerning  þ R� : -0.007812 */
+{'[', 0x005300fe, 0xffffffff},/*kerning  þ S� : -0.003906 */
+{'[', 0x005400fe, 0xffffffe4},/*kerning  þ T� : -0.109375 */
+{'[', 0x005500fe, 0xfffffffe},/*kerning  þ U� : -0.007812 */
+{'[', 0x005600fe, 0xffffffef},/*kerning  þ V� : -0.066406 */
+{'[', 0x005700fe, 0xffffffef},/*kerning  þ W� : -0.066406 */
+{'[', 0x005800fe, 0xfffffff7},/*kerning  þ X� : -0.035156 */
+{'[', 0x005900fe, 0xffffffea},/*kerning  þ Y� : -0.085938 */
+{'[', 0x005a00fe, 0xfffffffc},/*kerning  þ Z� : -0.015625 */
+{'[', 0x005c00fe, 0xfffffff4},/*kerning  þ \� : -0.046875 */
+{'[', 0x005d00fe, 0xfffffffe},/*kerning  þ ]� : -0.007812 */
+{'[', 0x006600fe, 0xfffffffe},/*kerning  þ f� : -0.007812 */
+{'[', 0x007400fe, 0xfffffffe},/*kerning  þ t� : -0.007812 */
+{'[', 0x007600fe, 0xfffffffc},/*kerning  þ v� : -0.015625 */
+{'[', 0x007700fe, 0xfffffffc},/*kerning  þ w� : -0.015625 */
+{'[', 0x007800fe, 0xfffffffb},/*kerning  þ x� : -0.019531 */
+{'[', 0x007900fe, 0xfffffffc},/*kerning  þ y� : -0.015625 */
+{'[', 0x007a00fe, 0xfffffffe},/*kerning  þ z� : -0.007812 */
+{'[', 0x007d00fe, 0xfffffffe},/*kerning  þ }� : -0.007812 */
+{'[', 0x00ba00fe, 0xfffffffe},/*kerning  þ º : -0.007812 */
+{'[', 0x00c000fe, 0xfffffffc},/*kerning  þ À : -0.015625 */
+{'[', 0x00c100fe, 0xfffffffc},/*kerning  þ Á : -0.015625 */
+{'[', 0x00c200fe, 0xfffffffc},/*kerning  þ Â : -0.015625 */
+{'[', 0x00c300fe, 0xfffffffc},/*kerning  þ Ã : -0.015625 */
+{'[', 0x00c400fe, 0xfffffffc},/*kerning  þ Ä : -0.015625 */
+{'[', 0x00c500fe, 0xfffffffc},/*kerning  þ Å : -0.015625 */
+{'[', 0x00c600fe, 0xfffffffd},/*kerning  þ Æ : -0.011719 */
+{'[', 0x00c800fe, 0xfffffffe},/*kerning  þ È : -0.007812 */
+{'[', 0x00c900fe, 0xfffffffe},/*kerning  þ É : -0.007812 */
+{'[', 0x00ca00fe, 0xfffffffe},/*kerning  þ Ê : -0.007812 */
+{'[', 0x00cb00fe, 0xfffffffe},/*kerning  þ Ë : -0.007812 */
+{'[', 0x00cc00fe, 0xfffffffe},/*kerning  þ Ì : -0.007812 */
+{'[', 0x00cd00fe, 0xfffffffe},/*kerning  þ Í : -0.007812 */
+{'[', 0x00ce00fe, 0xfffffffe},/*kerning  þ Î : -0.007812 */
+{'[', 0x00cf00fe, 0xfffffffe},/*kerning  þ Ï : -0.007812 */
+{'[', 0x00d000fe, 0xfffffffc},/*kerning  þ Ð : -0.015625 */
+{'[', 0x00d100fe, 0xfffffffe},/*kerning  þ Ñ : -0.007812 */
+{'[', 0x00d900fe, 0xfffffffe},/*kerning  þ Ù : -0.007812 */
+{'[', 0x00da00fe, 0xfffffffe},/*kerning  þ Ú : -0.007812 */
+{'[', 0x00db00fe, 0xfffffffe},/*kerning  þ Û : -0.007812 */
+{'[', 0x00dc00fe, 0xfffffffe},/*kerning  þ Ü : -0.007812 */
+{'[', 0x00dd00fe, 0xffffffea},/*kerning  þ Ý : -0.085938 */
+{'[', 0x00de00fe, 0xfffffffe},/*kerning  þ Þ : -0.007812 */
+{'[', 0x00fd00fe, 0xfffffffc},/*kerning  þ ý : -0.015625 */
+{'[', 0x00ff00fe, 0xfffffffc},/*kerning  þ ÿ : -0.015625 */
+{'@', 0x000000ff, 0x00005700},/*        ÿ        x-advance: 87.000000 */
+{'M', 0x41733333, 0x41b5c28f},
+{'8', 0x03210110, 0x01190110},
+{'8', 0xf2230014, 0xca21f20f},
+{'9', 0xffd80012, 0xff8a0030},
+{'l', 0xc20d70a4, 0xc2a70a3d},
+{'l', 0x416e147c, 0x00000000},
+{'l', 0x41e147ae, 0x428a8f5c},
+{'4', 0xfdd600cb, 0x0000006f},
+{'l', 0xc2228f5c, 0x42d2e147},
+{'q', 0xc0051ec0, 0x40b33334},
+{0, 0xc0ee1480, 0x411d70a4},
+{'q', 0xc0ab851c, 0x4087ae18},
+{0, 0xc1651eb6, 0x4087ae18},
+{'8', 0xffe900f5, 0xfbe2fff4},
+{'l', 0x00000000, 0xc147ae16},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41d0a3d7, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a2, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42500000, 0xc2c80000},
+{'l', 0x00000000, 0xc1828f5c},
+{'4', 0x0000005e, 0x00820000},
+{'l', 0xc13d70a4, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'[', 0x002000ff, 0xfffffffa},/*kerning  ÿ  � : -0.023438 */
+{'[', 0x002900ff, 0xfffffffc},/*kerning  ÿ )� : -0.015625 */
+{'[', 0x002c00ff, 0xffffffee},/*kerning  ÿ ,� : -0.070312 */
+{'[', 0x002d00ff, 0xfffffffe},/*kerning  ÿ -� : -0.007812 */
+{'[', 0x002e00ff, 0xffffffee},/*kerning  ÿ .� : -0.070312 */
+{'[', 0x002f00ff, 0xfffffff6},/*kerning  ÿ /� : -0.039062 */
+{'[', 0x004000ff, 0xfffffffe},/*kerning  ÿ @� : -0.007812 */
+{'[', 0x004100ff, 0xfffffff8},/*kerning  ÿ A� : -0.031250 */
+{'[', 0x004a00ff, 0xffffffee},/*kerning  ÿ J� : -0.070312 */
+{'[', 0x005400ff, 0xffffffeb},/*kerning  ÿ T� : -0.082031 */
+{'[', 0x005600ff, 0xfffffffd},/*kerning  ÿ V� : -0.011719 */
+{'[', 0x005700ff, 0xfffffffd},/*kerning  ÿ W� : -0.011719 */
+{'[', 0x005800ff, 0xfffffff9},/*kerning  ÿ X� : -0.027344 */
+{'[', 0x005900ff, 0xfffffff7},/*kerning  ÿ Y� : -0.035156 */
+{'[', 0x005a00ff, 0xfffffffc},/*kerning  ÿ Z� : -0.015625 */
+{'[', 0x005c00ff, 0xfffffffd},/*kerning  ÿ \� : -0.011719 */
+{'[', 0x006100ff, 0xfffffffd},/*kerning  ÿ a� : -0.011719 */
+{'[', 0x006300ff, 0xfffffffc},/*kerning  ÿ c� : -0.015625 */
+{'[', 0x006400ff, 0xfffffffc},/*kerning  ÿ d� : -0.015625 */
+{'[', 0x006500ff, 0xfffffffc},/*kerning  ÿ e� : -0.015625 */
+{'[', 0x006700ff, 0xfffffffc},/*kerning  ÿ g� : -0.015625 */
+{'[', 0x006f00ff, 0xfffffffc},/*kerning  ÿ o� : -0.015625 */
+{'[', 0x007100ff, 0xfffffffc},/*kerning  ÿ q� : -0.015625 */
+{'[', 0x007300ff, 0xfffffffd},/*kerning  ÿ s� : -0.011719 */
+{'[', 0x00ab00ff, 0xfffffffa},/*kerning  ÿ « : -0.023438 */
+{'[', 0x00c000ff, 0xfffffff8},/*kerning  ÿ À : -0.031250 */
+{'[', 0x00c100ff, 0xfffffff8},/*kerning  ÿ Á : -0.031250 */
+{'[', 0x00c200ff, 0xfffffff8},/*kerning  ÿ Â : -0.031250 */
+{'[', 0x00c300ff, 0xfffffff8},/*kerning  ÿ Ã : -0.031250 */
+{'[', 0x00c400ff, 0xfffffff8},/*kerning  ÿ Ä : -0.031250 */
+{'[', 0x00c500ff, 0xfffffff8},/*kerning  ÿ Å : -0.031250 */
+{'[', 0x00c600ff, 0xfffffff3},/*kerning  ÿ Æ : -0.050781 */
+{'[', 0x00d000ff, 0xfffffffe},/*kerning  ÿ Ð : -0.007812 */
+{'[', 0x00dd00ff, 0xfffffff7},/*kerning  ÿ Ý : -0.035156 */
+{'[', 0x00e000ff, 0xfffffffd},/*kerning  ÿ à : -0.011719 */
+{'[', 0x00e100ff, 0xfffffffd},/*kerning  ÿ á : -0.011719 */
+{'[', 0x00e200ff, 0xfffffffd},/*kerning  ÿ â : -0.011719 */
+{'[', 0x00e300ff, 0xfffffffd},/*kerning  ÿ ã : -0.011719 */
+{'[', 0x00e400ff, 0xfffffffd},/*kerning  ÿ ä : -0.011719 */
+{'[', 0x00e500ff, 0xfffffffd},/*kerning  ÿ å : -0.011719 */
+{'[', 0x00e600ff, 0xfffffffd},/*kerning  ÿ æ : -0.011719 */
+{'[', 0x00e700ff, 0xfffffffc},/*kerning  ÿ ç : -0.015625 */
+{'[', 0x00e800ff, 0xfffffffc},/*kerning  ÿ è : -0.015625 */
+{'[', 0x00e900ff, 0xfffffffc},/*kerning  ÿ é : -0.015625 */
+{'[', 0x00ea00ff, 0xfffffffc},/*kerning  ÿ ê : -0.015625 */
+{'[', 0x00eb00ff, 0xfffffffc},/*kerning  ÿ ë : -0.015625 */
+{'[', 0x00f000ff, 0xfffffffa},/*kerning  ÿ ð : -0.023438 */
+{'[', 0x00f200ff, 0xfffffffc},/*kerning  ÿ ò : -0.015625 */
+{'[', 0x00f300ff, 0xfffffffc},/*kerning  ÿ ó : -0.015625 */
+{'[', 0x00f400ff, 0xfffffffc},/*kerning  ÿ ô : -0.015625 */
+{'[', 0x00f500ff, 0xfffffffc},/*kerning  ÿ õ : -0.015625 */
+{'[', 0x00f600ff, 0xfffffffc},/*kerning  ÿ ö : -0.015625 */
+{'[', 0x00f800ff, 0xfffffffc},/*kerning  ÿ ø : -0.015625 */
+{'@', 0x000001e9, 0x0000a800},/*        ǩ        x-advance: 168.000000 */
+{'M', 0x42f33333, 0xc1e147ae},
+{'8', 0x141315fe, 0xe819fb18},
+{'8', 0xfa0bf002, 0x0c050506},
+{'8', 0x0f030afe, 0x01100506},
+{'8', 0xf60cfd09, 0xcbf4e310},
+{'8', 0xfbc9e9e4, 0x31e70be6},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4289eb85, 0xc1e8f5c2},
+{'q', 0xc1accccc, 0xc0e147b0},
+{0, 0xc207ae14, 0xc18147ae},
+{'8', 0xd5d1f4f0, 0xd6cfe0e0},
+{'8', 0x0ae7fdfa, 0x0eec0bf1},
+{'8', 0x07f101fd, 0x08f005f5},
+{'8', 0x06f102fb, 0x03f003f6},
+{'8', 0x00f001f9, 0xfdf000f4},
+{'8', 0xe9fbf8f4, 0xf014f506},
+{'q', 0x40999999, 0xc08f5c30},
+{0, 0x40dc28f5, 0xc1028f5c},
+{'q', 0x00000000, 0xc13ae14c},
+{0, 0xc0570a3c, 0xc1b1eb86},
+{'8', 0xf2fefdff, 0xf1fdf8fe},
+{'8', 0xf400fbff, 0xf506f901},
+{'8', 0x0a13020a, 0x18130708},
+{'8', 0x130e0f0a, 0x22140b06},
+{'8', 0x2615180c, 0x20170e08},
+{'8', 0x1d1e110e, 0x2a6c2f38},
+{'8', 0xec020001, 0xef0cec01},
+{'8', 0x1e27020b, 0x1d2b1413},
+{'8', 0x0817050b, 0x011e0206},
+{'8', 0x00190011, 0xff14ff03},
+{'8', 0xfe17ff0f, 0xfa11ff07},
+{'8', 0xf00ef80c, 0xf007fdff},
+{'8', 0xef06f903, 0xe205f801},
+{'8', 0xe105eb03, 0xe105f701},
+{'8', 0xe001e901, 0xe000f800},
+{'8', 0xddfef4ff, 0xe4ffe9ff},
+{'q', 0x40ccccd0, 0x3e23d600},
+{0, 0x4107ae18, 0x40a3d710},
+{'q', 0x40570a20, 0x40b851e0},
+{0, 0x40fffff0, 0x4191eb84},
+{'8', 0x3a542a13, 0x17630821},
+{'q', 0x4107ae18, 0x3fe147a0},
+{0, 0x416e1480, 0x406147b0},
+{'q', 0x410cccd0, 0x40199990},
+{0, 0x41428f60, 0x4075c290},
+{'q', 0x4170a3d0, 0x40d1eb80},
+{0, 0x419851e8, 0x41547ae0},
+{'8', 0x15060a05, 0x14fe0b00},
+{'8', 0x14f90cfd, 0x10f610f6},
+{'8', 0x14f10100, 0x15ed02fe},
+{'8', 0x1ae713ef, 0x11eb06fa},
+{'8', 0x10e40bf1, 0x06d903f4},
+{'8', 0x02d402ec, 0x00da00e8},
+{'8', 0xffd300f1, 0xffd8ffe2},
+{'8', 0xfeec00fe, 0xfee8ffef},
+{'8', 0xfbedfef1, 0xf5ecf6ec},
+{'8', 0xfffa00fe, 0xfdfafefd},
+{'8', 0xfef9fffd, 0x00fb00fd},
+{'8', 0x05fe02fb, 0x33652b18},
+{'8', 0x0225021e, 0x06270119},
+{'8', 0x0be308f2, 0x03d902ef},
+{'8', 0x01df01e8, 0x01da00f2},
+{'8', 0x00d401e8, 0xfddb00ec},
+{'8', 0xf4f0f8fb, 0xffebfef5},
+{'8', 0x00eb01f5, 0x15a2fec7},
+{'q', 0xc13ae148, 0x408f5c29},
+{0, 0xc1accccc, 0x4023d70c},
+{'8', 0xf9d9fbe8, 0xf1defdf0},
+{'8', 0xe4e4f4eb, 0xf401f8fd},
+{'8', 0xfe10fe03, 0xff0eff0b},
+{'q', 0x41666664, 0xc023d70c},
+{0, 0x41bd70a2, 0xc11c28f5},
+{'8', 0xf4f2f9fb, 0xf8ebfbf8},
+{'9', 0xfffdfff2, 0xfffaffed},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429bd70a, 0xc2d5c28f},
+{'8', 0x20151501, 0xff260a13},
+{'8', 0xe911fd0f, 0xe2faf001},
+{'8', 0xf0daedf4, 0x19e203eb},
+{'9', 0x0007fffd, 0x000efffe},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4294cccd, 0xc2d947ae},
+{'8', 0xd118e4ff, 0xf233f014},
+{'8', 0x0e260217, 0x1e190f13},
+{'8', 0x2e011003, 0x25eb19fd},
+{'8', 0x0aac13e4, 0xe2e3f6ec},
+{'q', 0xbf4ccd00, 0xbff5c280},
+{0, 0xbf23d700, 0xc0b851f0},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002190, 0x0000a800},/*        ←        x-advance: 168.000000 */
+{'M', 0x409eb852, 0xc241eb85},
+{'l', 0x426d70a4, 0xc208f5c3},
+{'l', 0x00000000, 0x41a28f5e},
+{'l', 0x42c570a3, 0x00000000},
+{'l', 0x00000000, 0x41deb852},
+{'4', 0x0000fceb, 0x00a30000},
+{'l', 0xc26d70a4, 0xc209999a},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002191, 0x00005000},/*        ↑        x-advance: 80.000000 */
+{'M', 0x42200000, 0xc2feb852},
+{'l', 0x4208f5c2, 0x426d70a4},
+{'l', 0xc1a28f5c, 0x00000000},
+{'l', 0x00000000, 0x42c5c28f},
+{'l', 0xc1deb851, 0x36000000},
+{'4', 0xfce90000, 0x0000ff5e},
+{'l', 0x4208f5c2, 0xc26d70a4},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002192, 0x0000a800},/*        →        x-advance: 168.000000 */
+{'M', 0x43230a3d, 0xc241eb85},
+{'l', 0xc26d70a2, 0x4209999a},
+{'l', 0x00000000, 0xc1a28f5c},
+{'l', 0xc2c570a4, 0x00000000},
+{'l', 0x35800000, 0xc1e00000},
+{'4', 0x00000315, 0xff5e0000},
+{'l', 0x426d70a2, 0x4208f5c3},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002193, 0x00005000},/*        ↓        x-advance: 80.000000 */
+{'M', 0x42200000, 0x41f70a3d},
+{'l', 0xc208f5c3, 0xc26d70a4},
+{'l', 0x41a28f5d, 0x36000000},
+{'l', 0x00000000, 0xc2c5c290},
+{'l', 0x41deb851, 0x00000000},
+{'4', 0x03170000, 0x000000a2},
+{'l', 0xc208f5c2, 0x426d70a4},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002194, 0x0000a800},/*        ↔        x-advance: 168.000000 */
+{'M', 0x4280a3d7, 0xc2099999},
+{'9', 0x00000000, 0x0000013a},
+{'l', 0x00000000, 0x41a28f5b},
+{'l', 0x426d70a2, 0xc209999a},
+{'4', 0xfeeffe26, 0x00a20000},
+{'l', 0xc21d70a4, 0x00000000},
+{'q', 0x00000000, 0x00000000},
+{0, 0x00000000, 0xc0051eb0},
+{'9', 0x00000000, 0xff6f0000},
+{'l', 0xc26d70a4, 0x4208f5c3},
+{'4', 0x011301da, 0xff5e0000},
+{'l', 0x00000000, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002195, 0x00005000},/*        ↕        x-advance: 80.000000 */
+{'M', 0x41d0a3d7, 0xc28851eb},
+{'9', 0x00000000, 0x013c0000},
+{'l', 0xc1a28f5c, 0x00000000},
+{'l', 0x4208f5c2, 0x426d70a4},
+{'4', 0xfe260111, 0x0000ff5e},
+{'l', 0x00000000, 0xc21e147a},
+{'q', 0x00000000, 0x00000000},
+{0, 0x40051ec0, 0x00000000},
+{'9', 0x00000000, 0x00000091},
+{'l', 0xc208f5c2, 0xc26d70a4},
+{'4', 0x01dafeef, 0x000000a2},
+{'l', 0x00000000, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002196, 0x00008400},/*        ↖        x-advance: 132.000000 */
+{'M', 0x40947ae1, 0xc2d4cccc},
+{'l', 0x42847ae1, 0x418e1478},
+{'l', 0xc1666664, 0x41666668},
+{'l', 0x428bd70a, 0x428b851e},
+{'l', 0xc19d70a0, 0x419eb854},
+{'4', 0xfdd1fdd1, 0x0073ff8d},
+{'l', 0xc18e147b, 0xc2847ae0},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002197, 0x00008400},/*        ↗        x-advance: 132.000000 */
+{'M', 0x42fccccc, 0xc2d4cccc},
+{'l', 0xc18e1478, 0x42847ae0},
+{'l', 0xc1666668, 0xc1666660},
+{'l', 0xc28bd70a, 0x428bd70a},
+{'l', 0xc19d70a4, 0xc19d70a4},
+{'4', 0xfdd1022f, 0xff8dff8d},
+{'l', 0x42847ae0, 0xc18e1478},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002198, 0x00008400},/*        ↘        x-advance: 132.000000 */
+{'M', 0x42fccccc, 0x4175c28f},
+{'l', 0xc2847ae0, 0xc18e147b},
+{'l', 0x41666660, 0xc1666665},
+{'l', 0xc28bd70a, 0xc28bd70a},
+{'l', 0x419d70a4, 0xc19d70a0},
+{'4', 0x022f022f, 0xff8d0073},
+{'l', 0x418e1478, 0x42847ae1},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002199, 0x00008400},/*        ↙        x-advance: 132.000000 */
+{'M', 0x40947ae1, 0x4175c28f},
+{'l', 0x418e147b, 0xc2847ae1},
+{'l', 0x41666666, 0x41666664},
+{'l', 0x428bd70a, 0xc28bd70a},
+{'l', 0x419d70a0, 0x419d70a0},
+{'4', 0x022ffdd1, 0x00730073},
+{'l', 0xc2847ae1, 0x418e147a},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000021e9, 0x00007200},/*        ⇩        x-advance: 114.000000 */
+{'M', 0x42399999, 0xc2f9eb85},
+{'8', 0x0f6ff938, 0x45621838},
+{'8', 0x532e2220, 0x6002300c},
+{'q', 0xc0947ae0, 0x41451eb8},
+{0, 0xc16b8520, 0x41a147b0},
+{'8', 0x03fb01fe, 0x05fb02fe},
+{'8', 0x06fb02fe, 0x05ff02fe},
+{'8', 0x05030500, 0x012e0011},
+{'8', 0x07350221, 0x0b2e0821},
+{'8', 0x0e330622, 0x0121070f},
+{'8', 0xeb1afa11, 0xf133ef14},
+{'q', 0x40570a40, 0x3ef5c200},
+{0, 0x40b33330, 0x406147a0},
+{'q', 0x40b33330, 0x41028f5c},
+{0, 0x3f23d700, 0x41ab851e},
+{'q', 0xc075c280, 0x4128f5c4},
+{0, 0xc11c28f8, 0x41947ae2},
+{'q', 0xc0c7ae10, 0x4107ae14},
+{0, 0xc16b8518, 0x41666665},
+{'q', 0xc0e147b0, 0x40800001},
+{0, 0xc17d70a8, 0x40bd70a4},
+{'q', 0xc175c28c, 0x40051eb9},
+{0, 0xc1d33332, 0x3f23d710},
+{'q', 0xc14f5c2a, 0xbff5c290},
+{0, 0xc1accccd, 0xc1028f5c},
+{'q', 0xc128f5c2, 0xc0c28f5c},
+{0, 0xc1599999, 0xc187ae14},
+{'8', 0xa8f8d5f4, 0xad1edb03},
+{'8', 0xe90ef406, 0xe715f507},
+{'8', 0xef10f20c, 0xe918fb05},
+{'8', 0xed13ef13, 0xc42ff110},
+{'8', 0xdfdbf8f8, 0xd5d2e8e4},
+{'8', 0xd6e4ecf0, 0xe202f0f9},
+{'8', 0xf01cf20a, 0xf821fd13},
+{'8', 0xf11cfd0e, 0xe411f60b},
+{'8', 0xe307f802, 0xe007ec05},
+{'8', 0xe60af603, 0xe50ff007},
+{'q', 0x40f5c28c, 0xc12147b0},
+{0, 0x417851ea, 0xc1333338},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000023ce, 0x00008000},/*        ⏎        x-advance: 128.000000 */
+{'M', 0x429b3333, 0xc2f00000},
+{'l', 0x422c28f6, 0x00000000},
+{'l', 0x00000000, 0x42b0a3d7},
+{'l', 0xc28570a4, 0x36000000},
+{'l', 0x00000000, 0x41bd70a3},
+{'l', 0xc23a3d70, 0xc23a3d70},
+{'l', 0x423a3d70, 0xc23a3d70},
+{'4', 0x00bd0000, 0x000000bd},
+{'l', 0x00000000, 0xc22a3d72},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42aa3d70, 0xc2ddc28f},
+{'l', 0x00000000, 0x422a3d70},
+{'l', 0xc21b851e, 0x00000000},
+{'l', 0x00000000, 0xc151eb80},
+{'l', 0xc1d70a3d, 0x41d70a3c},
+{'l', 0x41d70a3d, 0x41d70a3c},
+{'l', 0x00000000, 0xc151eb84},
+{'4', 0x00000215, 0xfdd00000},
+{'l', 0xc1deb854, 0x37000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002408, 0x00008000},/*        ␈        x-advance: 128.000000 */
+{'M', 0x423ccccd, 0xc2cd1eb8},
+{'l', 0x42900000, 0x00000000},
+{'l', 0x00000000, 0x429a3d70},
+{'4', 0x0000fdc0, 0xfeccfecd},
+{'l', 0x4219999a, 0xc21a3d70},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x424ccccc, 0xc2b9eb85},
+{'l', 0xc1e66665, 0x41e7ae14},
+{'l', 0x41e66665, 0x41e7ae14},
+{'4', 0x000001d3, 0xfe310000},
+{'l', 0xc269999a, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x424d70a4, 0xc29f5c29},
+{'l', 0x40ccccc8, 0xc0d1eb80},
+{'l', 0x41800002, 0x417ae148},
+{'l', 0x417d70a0, 0xc17ae148},
+{'l', 0x40d1eb80, 0x40d1eb80},
+{'l', 0xc17d70a0, 0x417ae148},
+{'l', 0x417d70a0, 0x417ae148},
+{'l', 0xc0d1eb80, 0x40d1eb88},
+{'l', 0xc17d70a0, 0xc17ae148},
+{'l', 0xc1800002, 0x417ae148},
+{'4', 0xffccffcd, 0xff83007e},
+{'l', 0xc17d70a0, 0xc17ae148},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x0000240f, 0x00008000},/*        ␏        x-advance: 128.000000 */
+{'M', 0x42800000, 0xc2d33333},
+{'l', 0x423a3d70, 0x423a3d71},
+{'l', 0xc1bd70a4, 0x00000000},
+{'l', 0x00000000, 0x42128f5c},
+{'l', 0xc2370a3d, 0xb6000000},
+{'4', 0xfedb0000, 0x0000ff43},
+{'l', 0x423a3d70, 0xc23a3d71},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42800000, 0xc2bb851e},
+{'l', 0xc1d70a3e, 0x41d851e8},
+{'l', 0x4151eb84, 0x00000000},
+{'l', 0x00000000, 0x42128f5c},
+{'l', 0x41dc28f4, 0x36000000},
+{'4', 0xfedb0000, 0x00000068},
+{'l', 0xc1d70a3c, 0xc1d851e8},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000025a1, 0x00008000},/*        □        x-advance: 128.000000 */
+{'M', 0x414f5c29, 0xc2e6147b},
+{'l', 0x42cc28f6, 0x00000000},
+{'4', 0x03300000, 0x0000fcd0},
+{'l', 0x35800000, 0xc2cc28f6},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41ca3d70, 0xc2cd70a4},
+{'l', 0x00000000, 0x429ae148},
+{'4', 0x0000026b, 0xfd950000},
+{'l', 0xc29ae148, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000025b2, 0x0000a000},/*        ▲        x-advance: 160.000000 */
+{'M', 0x42a00000, 0xc2eccccc},
+{'4', 0x036301f4, 0x0000fc18},
+{'l', 0x427a3d70, 0xc2d8f5c2},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000025b3, 0x00008000},/*        △        x-advance: 128.000000 */
+{'M', 0x42800000, 0xc2e7ae14},
+{'4', 0x033d01e8, 0x0000fc2f},
+{'l', 0x42747ae2, 0xc2cf5c28},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42800000, 0xc2b6b852},
+{'4', 0x0215fec4, 0x00000278},
+{'l', 0xc21e1478, 0xc28570a4},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000025b6, 0x0000a000},/*        ▶        x-advance: 160.000000 */
+{'M', 0x43063d70, 0xc28051eb},
+{'4', 0x01f4fc9d, 0xfc180000},
+{'l', 0x42d8f5c1, 0x427a3d70},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000025bc, 0x0000a000},/*        ▼        x-advance: 160.000000 */
+{'M', 0x42a00000, 0xc11eb852},
+{'4', 0xfc9dfe0c, 0x000003e8},
+{'l', 0xc27a3d70, 0x42d8f5c2},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000025c0, 0x0000a000},/*        ◀        x-advance: 160.000000 */
+{'M', 0x41ce147b, 0xc28051eb},
+{'4', 0xfe0c0363, 0x03e80000},
+{'l', 0xc2d8f5c1, 0xc27a3d70},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000025c7, 0x00008000},/*        ◇        x-advance: 128.000000 */
+{'M', 0x42800000, 0xc2f6b852},
+{'l', 0x426d70a4, 0x426d70a4},
+{'4', 0x01dafe26, 0xfe26fe26},
+{'l', 0x426d70a4, 0xc26d70a4},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42800000, 0xc2d3d70a},
+{'l', 0xc227ae14, 0x4227ae14},
+{'4', 0x014f014f, 0xfeb1014f},
+{'l', 0xc227ae14, 0xc227ae14},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000025cb, 0x00008000},/*        ○        x-advance: 128.000000 */
+{'M', 0x427fffff, 0xc2e5c28f},
+{'q', 0x415c28f4, 0x00000000},
+{0, 0x41cc28f6, 0x40d99990},
+{'q', 0x413c28f8, 0x40d999a0},
+{0, 0x41947ae4, 0x41947ae4},
+{'q', 0x40d99990, 0x413c28f8},
+{0, 0x40d99990, 0x41cc28f6},
+{'q', 0x00000000, 0x415c28f4},
+{0, 0xc0d99990, 0x41cc28f4},
+{'q', 0xc0d999a0, 0x413c28f6},
+{0, 0xc1947ae4, 0x41947ae1},
+{'q', 0xc13c28f8, 0x40d9999a},
+{0, 0xc1cc28f6, 0x40d9999a},
+{'q', 0xc15c28f4, 0x00000000},
+{0, 0xc1cc28f4, 0xc0d9999a},
+{'q', 0xc13c28f6, 0xc0d99998},
+{0, 0xc1947ae1, 0xc1947ae1},
+{'q', 0xc0d9999a, 0xc13c28f4},
+{0, 0xc0d9999a, 0xc1cc28f4},
+{'q', 0x00000000, 0xc15c28f4},
+{0, 0x40d9999a, 0xc1cc28f6},
+{'q', 0x40d99998, 0xc13c28f8},
+{0, 0x41947ae1, 0xc1947ae4},
+{'9', 0xffca005e, 0xffca00cc},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42800000, 0xc2cb3333},
+{'q', 0xc17851ec, 0x00000000},
+{0, 0xc1d47ae2, 0x4130a3d8},
+{'q', 0xc130a3d6, 0x4130a3d8},
+{0, 0xc130a3d6, 0x41d47ae0},
+{'q', 0x00000000, 0x417851ec},
+{0, 0x4130a3d6, 0x41d47ae2},
+{'q', 0x4130a3d8, 0x4130a3d6},
+{0, 0x41d47ae2, 0x4130a3d6},
+{'q', 0x417851e8, 0x00000000},
+{0, 0x41d47ae0, 0xc130a3d6},
+{'q', 0x4130a3d8, 0xc130a3d8},
+{0, 0x4130a3d8, 0xc1d47ae2},
+{'q', 0x00000000, 0xc17851e8},
+{0, 0xc130a3d8, 0xc1d47ae0},
+{'q', 0xc130a3d8, 0xc130a3d8},
+{0, 0xc1d47ae0, 0xc130a3d8},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002663, 0x00008000},/*        ♣        x-advance: 128.000000 */
+{'M', 0x42800000, 0xc2ed1eb8},
+{'q', 0x41666668, 0x00000000},
+{0, 0x41c33334, 0x41133330},
+{'q', 0x41200000, 0x41133338},
+{0, 0x41200000, 0x41ba3d70},
+{'q', 0x00000000, 0x408f5c30},
+{0, 0xbf8f5c40, 0x410f5c30},
+{'q', 0x412b8520, 0x402e1460},
+{0, 0x419147b0, 0x4147ae10},
+{'q', 0x40ee1470, 0x411c28f8},
+{0, 0x40ee1470, 0x41a66666},
+{'q', 0x00000000, 0x40051ec0},
+{0, 0xbea3d700, 0x40851eb8},
+{'q', 0xbfb85200, 0x4147ae16},
+{0, 0xc1333330, 0x41aae148},
+{'q', 0xc11c28f8, 0x410e147b},
+{0, 0xc1b851ec, 0x410e147b},
+{'q', 0xc163d708, 0x00000000},
+{0, 0xc1c28f5c, 0xc123d70b},
+{'8', 0x3aa522df, 0x179817c6},
+{'q', 0xc107ae16, 0x00000000},
+{0, 0xc1800001, 0xc0800000},
+{'q', 0xc0fae146, 0xc0851eba},
+{0, 0xc151eb84, 0xc13fffff},
+{'q', 0xc0a8f5c2, 0xc0fae148},
+{0, 0xc0a8f5c2, 0xc1933334},
+{'q', 0x00000000, 0xc147ae14},
+{0, 0x40e66666, 0xc1ab851e},
+{'q', 0x40e66668, 0xc10f5c28},
+{0, 0x41933333, 0xc13d70a0},
+{'q', 0xbf8f5c30, 0xc08f5c30},
+{0, 0xbf8f5c30, 0xc10f5c30},
+{'q', 0x00000000, 0xc16e1478},
+{0, 0x411d70a4, 0xc1bd70a0},
+{'9', 0xffba004e, 0xffba00c4},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42800000, 0xc2d9eb85},
+{'q', 0xc1170a40, 0x00000000},
+{0, 0xc181eb86, 0x40d70a40},
+{'q', 0xc0d99998, 0x40d70a40},
+{0, 0xc0d99998, 0x418147ac},
+{'9', 0x002c0000, 0x00570017},
+{'4', 0x00410023, 0x0001ffb5},
+{'q', 0xc1147ae0, 0x3ea3d700},
+{0, 0xc17c28f4, 0x40e147b0},
+{'q', 0xc0cf5c28, 0x40d70a38},
+{0, 0xc0cf5c28, 0x417ffffc},
+{'q', 0x00000000, 0x40f5c290},
+{0, 0x40947ae0, 0x415c28f6},
+{'q', 0x40dc28f8, 0x4111eb86},
+{0, 0x4191eb86, 0x4111eb86},
+{'9', 0x00000066, 0xffa8009c},
+{'4', 0xffc20027, 0x003e0026},
+{'8', 0x41432a19, 0x17581729},
+{'q', 0x41199998, 0x00000000},
+{0, 0x41828f5c, 0xc0d70a3c},
+{'q', 0x40d70a40, 0xc0d70a3c},
+{0, 0x40d70a40, 0xc18147af},
+{'q', 0x00000000, 0xc1170a3c},
+{0, 0xc0cf5c20, 0xc180a3d6},
+{'9', 0xffcbffcd, 0xffc9ff81},
+{'4', 0xffffffb6, 0xffbf0023},
+{'8', 0xa917d517, 0xbdf2dd00},
+{'8', 0xb0c0d2ef, 0xde97ded2},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002715, 0x00008000},/*        ✕        x-advance: 128.000000 */
+{'M', 0x425b851e, 0xc2800000},
+{'l', 0xc21eb851, 0xc21eb852},
+{'l', 0x4111eb84, 0xc111eb80},
+{'l', 0x421eb852, 0x421eb852},
+{'l', 0x421eb852, 0xc21eb852},
+{'l', 0x4111eb80, 0x4111eb80},
+{'l', 0xc21eb852, 0x421eb852},
+{'l', 0x421eb852, 0x421eb852},
+{'l', 0xc111eb80, 0x4111eb85},
+{'l', 0xc21eb852, 0xc21eb851},
+{'4', 0x013dfec3, 0xffb8ffb8},
+{'l', 0x421eb851, 0xc21eb852},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002b21, 0x0000a000},/*        ⬡        x-advance: 160.000000 */
+{'M', 0x42a00000, 0xc18ccccd},
+{'l', 0x42251eb8, 0xc1beb851},
+{'l', 0x00000000, 0xc23eb851},
+{'l', 0xc2251eb8, 0xc1beb854},
+{'4', 0x00befeb6, 0x017d0000},
+{'l', 0x42251eb9, 0x41beb851},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42a00000, 0xc0b33333},
+{'l', 0xc24eb852, 0xc1ef5c29},
+{'l', 0x00000000, 0xc26e147b},
+{'l', 0x424eb852, 0xc1ef5c28},
+{'4', 0x00ef019d, 0x01dc0000},
+{'l', 0xc24eb850, 0x41ef5c29},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002b22, 0x0000a000},/*        ⬢        x-advance: 160.000000 */
+{'M', 0x42a00000, 0xc0b33333},
+{'l', 0xc24eb852, 0xc1ef5c29},
+{'l', 0x00000000, 0xc26e147b},
+{'l', 0x424eb852, 0xc1ef5c28},
+{'4', 0x00ef019d, 0x01dc0000},
+{'l', 0xc24eb850, 0x41ef5c29},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002b23, 0x0000a000},/*        ⬣        x-advance: 160.000000 */
+{'M', 0x430c51eb, 0xc2966666},
+{'l', 0x00000000, 0x00000000},
+{'8', 0x1c060b06, 0x1cfa1000},
+{'l', 0xc1d99998, 0x423c28f5},
+{'8', 0x13ec0ef9, 0x07e607eb},
+{'4', 0x0000fff6, 0xff590000},
+{'9', 0xfff90000, 0xfff9fff9},
+{'l', 0xc0ccccd0, 0x00000000},
+{'9', 0x0000fff9, 0x0007fff9},
+{'4', 0x01270000, 0x0000fee7},
+{'l', 0x00000000, 0xc213d70a},
+{'9', 0xfff90000, 0xfff9fff9},
+{'l', 0xc0ccccd0, 0x00000000},
+{'9', 0x0000fff9, 0x0007fff9},
+{'4', 0x00a70000, 0x0000fff6},
+{'8', 0xf9e600f4, 0xedecf9f2},
+{'l', 0xc1d99998, 0xc23c28f5},
+{'8', 0xe4faf5fa, 0xe406ef00},
+{'l', 0x41d99998, 0xc23c28f6},
+{'8', 0xed14f506, 0xf81af80c},
+{'l', 0x42599999, 0x00000000},
+{'8', 0x081a000e, 0x1314070e},
+{'l', 0x41d99998, 0x423c28f6},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x00002b4d, 0x00008000},/*        ⭍        x-advance: 128.000000 */
+{'M', 0x42a8a3d7, 0xc2cbd70a},
+{'l', 0x3f23d700, 0x3ea3d700},
+{'8', 0xed0df805, 0xe31ff608},
+{'q', 0x403851e0, 0xc0147ae0},
+{0, 0x40ccccd0, 0xc051eba0},
+{'q', 0x410cccc8, 0xc0199980},
+{0, 0x419ae148, 0x40851ec0},
+{'q', 0x4123d708, 0x40d1eb80},
+{0, 0x41266660, 0x418b8520},
+{'8', 0x5ee83100, 0x42c62ce8},
+{'q', 0xc0c7ae20, 0x40800000},
+{0, 0xc15eb858, 0x40800000},
+{'9', 0x0000ffcc, 0xffe9ff90},
+{'l', 0x3ff5c280, 0xc0947ae0},
+{'q', 0x416147b0, 0x40a8f5c0},
+{0, 0x41bae148, 0xbf4ccd00},
+{'8', 0xcc2df019, 0xb812dd13},
+{'q', 0x00000000, 0xc1051eb8},
+{0, 0xc1000000, 0xc1547ae0},
+{'q', 0xc107ae18, 0xc0ae1480},
+{0, 0xc175c290, 0xc06b8520},
+{'9', 0x000cffd5, 0x0035ffba},
+{'l', 0x3f4ccd00, 0x3ea3d700},
+{'l', 0xc0e147b0, 0x4170a3d8},
+{'l', 0x3f75c280, 0x3ef5c200},
+{'l', 0xc1147ae0, 0x41c00000},
+{'l', 0xbea3d700, 0x40b851f0},
+{'l', 0xc023d700, 0x40b33330},
+{'l', 0xc08f5c30, 0xbff5c280},
+{'l', 0xc13d70a0, 0x41ca3d70},
+{'0', 0x00ff0001, 0xfdf81df4},
+{'0', 0x0feb1cf4, 0xe20ee7f9},
+{'l', 0xbf75c280, 0xbef5c2c0},
+{'l', 0x41599998, 0xc1e7ae14},
+{'l', 0xc0851eb8, 0xbff5c280},
+{'l', 0x4023d710, 0xc0b33338},
+{'l', 0x407ffff0, 0xc0851eb0},
+{'4', 0xff4b005e, 0x00020007},
+{'l', 0x40e147b0, 0xc170a3d8},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x422ccccd, 0xc1aa3d70},
+{'l', 0xbfcccce0, 0x3e23d700},
+{'8', 0xe2eff0fb, 0xe8e4f2f4},
+{'8', 0xdabeebe3, 0xc6bdedd5},
+{'8', 0xd2f1e9f2, 0xcd0be7fe},
+{'8', 0xdb20ec0b, 0xe926f40f},
+{'l', 0x400f5c28, 0xbf8f5c20},
+{'8', 0xf810fe06, 0xed1df513},
+{'8', 0xd028e820, 0xe901f405},
+{'8', 0xf1f5f8ff, 0xf6c8f1eb},
+{'9', 0x0002ffef, 0x0007ffde},
+{'l', 0xc01999a0, 0x3f23d700},
+{'8', 0x01fa01fd, 0x03f202f9},
+{'8', 0x03a70bcf, 0xecd2fae6},
+{'8', 0xd6e2f0ec, 0xcffbe8f9},
+{'8', 0xd20ce701, 0xdb1cec0a},
+{'8', 0xe722f014, 0xe450e728},
+{'8', 0x032aff15, 0x13270614},
+{'l', 0xbf75c280, 0x3fb85200},
+{'8', 0xf8baf0de, 0x20bf06df},
+{'8', 0x18e408f4, 0x1af00af8},
+{'8', 0x3dff22f4, 0x1e2b190a},
+{'9', 0x0005001a, 0xfffa0042},
+{'l', 0x3fb851f0, 0xbef5c300},
+{'8', 0xf133f620, 0xfe35fb13},
+{'8', 0x143a0221, 0x3021111a},
+{'8', 0x37fb1a06, 0x28e717f8},
+{'8', 0x1ede0ff2, 0x15db0af1},
+{'9', 0x0006fff2, 0x0008ffec},
+{'l', 0xc00f5c28, 0x3f75c280},
+{'8', 0x26cd10db, 0x19f90cfa},
+{'8', 0x1d070c00, 0x302f1d0f},
+{'8', 0x3043182a, 0x201a1010},
+{'8', 0x130a0806, 0x15060705},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000041e9, 0x00007e00},/*        䇩        x-advance: 126.000000 */
+{'g', 0x00000000, 0x00000000},
+{'*', 0xFF0000FF, 0x00000000},
+{'M', 0x425c28f5, 0xbe23d70a},
+{'q', 0xbef5c280, 0x00000000},
+{0, 0xbf4cccc0, 0x00000000},
+{'q', 0xc1428f5c, 0xbef5c28f},
+{0, 0xc1a3d70a, 0xbfa3d70a},
+{'8', 0xedb6fdd4, 0xf9e6faf4},
+{'8', 0xfee2fef8, 0xfbde00e8},
+{'8', 0xdfd0f5e6, 0xdbdeeceb},
+{'8', 0xf2fbf8fa, 0xf307fb00},
+{'9', 0xfffd0003, 0xfff90008},
+{'4', 0xfffb0005, 0xfffeffff},
+{'8', 0xe9fdf4fd, 0xdd0af500},
+{'8', 0xfa08fa03, 0x08100007},
+{'8', 0x060e0a0a, 0xfd03ff02},
+{'8', 0xd901fe01, 0xd201dc00},
+{'8', 0x9615b506, 0xcd2af007},
+{'8', 0xc542e020, 0xdb38e522},
+{'8', 0xf139f813, 0xfa45fa23},
+{'8', 0x073d001d, 0x17380822},
+{'8', 0x050b0507, 0xf4150007},
+{'8', 0xe826e918, 0xf80bff07},
+{'8', 0xd906f505, 0xe602f001},
+{'8', 0xbafacd03, 0xf4f9fbff},
+{'8', 0xa4c6c7d1, 0x9bfbecfa},
+{'8', 0xc903cf01, 0xf423f007},
+{'8', 0x14280215, 0x1d150a0a},
+{'8', 0x1810110a, 0x04090605},
+{'8', 0xed03ff03, 0xe802ef01},
+{'8', 0xf213f603, 0x061efa17},
+{'8', 0x4d251a11, 0x5b1c3213},
+{'8', 0x19020a02, 0x2a021101},
+{'8', 0x08040601, 0x020e0203},
+{'8', 0x0a2c0114, 0x101a0711},
+{'8', 0x23190808, 0x2115180f},
+{'8', 0x1a0f0807, 0x160a1006},
+{'8', 0x0c0c0503, 0x110e0608},
+{'8', 0x15050a05, 0x17f80b00},
+{'8', 0x11f406fb, 0x1cea14f2},
+{'8', 0x0bed07f8, 0x0cbf0ae0},
+{'8', 0x07f001f6, 0x10f807f8},
+{'8', 0x130a0600, 0x0f070a06},
+{'8', 0x13010501, 0x3cf61400},
+{'8', 0x2af810fd, 0x3dec31f9},
+{'8', 0x0edf08f6, 0x0be803f0},
+{'8', 0x1ef90ef4, 0x130c0b03},
+{'8', 0x18230708, 0x19251320},
+{'8', 0x0c070606, 0x13f50c02},
+{'8', 0x09c906f1, 0x00c603d8},
+{'8', 0xe3cffdf1, 0xebdff1e9},
+{'8', 0xefedfbf6, 0xf5ecf5f6},
+{'8', 0x0cd900f5, 0x07f006f4},
+{'8', 0x01f201fd, 0x07e701e9},
+{'8', 0x1a0b05fe, 0x110a0c08},
+{'8', 0x0ffa0602, 0x07f606fa},
+{'8', 0x05f502fd, 0x01ec01f8},
+{'q', 0xbfa3d700, 0x3e23d70a},
+{0, 0xc03851f0, 0x00000000},
+{'z', 0x00000000, 0x00000000},
+{'F', 0x00000000, 0x00000000},
+{'G', 0x00000000, 0x00000000},
+{'@', 0x000071e9, 0x0000a000},/*        燩        x-advance: 160.000000 */
+{'M', 0x42c00000, 0xc2e1eb85},
+{'8', 0x06600023, 0x0e440634},
+{'8', 0x1a090810, 0x10fb0bfe},
+{'8', 0x08ef05fd, 0x04df03f2},
+{'9', 0x0000ffed, 0x0000ffc0},
+{'4', 0x0000ff9d, 0x0011fffb},
+{'8', 0x28f61df6, 0x0d080a00},
+{'9', 0x0003000b, 0x0013002a},
+{'4', 0x00100020, 0xffdf0041},
+{'8', 0xdf5de040, 0x185eff1d},
+{'q', 0x414a3d70, 0x409999a0},
+{0, 0x418851f0, 0x41051eb8},
+{'8', 0x350e1c23, 0x0be80ef5},
+{'q', 0xbfd70a80, 0xbea3d700},
+{0, 0xc0fd70a0, 0xc06147c0},
+{'q', 0xc1333338, 0xc0b33330},
+{0, 0xc180a3d8, 0xc0ccccc0},
+{'8', 0x0fadfad9, 0x18d611dd},
+{'9', 0x0007fffa, 0x00110003},
+{'4', 0x000a000a, 0xfff10022},
+{'8', 0xef57e838, 0x3c65061e},
+{'q', 0x417851f0, 0x413ae148},
+{0, 0x41a70a40, 0x418eb852},
+{'8', 0x4712312a, 0x07df0ff0},
+{'8', 0xcbbef9f0, 0xb6add1cc},
+{'8', 0xd2c6e6e1, 0xe8d3ede6},
+{'8', 0xfddefbee, 0x0adc01f0},
+{'4', 0x000affe8, 0x0035ffff},
+{'q', 0xbe23d800, 0x412e147c},
+{0, 0xc1066668, 0x418b8520},
+{'9', 0x0034ffbf, 0x0034ff53},
+{'4', 0x0000ffe8, 0x0022fff8},
+{'q', 0xc00f5c20, 0x411eb852},
+{0, 0x3ea3d700, 0x41b851ec},
+{'8', 0x4509340a, 0x1cf31000},
+{'8', 0x0bef0bf5, 0xf9f000fa},
+{'q', 0xc06147c0, 0xc03851eb},
+{0, 0xc0a147b0, 0xc17ae147},
+{'q', 0xbfc28f40, 0xc14ccccc},
+{0, 0x3f0f5c00, 0xc1ab851e},
+{'8', 0xd907df08, 0xf2edfbff},
+{'8', 0xe4d1f5eb, 0xf4ddf1e9},
+{'8', 0x1dcc02f4, 0x3ec01ad8},
+{'q', 0xc03d70a0, 0x408cccc8},
+{0, 0xc0d47ae0, 0x4167ae10},
+{'8', 0x2ce921f4, 0x0be70bf6},
+{'8', 0xeae300e4, 0xab17eaff},
+{'q', 0x408a3d70, 0xc12e147a},
+{0, 0x40f33330, 0xc1747ae2},
+{'8', 0xb952dd1a, 0xe721f01a},
+{'8', 0xf3fdf807, 0xfcd9fcf6},
+{'q', 0xc18ccccd, 0x3e23d700},
+{0, 0xc2051eb8, 0x4159999c},
+{'8', 0x0eb12bcd, 0xecf8f5f5},
+{'q', 0x3ea3d70b, 0xbf8f5c40},
+{0, 0x40428f5c, 0xc0800000},
+{'q', 0x40c7ae14, 0xc0dc28f8},
+{0, 0x4183d70a, 0xc13ae148},
+{'q', 0x4123d70a, 0xc09999a0},
+{0, 0x41a51eb8, 0xc0b851f0},
+{'8', 0xf921fe1e, 0xe1f9fc03},
+{'8', 0xe4e8e9f9, 0xfdb8fbf0},
+{'4', 0x0001ffd0, 0x0023ffd1},
+{'8', 0x24ca1ed8, 0x00e505f3},
+{'8', 0xa622e7cb, 0xd349da34},
+{'9', 0xfff90015, 0xfff90053},
+{'4', 0x00000047, 0xffec0005},
+{'q', 0x40051ec0, 0xc1028f58},
+{0, 0x41200000, 0xc12e1478},
+{'q', 0x40fd70a8, 0xc02e1480},
+{0, 0x41a33334, 0x3ea3d700},
+{'8', 0x09300b2e, 0xdb0cff01},
+{'8', 0xc027d20e, 0xef52ef18},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42bb851e, 0xc2833333},
+{'8', 0x05f400f9, 0x1ae017e8},
+{'8', 0xf0cb08e8, 0xfbf5fbfb},
+{'8', 0x06f200f8, 0x0bfd05fd},
+{'8', 0x0e060800, 0x1559272e},
+{'8', 0xf810fe08, 0xf70cfb07},
+{'8', 0xf809fd04, 0xfb05fb05},
+{'8', 0xf206fb06, 0xf5fbfa00},
+{'9', 0xfffbfffb, 0xfffafff4},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42a33333, 0xc29ccccd},
+{'8', 0x08ed00f5, 0x13f908f9},
+{'8', 0x13070b00, 0x07130707},
+{'8', 0xf913000b, 0xed08f908},
+{'8', 0xedf8f500, 0xf8edf8f8},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42b7ae14, 0xc2a00000},
+{'8', 0x08ed00f5, 0x13f808f8},
+{'8', 0x13080b00, 0x07130708},
+{'8', 0xf913000b, 0xed07f907},
+{'8', 0xedf9f500, 0xf8edf8f9},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x000081e9, 0x0000a000},/*        臩        x-advance: 160.000000 */
+{'M', 0x429dc28f, 0xc2f47ae1},
+{'8', 0x191a011a, 0x16f40b00},
+{'8', 0x2cbf0af4, 0x17df11e3},
+{'8', 0x13ff05fc, 0x230c1c05},
+{'8', 0x0d200707, 0x0b27071d},
+{'8', 0x00050005, 0xda0cfe02},
+{'8', 0xc027d20e, 0xef52ef18},
+{'8', 0x06600023, 0x0e440634},
+{'8', 0x1a090810, 0x10fb0bfe},
+{'8', 0x08ef05fd, 0x04df03f2},
+{'9', 0x0000ffed, 0x0000ffc0},
+{'4', 0x0000ff9d, 0x0011fffb},
+{'8', 0x28f61df6, 0x0d080a00},
+{'9', 0x0003000b, 0x0013002a},
+{'4', 0x00100020, 0xffdf0041},
+{'8', 0xdf5de040, 0x185eff1d},
+{'q', 0x414a3d70, 0x409999a0},
+{0, 0x418851f0, 0x41051eb8},
+{'8', 0x350e1c23, 0x0be80ef5},
+{'q', 0xbfd70a80, 0xbea3d700},
+{0, 0xc0fd70a0, 0xc06147c0},
+{'q', 0xc1333338, 0xc0b33330},
+{0, 0xc180a3d8, 0xc0ccccc0},
+{'8', 0x0fadfad9, 0x18d611dd},
+{'9', 0x0007fffa, 0x00110003},
+{'4', 0x000a000a, 0xfff10022},
+{'8', 0xef57e838, 0x3c65061e},
+{'q', 0x417851f0, 0x413ae148},
+{0, 0x41a70a40, 0x418eb852},
+{'8', 0x4712312a, 0x07df0ff0},
+{'8', 0xcbbef9f0, 0xb6add1cc},
+{'8', 0xd2c6e6e1, 0xe8d3ede6},
+{'8', 0xfddefbee, 0x0adc01f0},
+{'4', 0x000affe8, 0x0035ffff},
+{'q', 0xbe23d800, 0x412e147c},
+{0, 0xc1066668, 0x418b8520},
+{'9', 0x0034ffbf, 0x0034ff53},
+{'4', 0x0000ffe8, 0x0022fff8},
+{'q', 0xc00f5c20, 0x411eb852},
+{0, 0x3ea3d700, 0x41b851ec},
+{'8', 0x4509340a, 0x1cf31000},
+{'8', 0x0bef0bf5, 0xf9f000fa},
+{'q', 0xc06147c0, 0xc03851eb},
+{0, 0xc0a147b0, 0xc17ae147},
+{'q', 0xbfc28f40, 0xc14ccccc},
+{0, 0x3f0f5c00, 0xc1ab851e},
+{'8', 0xd907df08, 0xf2edfbff},
+{'8', 0xe4d1f5eb, 0xf4ddf1e9},
+{'8', 0x1dcc02f4, 0x3ec01ad8},
+{'q', 0xc03d70a0, 0x408cccc8},
+{0, 0xc0d47ae0, 0x4167ae10},
+{'8', 0x2ce921f4, 0x0be70bf6},
+{'8', 0xeae300e4, 0xab17eaff},
+{'q', 0x408a3d70, 0xc12e147a},
+{0, 0x40f33330, 0xc1747ae2},
+{'8', 0xb952dd1a, 0xe721f01a},
+{'8', 0xf3fdf807, 0xfcd9fcf6},
+{'q', 0xc18ccccd, 0x3e23d700},
+{0, 0xc2051eb8, 0x4159999c},
+{'8', 0x0eb12bcd, 0xecf8f5f5},
+{'q', 0x3ea3d70b, 0xbf8f5c40},
+{0, 0x40428f5c, 0xc0800000},
+{'q', 0x40c7ae14, 0xc0dc28f8},
+{0, 0x4183d70a, 0xc13ae148},
+{'q', 0x4123d70a, 0xc09999a0},
+{0, 0x41a51eb8, 0xc0b851f0},
+{'8', 0xf921fe1e, 0xe1f9fc03},
+{'8', 0xe4e8e9f9, 0xfdb8fbf0},
+{'4', 0x0001ffd0, 0x0023ffd1},
+{'8', 0x24ca1ed8, 0x00e505f3},
+{'8', 0xa622e7cb, 0xd349da34},
+{'9', 0xfff90015, 0xfff90053},
+{'4', 0x00000047, 0xffec0005},
+{'9', 0xffa20018, 0xff9f008b},
+{'4', 0xfffbffff, 0xffe2fffe},
+{'8', 0xd403e3fd, 0xdd1ff107},
+{'9', 0xffc70042, 0xffc90075},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42b7ae14, 0xc2a00000},
+{'8', 0x08ed00f5, 0x13f808f8},
+{'8', 0x13080b00, 0x07130708},
+{'8', 0xf913000b, 0xed07f907},
+{'8', 0xedf9f500, 0xf8edf8f9},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42a33333, 0xc29ccccd},
+{'8', 0x08ed00f5, 0x13f908f9},
+{'8', 0x13070b00, 0x07130707},
+{'8', 0xf913000b, 0xed08f908},
+{'8', 0xedf8f500, 0xf8edf8f8},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42bb851e, 0xc2830a3d},
+{'8', 0x04f400f9, 0x1ae017e8},
+{'8', 0xf0cb08e8, 0xfbf5fbfb},
+{'8', 0x06f200f8, 0x0bfd05fd},
+{'8', 0x0e060800, 0x1559272e},
+{'8', 0xf810fe08, 0xf70cfb07},
+{'8', 0xf809fd04, 0xfb05fb05},
+{'8', 0xf206fb06, 0xf5fbfa00},
+{'q', 0xbf23d700, 0xbf23d700},
+{0, 0xbfcccd00, 0xbf385200},
+{'z', 0x00000000, 0x00000000},
+{'@', 0x0000e000, 0x00005f00},/*                x-advance: 95.000000 */
+{'M', 0x42b28f5c, 0xc288f5c2},
+{'8', 0x01fe0100, 0x2ad600d6},
+{'8', 0x02ff0200, 0xfeff00ff},
+{'8', 0xd6d5d600, 0xffff00ff},
+{'8', 0xff01ff00, 0xd62b002b},
+{'8', 0xfe01fe00, 0x02010001},
+{'8', 0x2a2a2a00, 0x01020002},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429428f6, 0xc2bd999a},
+{'8', 0x01ff0100, 0x2ad500d5},
+{'8', 0x01ff0100, 0xffff00ff},
+{'8', 0xd6d6d600, 0xfffe00fe},
+{'8', 0xff02ff00, 0xd62a002a},
+{'8', 0xff01ff00, 0x01010001},
+{'8', 0x2a2b2a00, 0x01010001},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x4288f5c2, 0xc2d451eb},
+{'8', 0x01fe0100, 0x2ad600d6},
+{'8', 0x01ff0100, 0xffff00ff},
+{'8', 0xd6d5d600, 0xffff00ff},
+{'8', 0xff01ff00, 0xd62b002b},
+{'8', 0xff01ff00, 0x01010001},
+{'8', 0x2a2a2a00, 0x01020002},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x429428f6, 0xc23851eb},
+{'8', 0x65633742, 0x48112e20},
+{'q', 0xbff5c280, 0x40428f60},
+{0, 0xc10e1480, 0x401eb850},
+{'q', 0xc0deb850, 0xbf0f5c20},
+{0, 0xc1899998, 0xc08ccccc},
+{'9', 0x001dffd4, 0x0022ff9f},
+{'4', 0x01a50000, 0x0000ffd8},
+{'l', 0x00000000, 0xc2528f5c},
+{'q', 0xc12147ac, 0xbf75c280},
+{0, 0xc1870a3c, 0xc107ae12},
+{'q', 0xc0d9999c, 0xc0f0a3d8},
+{0, 0xc0d9999c, 0xc18cccce},
+{'8', 0xf101f900, 0x9b9cc9bd},
+{'8', 0xb9efd2e0, 0xeb47e70f},
+{'q', 0x40deb850, 0x3f0f5c80},
+{0, 0x41899999, 0x4091eb90},
+{'9', 0xffe2002b, 0xffdd0061},
+{'4', 0xfe5b0000, 0x00000028},
+{'l', 0x00000000, 0x42528f5a},
+{'q', 0x412147b0, 0x3f75c300},
+{0, 0x41870a3e, 0x4107ae18},
+{'q', 0x40d999a0, 0x40f0a3d8},
+{0, 0x40d999a0, 0x418ccccc},
+{'9', 0x00070000, 0x000f0000},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x41b99999, 0xc263d70a},
+{'8', 0xda11ed07, 0xcc2ee313},
+{'q', 0xc18147ae, 0xc0a8f5c0},
+{0, 0xc19851eb, 0xbe75c200},
+{'q', 0xc03851ec, 0x40a147a8},
+{0, 0x411c28f6, 0x41833332},
+{'9', 0xffec0003, 0xffda000a},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x423f5c29, 0xc1d851eb},
+{'8', 0xf2430023, 0xe4c6f4e4},
+{'l', 0x00000000, 0x00000000},
+{'8', 0xdfc3f1e2, 0xdbc3ede0},
+{'8', 0xdbccede4, 0x6a354006},
+{'8', 0x233c191c, 0x07340719},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42699999, 0xc1ef5c29},
+{'8', 0xd134ef20, 0xdb13ef0c},
+{'9', 0xffe4000b, 0xffc7000b},
+{'l', 0x00000000, 0xbea3d700},
+{'8', 0xf0fff800, 0x95cbc0fa},
+{'q', 0xc0bd70a0, 0xc0ae1480},
+{0, 0xc16147ac, 0xc0ae1480},
+{'8', 0x0ebb00dd, 0x08f003f8},
+{'8', 0x35c914de, 0x26ed11f5},
+{'8', 0x33f918f9, 0x212e1015},
+{'8', 0x304b1923, 0x284e1527},
+{'9', 0x000c001c, 0x00170034},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x42a70a3e, 0xc1dae148},
+{'q', 0x403851e0, 0xc09eb850},
+{0, 0xc11c28f8, 0xc1828f5c},
+{'8', 0x2cf417fd, 0x25ed13f9},
+{'q', 0xc00f5c40, 0x404cccc8},
+{0, 0xc0a8f5d0, 0x40b851e8},
+{'9', 0x002a0081, 0x00020098},
+{'z', 0x00000000, 0x00000000},
+{'M', 0x426e147b, 0xc2466666},
+{'8', 0x1eed1cef, 0x14d515ef},
+{'8', 0xfdf000f9, 0xfaf1fef9},
+{'8', 0xfbf9fffe, 0xf9f0faf6},
+{'8', 0xfffbfffe, 0x0ceb00f6},
+{'8', 0x0cf50cf5, 0xf7f1fefb},
+{'8', 0xf6f1f9f6, 0xe311ec0b},
+{'8', 0xec2beb11, 0x020e0006},
+{'8', 0x0a130205, 0x0a17070e},
+{'8', 0xe8260315, 0x090f0205},
+{'q', 0x3fa3d700, 0x3f6147c0},
+{0, 0x3ff5c2a0, 0x3fae1480},
+{'z', 0x00000000, 0x00000000},
+};
+#define ctx_font_EMF_Camp_Font_name "EMF Camp Font"
+#endif

--- a/components/ctx/fonts/FONTLOG.txt
+++ b/components/ctx/fonts/FONTLOG.txt
@@ -1,0 +1,135 @@
+FONTLOG for the Raleway fonts
+
+This file provides detailed information on the Raleway Font Software.
+
+This information should be distributed along with the Raleway fonts and any
+derivative works.
+
+Basic Font Information
+
+Raleway is an elegant sans-serif typeface family. Initially designed by
+Matt McInerney as a single thin weight, it was expanded into a 9 weight family
+by Pablo Impallari and Rodrigo Fuenzalida in 2012 and iKerned by Igino Marini.
+In 2013 the Italics where added.
+
+It is a display face and the download features both old style and lining
+numerals, standard and discretionary ligatures, a pretty complete set of
+diacritics, as well as a stylistic alternate inspired by more geometric
+sans-serif typefaces than its neo-grotesque inspired default character
+set.
+
+It also has a sister display family, Raleway Dots.
+
+Also, the characters set has been expanded to cover 104 Latin languages:
+Afar, Afrikaans, Albanian, Azerbaijani, Basque, Belarusian, Bislama, Bosnian, Breton, Catalan, Chamorro, Chichewa, Comorian, Croatian, Czech, Danish, Dutch, English, Esperanto, Estonian, Faroese, Fijian, Filipino/Tagalog, Finnish, Flemish, French, Gaelic (Irish / Manx / Scottish), Gagauz, German, Gikuyu, Gilbertese/Kiribati, Greenlandic, Guarani, Haitian_Creole, Hawaiian, Hungarian, Icelandic, Igo/Igbo, Indonesian, Irish, Italian, Javanese, Kashubian, Kinyarwanda, Kirundi, Latin, Latvian, Lithuanian, Luba/Ciluba/Kasai, Luxembourgish, Malagasy, Malay, Maltese, Maori, Marquesan, Marshallese, Moldovan/Moldovian/Romanian, Montenegrin, Nauruan, Ndebele, Norwegian, Oromo, Palauan/Belauan, Polish, Portuguese, Quechua, Romanian, Romansh, Sami, Samoan, Sango, Serbian, Sesotho, Setswana/Sitswana/Tswana, Seychellois_Creole, SiSwati/Swati/Swazi, Silesian, Slovak, Slovenian, Somali, Sorbian, Sotho, Spanish, Swahili, Swedish, Tahitian, Tetum, Tok_Pisin, Tongan, Tsonga, Tswana, Tuareg/Berber, Turkish, Turkmen, Tuvaluan, Uzbek/Usbek, Wallisian, Walloon, Welsh, Xhosa, Yoruba, Zulu.
+
+The Roman Styles also include support for the following 17 Cyrillic languages:
+Balkar, Belarusian, Bosnian, Chukchi, Crimean_Tartar, Erzya, Karachay, Kumyk, Lak,
+Macedonian, Moksha, Montenegrin, Nanai, Nogai, Rusyn, Serbian, Ukranian
+
+Documentation can be found at https://www.theleagueofmoveabletype.com
+
+To report issues or contribute to the project see the source repository:
+https://github.com/theleagueof/raleway
+
+ChangeLog
+
+4 March 2026 - Tildagon Project Authors
+- Add additional geometric glyphs
+- Convert to header file for use with ctx
+- Rename font to comply with licenses
+
+29 August 2020 (Caleb Maclennan) v4.101
+- Repackage so license files get distributed properly
+
+27 August 2020 (Caleb Maclennan) v4.100
+- Re-release of the entire font family in more output formats
+- Collect all the developments from various forks back to the original project repository
+- Build and release using Fontship
+
+10 Jul 2020 () v4.026
+- Release on Google Fonts
+- Add VTT hints
+- Fixup Italic
+- Fixup compose/decompose for several glyphs
+- Fix diacritic placements
+
+17 December 2016 (Alexei Vanyashin, Cyreal) v4.020
+— Expanded glyph set to GF Cyrillic Pro
+
+15 October 2016 (Alexei Vanyashin, Ivan Petrov, Cyreal) v.4.010
+— Merged in Cyrillic in the GF Cyrillic Plus + localised variants range
+— minor fixed: adjusted win ascender
+— changed italic angle to 12 in Italic masters
+— added Cyrillic kerning
+
+24 Sept 2013  (Matt McInerney, Pablo Impallari, Rodrigo Fuenzalida) Raleway Family v3.0
+- Added Cyrillic to the 9 Roman Weights
+
+26 Jun 2013  (Matt McInerney, Pablo Impallari, Rodrigo Fuenzalida) Raleway Family v2.5
+- Charset Extension, now covering 104 Latin Languages.
+- Italics Added
+- Re-mastered
+
+27 May 2013  (Matt McInerney, Pablo Impallari, Rodrigo Fuenzalida) Raleway Family v2.4 (Beta)
+- Italic Masters, ready for iKern
+
+1 May 2013  (Matt McInerney, Pablo Impallari, Rodrigo Fuenzalida) Raleway Family v2.3 (Beta)
+- More diactritics added, now supporting all 104 Latin languages
+- Added /Delta /Omega /estimated /infinity /integral /lozenge /partialdiff /pi /product /radical /summation /uni0394 /uni03A9 /uni2113
+- Lots of small bugs fixed
+
+11 Nov 2012  (Matt McInerney, Pablo Impallari, Rodrigo Fuenzalida) Raleway Family v2.2
+- Fixed Font Info and other small bugs.
+- 'Heavy' style renamed as 'Black'
+- Hinted using the latest version of TTFAutohint, currently v0.9.3.
+- Removed the KERN table, now we are using GPOS based Kerning.
+- Smaller file size for faster loading on the web.
+- Al '-OT' sources files renamed as '-OTF'
+
+7 Sept 2012  (Matt McInerney, Pablo Impallari, Rodrigo Fuenzalida) Raleway Family v2.1
+- Fixed vertical metrics bug
+
+11 May 2012  (Matt McInerney, Pablo Impallari, Rodrigo Fuenzalida) Raleway Family v2.0
+- iKerned
+- Remastered
+
+30 March 2012 (Matt McInerney, Pablo Impallari, Rodrigo Fuenzalida) Raleway Family Beta v1.06
+- Initial Beta release of the family expansion - Not yet spaced or Kerned.
+- 9 Weights: Thin, ExtraLight, Light, Regular, Medium, SemiBold, Bold, ExtraBold and Heavy weights.
+- Characters set expanded to cover 95 languages
+- For detailed inspection, please refer to the the FL source files (The OTF files where quickly generated using Ben Kiel's Font Generator macro, for testing purposes only).
+
+20 Feb 2010 (Matt McInerney) Raleway Light v1.01
+- Initial Release
+
+Acknowledgements
+
+If you make modifications be sure to add your name (N),
+email (E), web-address (if you have one) (W) and
+description (D). This list is in alphabetical order.
+
+N: Caleb Maclennan
+E: caleb@alerque.com
+W: https://alerque.com
+D: Fontship build system
+
+N: Cyreal
+E: contact@cyreal.org
+W: http://cyreal.org
+D: Cyrillic expansion
+
+N: Matt McInerney
+E: matt@pixelspread.com
+W: http://pixelspread.com/
+D: Designer
+
+N: Pablo Impallari
+E: impallari@gmail.com
+W: http://www.impallari.com
+D: Designer
+
+N: Rodrigo Fuenzalida
+E: hello@rfuenzalida.com
+W: http://www.rfuenzalida.com
+D: Designer

--- a/modules/app_components/tokens.py
+++ b/modules/app_components/tokens.py
@@ -48,6 +48,41 @@ ui_colors = {
 }
 
 
+symbols = {
+    "arrows": {
+        "left": "←",
+        "up": "↑",
+        "right": "→",
+        "down": "↓",
+        "left_right": "↔",
+        "up_down": "↕",
+        "north_west": "↖",
+        "north_east": "↗",
+        "south_east": "↘",
+        "south_west": "↙",
+    },
+    "hexagons": {"outline": "⬡", "filled": "⬢"},
+    "hexpansion": "⬣",
+    "pointing_triangles": {"up": "▲", "right": "▶", "down": "▼", "left": "◀"},
+    "keyboard": {
+        "return": "⏎",
+        "backspace": "␈",
+        "shift": "␏",
+        "square": "□",
+        "triangle": "△",
+        "diamond": "◇",
+        "circle": "○",
+        "club": "♣",
+        "cross": "✕",
+        "solderparty": "⭍",
+    },
+    "emf_logo": "",
+    "shark": "ǩ",
+    "duck": "⇩",
+    "spider": "臩",
+}
+
+
 def clear_background(ctx):
     ctx.rgb(*colors["dark_green"]).rectangle(-120, -120, display_x, display_y).fill()
 

--- a/sim/fakes/ctx.py
+++ b/sim/fakes/ctx.py
@@ -503,15 +503,7 @@ class Context:
 
     def get_font_name(self, i):
         return [
-            "Arimo Regular",
-            "Arimo Bold",
-            "Arimo Italic",
-            "Arimo Bold Italic",
-            "Camp Font 1",
-            "Camp Font 2",
-            "Camp Font 3",
-            "Material Icons",
-            "Comic Mono",
+            "EMF Camp Font"
         ][i]
 
     def scope(self):


### PR DESCRIPTION
# Description

Added the brand font as per #23 but with a custom Raleway build including additional glyphs for `(⬡,⬢,▲,▶,▼,◀) ` 

This allows inline rendering of hexagons and direction triangles alongside text, which is cool and useful for UI stuff.

Since there are new glyphs, the font has been renamed to EMF Camp Font to comply with the OFL, so I don't think there's any issues there.

I've flashed this onto my badge and it works fine, but I have since broken my build toolchain so it could maybe use a tester. Toolchain for editing and baking the font is working though so more glyphs can be added if desired.

<img width="600" height="800" alt="An image showing the working extra glyphs on the main badge menu" src="https://github.com/user-attachments/assets/2a96e05a-e7e7-402f-acd7-d98d562d4ebf" />
