### PR TITLE
Make App Store codeinstall see keyboard buttons

### DIFF
--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -488,6 +488,8 @@ class CodeInstall:
         eventbus.on(ButtonDownEvent, self._handle_buttondown, app)
 
     def _handle_buttondown(self, event: ButtonDownEvent):
+        kbd_button = event.button.find_parent_in_group("Keyboard")
+
         if BUTTON_TYPES["UP"] in event.button:
             self.id += "0"
         elif BUTTON_TYPES["RIGHT"] in event.button:
@@ -500,6 +502,8 @@ class CodeInstall:
             self.id += "4"
         elif BUTTON_TYPES["CANCEL"] in event.button:
             self.id += "5"
+        elif kbd_button is not None and kbd_button.name in "012345":
+            self.id += kbd_button.name
 
         if len(self.id) == 8:
             self._cleanup()


### PR DESCRIPTION
Before this PR, the code input dialog only did directional frontboard A-F buttons, even though codes are often represented as numbers.

It did not respond to button pushes for actual number buttons on tildagons with those additional button types
(in my case, my usb serial keyboard driver, but I guess also any other external keyboard? I'm not sure? it's also "broken" behaviour inside the web emulator which has a keyboard driver)

After this PR, you can use the frontboard A-F buttons as before or press numerical keys if you have them.
