### PR TITLE
Create eventbus methods to add and remove app directories for the launcher

### DIFF
--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -20,6 +20,7 @@ from requests import get
 from system.eventbus import eventbus
 from system.launcher.app import (
     APP_DIR,
+    APP_INSTALL_DIR,
     load_info,
     InstallNotificationEvent,
 )
@@ -74,12 +75,12 @@ def list_apps(dir, callable):
 
 
 def list_all_apps():
-    return (
-        list_apps(APP_DIR, "__app_export__")
-        + list_apps(BG_DIR, "__Background__")
-        + list_apps(PAT_DIR, "__Pattern_Export__")
-    )
-
+    app_list = []
+    for d in APP_DIR:
+        app_list.extend(list_apps(d, "__app_export__"))
+    app_list += list_apps(BG_DIR, "__Background__")
+    app_list += list_apps(PAT_DIR, "__Pattern_Export__")
+    return app_list
 
 class AppStoreApp(app.App):
     state = "init"
@@ -555,7 +556,7 @@ def install_app(app):
         elif app["manifest"]["app"].get("category") == "Pattern":
             TARGET_DIR = "/pattern"
         else:
-            TARGET_DIR = APP_DIR
+            TARGET_DIR = APP_INSTALL_DIR
         # Make sure apps dir exists
         try:
             os.mkdir(TARGET_DIR)

--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -82,6 +82,7 @@ def list_all_apps():
     app_list += list_apps(PAT_DIR, "__Pattern_Export__")
     return app_list
 
+
 class AppStoreApp(app.App):
     state = "init"
 

--- a/modules/lib/shutil.py
+++ b/modules/lib/shutil.py
@@ -37,6 +37,7 @@ def copyfileobj(src, dest, length=512):
                 break
             dest.write(buf)
 
+
 def copytree(src, dst, **kwargs):
     os.mkdir(dst)
     for name, type, *_ in os.ilistdir(src):
@@ -47,6 +48,7 @@ def copytree(src, dst, **kwargs):
             with open(f"{src}/{name}", "rb") as fr:
                 with open(f"{dst}/{name}", "wb") as fw:
                     copyfileobj(fr, fw)
+
 
 def move(src, dst, **kwargs):
     try:
@@ -62,6 +64,7 @@ def move(src, dst, **kwargs):
                 with open(dst, "wb") as fw:
                     copyfileobj(fr, fw)
             os.remove(src)
+
 
 def disk_usage(path):
     bit_tuple = os.statvfs(path)

--- a/modules/lib/shutil.py
+++ b/modules/lib/shutil.py
@@ -37,6 +37,30 @@ def copyfileobj(src, dest, length=512):
                 break
             dest.write(buf)
 
+def copytree(src, dst, **kwargs):
+    for name, type, *_ in os.ilistdir(src):
+        if type & 0x4000:
+            # it's a directory
+            copytree(f"{src}/{name}", f"{dst}/{name}")
+        else:
+            with open(f"{src}/{name}", "rb") as fr:
+                with open(f"{src}/{name}", "wb") as fw:
+                    copyfileobj(fr, fw)
+
+def move(src, dst, **kwargs):
+    try:
+        os.rename(src, dst)
+    except OSError:
+        st = os.stat(src)
+        if st[0] & 0x4000:
+            # src is a directory
+            copytree(src, dst)
+            rmtree(src)
+        else:
+            with open(src, "rb") as fr:
+                with open(dst, "wb") as fw:
+                    copyfileobj(fr, fw)
+            os.remove(src)
 
 def disk_usage(path):
     bit_tuple = os.statvfs(path)

--- a/modules/lib/shutil.py
+++ b/modules/lib/shutil.py
@@ -38,13 +38,14 @@ def copyfileobj(src, dest, length=512):
             dest.write(buf)
 
 def copytree(src, dst, **kwargs):
+    os.mkdir(dst)
     for name, type, *_ in os.ilistdir(src):
         if type & 0x4000:
             # it's a directory
             copytree(f"{src}/{name}", f"{dst}/{name}")
         else:
             with open(f"{src}/{name}", "rb") as fr:
-                with open(f"{src}/{name}", "wb") as fw:
+                with open(f"{dst}/{name}", "wb") as fw:
                     copyfileobj(fr, fw)
 
 def move(src, dst, **kwargs):

--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -19,16 +19,20 @@ from app_components.background import Background as bg
 APP_DIR = ["/apps"]
 APP_INSTALL_DIR = "/apps"
 
+
 class InstallNotificationEvent(Event):
     pass
+
 
 class AppDirAddedNotificationEvent(Event):
     def __init__(self, path):
         self.path = path
 
+
 class AppDirRemovedNotificationEvent(Event):
     def __init__(self, path):
         self.path = path
+
 
 def path_isdir(path):
     try:
@@ -73,7 +77,7 @@ def list_user_apps():
             path = dirname
             for p in sys.path:
                 if p and dirname.startswith(p):
-                    path = dirname[len(p):]
+                    path = dirname[len(p) :]
                     break
             path = ".".join(path.lstrip("/").split("/"))
             app = {
@@ -114,7 +118,7 @@ class Launcher(App):
     async def _handle_dir_added_notification(self, event):
         APP_DIR.append(event.path)
         self.update_menu()
-    
+
     async def _handle_dir_removed_notification(self, event):
         try:
             APP_DIR.remove(event.path)

--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -16,12 +16,17 @@ from system.scheduler.events import (
 from system.notification.events import ShowNotificationEvent
 from app_components.background import Background as bg
 
-APP_DIR = "/apps"
-
+APP_DIR = ["/apps"]
+APP_INSTALL_DIR = "/apps"
 
 class InstallNotificationEvent(Event):
     pass
 
+class AppDirAddedNotificationEvent(Event):
+    pass
+
+class AppDirRemovedNotificationEvent(Event):
+    pass
 
 def path_isdir(path):
     try:
@@ -54,25 +59,29 @@ def load_info(folder, name):
 def list_user_apps():
     with PerfTimer("List user apps"):
         apps = []
-        try:
-            contents = os.listdir(APP_DIR)
-        except OSError:
-            # No apps dir full stop
+        contents = []
+        for d in APP_DIR:
             try:
-                os.mkdir(APP_DIR)
-            except OSError:
+                contents.extend([(d, x) for x in os.listdir(d)])
+            except (OSError, UnicodeError):
+                # directory or mount point don't exist
                 pass
-            return []
 
-        for name in contents:
+        for dirname, name in contents:
+            path = dirname
+            for p in sys.path:
+                if p and dirname.startswith(p):
+                    path = dirname[len(p):]
+                    break
+            path = ".".join(path.lstrip("/").split("/"))
             app = {
-                "path": f"apps.{name}.app",
+                "path": f"{path}.{name}.app",
                 "callable": "__app_export__",
                 "name": name,
                 "folder": name,
                 "hidden": False,
             }
-            metadata = load_info(APP_DIR, name)
+            metadata = load_info(dirname, name)
             if "version" not in metadata:
                 app["version"] = "0.0.0"
             app.update(metadata)
@@ -90,8 +99,25 @@ class Launcher(App):
         eventbus.on_async(
             InstallNotificationEvent, self._handle_refresh_notifications, self
         )
+        eventbus.on_async(
+            AppDirAddedNotificationEvent, self._handle_dir_added_notification, self
+        )
+        eventbus.on_async(
+            AppDirRemovedNotificationEvent, self._handle_dir_removed_notification, self
+        )
 
     async def _handle_refresh_notifications(self, _):
+        self.update_menu()
+
+    async def _handle_dir_added_notification(self, dirname):
+        APP_DIR.append(dirname)
+        self.update_menu()
+    
+    async def _handle_dir_removed_notification(self, dirname):
+        try:
+            APP_DIR.remove(dirname)
+        except ValueError:
+            pass
         self.update_menu()
 
     async def _handle_stop_app(self, event: RequestStopAppEvent):

--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -23,10 +23,12 @@ class InstallNotificationEvent(Event):
     pass
 
 class AppDirAddedNotificationEvent(Event):
-    pass
+    def __init__(self, path):
+        self.path = path
 
 class AppDirRemovedNotificationEvent(Event):
-    pass
+    def __init__(self, path):
+        self.path = path
 
 def path_isdir(path):
     try:
@@ -109,13 +111,13 @@ class Launcher(App):
     async def _handle_refresh_notifications(self, _):
         self.update_menu()
 
-    async def _handle_dir_added_notification(self, dirname):
-        APP_DIR.append(dirname)
+    async def _handle_dir_added_notification(self, event):
+        APP_DIR.append(event.path)
         self.update_menu()
     
-    async def _handle_dir_removed_notification(self, dirname):
+    async def _handle_dir_removed_notification(self, event):
         try:
-            APP_DIR.remove(dirname)
+            APP_DIR.remove(event.path)
         except ValueError:
             pass
         self.update_menu()


### PR DESCRIPTION
# Description

Adds the ability to add and remove app directories from the launcher search path.  This means you can have app directories on external (Hexpansion) storage and have the apps appear in the main app list.

Also added a couple of extra shutil methods which are useful for moving apps off internal storage.