### PR TITLE
Fix crash to REPL when using "Caps Lock"

### DIFF
--- a/modules/app_components/dialog.py
+++ b/modules/app_components/dialog.py
@@ -348,7 +348,7 @@ class TextDialog:
                     self._current_alphabet = self._default_alphabet
                 self._layer = 0
                 if self._caps:
-                    self._current_alphabet = self.self._shifted_alphabet
+                    self._current_alphabet = self._shifted_alphabet
                 else:
                     self._current_alphabet = self._default_alphabet
         elif len(selected) > 0:


### PR DESCRIPTION
When entering text into any text entry dialog, using Caps Lock results in a crash to REPL:


```
Traceback (most recent call last):
  File "main.py", line 43, in <module>
  File "system/scheduler/__init__.py", line 243, in run_forever
  File "asyncio/core.py", line 1, in run_until_complete
  File "asyncio/core.py", line 1, in run_until_complete
  File "asyncio/core.py", line 1, in run_until_complete
  File "system/scheduler/__init__.py", line 239, in _main
  File "asyncio/funcs.py", line 1, in gather
  File "asyncio/core.py", line 1, in run_until_complete
  File "system/eventbus.py", line 85, in run
  File "app_components/dialog.py", line 351, in _handle_buttondown
AttributeError: 'TextDialog' object has no attribute 'self'
```

Steps to reproduce:

1. Open Settings
2. Select "Name"
3. Press F to select the "..." option
4. Press D to enable "Caps Lock"
5. Press E to select numerals
6. Press any button to select a number
7. Observe crash on the console

This change fixes the crash by correcting a double self dereference typo.