### PR TITLE
Sim: Add missing conic_gradient function to the ctx fake

### DIFF
--- a/sim/fakes/ctx.py
+++ b/sim/fakes/ctx.py
@@ -454,6 +454,10 @@ class Context:
         self._emit(f"linearGradient {x0:.3f} {y0:.3f} {x1:.3f} {y1:.3f}")
         return self
 
+    def conic_gradient(self, cx, cy, start_angle, cycles):
+        self._emit(f"conicGradient {cx:.3f} {cy:.3f} {start_angle:.3f} {cycles:.3f}")
+        return self
+
     def add_stop(self, pos, color, alpha):
         red, green, blue = color
         if red > 1.0 or green > 1.0 or blue > 1.0:


### PR DESCRIPTION
Any app that uses conic gradients just crashes in the simulator

Adding this function fixes those crashes.