### PR TITLE
Fixed crash on wifi setting reset if wifi_wpa2ent_username not set

### DIFF
--- a/modules/settings.py
+++ b/modules/settings.py
@@ -26,7 +26,8 @@ def set(k, v):
     if _settings is None:
         load()
     if v is None:
-        del _settings[k]
+        if k in _settings:
+            del _settings[k]
     else:
         _settings[k] = v
     _modified = True


### PR DESCRIPTION
# Description

Hitting "Reset WiFi" in the settings app causes a crash to REPL with `KeyError: wifi_wpa2ent_username` if the badge has previously been connected to a non wpa2 enterprise network, becaue `wifi_wpa2ent_username = None`. Added a check for this when resetting which prevents this.