### PR TITLE
Fix sim on Windows

### DIFF
--- a/sim/run.py
+++ b/sim/run.py
@@ -68,7 +68,7 @@ sys.path = [
 builtin = BuiltinImporter()
 pathfinder = PathFinder()
 underscore = UnderscoreFinder(builtin, pathfinder)
-sys.meta_path = [pathfinder, underscore]
+sys.meta_path = [pathfinder, underscore, builtin]
 
 # Clean up whatever might have already been imported as `time`.
 import time
@@ -126,7 +126,11 @@ def _mkmock2(fun):
 os.listdir = _mkmock(os.listdir)
 os.rename = _mkmock2(os.rename)
 os.stat = _mkmock(os.stat)
-os.statvfs = _mkmock(os.statvfs)
+if hasattr(os, "statvfs"):
+    os.statvfs = _mkmock(os.statvfs)
+else:
+    # We seem to be on Windows, mock out plausible filesystem:
+    os.statvfs = lambda path: (4096, 4096, 4096, 2048, 2048, 0, 0, 0, 0, 255)
 os.mkdir = _mkmock(os.mkdir)
 os.rmdir = _mkmock(os.rmdir)
 os.unlink = _mkmock(os.unlink)


### PR DESCRIPTION
# Description

Hi badge team! I tried the sim on Windows and it wouldn't load, you seem to all be Unix users :)

It works with the following 2 changes:
* Mock out `os.statvfs`, which just isn't there on windows
* Add `builtin` as a fallback to the os path resolution mocks

With these 2 it runs fine

<img width="552" height="573" alt="{90EAD8DD-B198-472D-B505-4C136779BF1F}" src="https://github.com/user-attachments/assets/37d2b369-635a-4c18-bce0-91f2b08fd593" />


DISCLAIMER
1. I have not tested this on a Unix system because I don't have one. Strongly recommend someone with mac/linux gives it a quick run before merging.
2. AI suggested both these fixes, I am not an expert in this area (not sure what your contribution policy is for this)