### PR TITLE
Multi-inheritence of buttons and common parents

### DIFF
--- a/modules/app_components/dialog.py
+++ b/modules/app_components/dialog.py
@@ -3,6 +3,7 @@ import math
 
 import display
 from events.input import BUTTON_TYPES, ButtonDownEvent
+from frontboards.common import FRONTBOARD_BUTTON_TYPES
 from events.keyboard import KEYBOARD_BUTTONS
 from system.eventbus import eventbus
 
@@ -272,17 +273,17 @@ class TextDialog:
 
         kbd_button = event.button.find_parent_in_group("Keyboard")
 
-        if BUTTON_TYPES["UP"] in event.button:
+        if FRONTBOARD_BUTTON_TYPES["A"] in event.button:
             key = 0
-        elif BUTTON_TYPES["RIGHT"] in event.button:
+        elif FRONTBOARD_BUTTON_TYPES["B"] in event.button:
             key = 1
-        elif BUTTON_TYPES["DOWN"] in event.button:
+        elif FRONTBOARD_BUTTON_TYPES["D"] in event.button:
             key = 3
-        elif BUTTON_TYPES["LEFT"] in event.button:
+        elif FRONTBOARD_BUTTON_TYPES["E"] in event.button:
             key = 4
-        elif BUTTON_TYPES["CANCEL"] in event.button:
+        elif FRONTBOARD_BUTTON_TYPES["F"] in event.button:
             key = 5
-        elif BUTTON_TYPES["CONFIRM"] in event.button:
+        elif FRONTBOARD_BUTTON_TYPES["C"] in event.button:
             key = 2
 
         elif kbd_button is not None:
@@ -306,6 +307,18 @@ class TextDialog:
             elif kbd_button.name in SYMBOL_ALPHABET:
                 key = -2
                 final = kbd_button.name
+
+        # The following are generics not caught by either frontboard corner buttons
+        # or keyboard events. They are, therefore, secondary confirm/cancel/etc buttons
+        elif BUTTON_TYPES["CONFIRM"] in event.button:
+            key = -2
+            final = SPECIAL_KEY_DONE
+        elif BUTTON_TYPES["UP"] in event.button:
+            key = -2
+            final = SPECIAL_KEY_CAPS
+        elif BUTTON_TYPES["LEFT"] in event.button:
+            key = -2
+            final = SPECIAL_KEY_BACKSPACE
 
         if key == -1:
             return

--- a/modules/events/input.py
+++ b/modules/events/input.py
@@ -3,19 +3,26 @@ from events import Event
 
 
 class Button:
-    __slots__ = ("name", "group", "parent")
+    __slots__ = ("name", "group", "parent", "_all_parents")
 
     def __init__(self, name, group, parent=None):
         self.name = name
         self.group = group
-        self.parent = parent
+        if isinstance(parent, Button):
+            self.parents = [parent]
+        if parent is None:
+            self.parents = []
+        else:
+            self.parents = parent
+        self._all_parents = None
 
     def __hash__(self):
         return hash((self.name, self.group))
 
     def _inner_repr(self):
-        parents_clause = (
-            f" - {self.parent._inner_repr()}" if self.parent is not None else ""
+        parents_clause = "".join(
+            f" - {parent._inner_repr()}" if parent is not None else ""
+            for parent in self.parents
         )
         return f"{self.group}.{self.name}{parents_clause}"
 
@@ -25,26 +32,30 @@ class Button:
     def __eq__(self, other):
         return self.name == other.name and self.group == other.group
 
+    @property
+    def all_parents(self):
+        if self._all_parents is not None:
+            return self._all_parents
+        self._all_parents = []
+        for parent in self.parents:
+            self._all_parents.append(parent)
+            self._all_parents += parent.all_parents
+        return self._all_parents
+
     def __contains__(self, other):
         if other == self:
             return True
-        parent = self.parent
-        while parent is not None:
+        for parent in self.all_parents:
             if other == parent:
                 return True
-            else:
-                parent = parent.parent
         return False
 
     def find_parent_in_group(self, group):
         if self.group == group:
             return self
-        parent = self.parent
-        while parent is not None:
+        for parent in self.all_parents:
             if parent.group == group:
                 return parent
-            else:
-                parent = parent.parent
         return None
 
 

--- a/modules/events/input.py
+++ b/modules/events/input.py
@@ -3,14 +3,14 @@ from events import Event
 
 
 class Button:
-    __slots__ = ("name", "group", "parent", "_all_parents")
+    __slots__ = ("name", "group", "parents", "_all_parents")
 
     def __init__(self, name, group, parent=None):
         self.name = name
         self.group = group
         if isinstance(parent, Button):
             self.parents = [parent]
-        if parent is None:
+        elif parent is None:
             self.parents = []
         else:
             self.parents = parent

--- a/modules/events/joystick.py
+++ b/modules/events/joystick.py
@@ -9,7 +9,8 @@ JOYSTICK_BUTTON_TYPES = {
     "A": Button("A", "Joystick"),
     "B": Button("B", "Joystick"),
     "C": Button("C", "Joystick"),
-    "D": Button("D", "Joystick"),
-    "E": Button("E", "Joystick"),
-    "F": Button("F", "Joystick"),
+    "X": Button("X", "Joystick"),
+    "Y": Button("Y", "Joystick"),
+    "Z": Button("Z", "Joystick"),
+    "SELECT": Button("SELECT", "Joystick"),
 }

--- a/modules/events/joystick.py
+++ b/modules/events/joystick.py
@@ -1,0 +1,15 @@
+from events.input import Button
+
+
+JOYSTICK_BUTTON_TYPES = {
+    "UP": Button("UP", "Joystick"),
+    "DOWN": Button("DOWN", "Joystick"),
+    "LEFT": Button("LEFT", "Joystick"),
+    "RIGHT": Button("RIGHT", "Joystick"),
+    "A": Button("A", "Joystick"),
+    "B": Button("B", "Joystick"),
+    "C": Button("C", "Joystick"),
+    "D": Button("D", "Joystick"),
+    "E": Button("E", "Joystick"),
+    "F": Button("F", "Joystick"),
+}

--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -16,7 +16,8 @@ import shutil
 import machine
 from app_components import Menu, fourteen_pt, sixteen_pt, ten_pt, seven_pt
 from app_components.tokens import set_color
-from events.input import BUTTON_TYPES, ButtonDownEvent
+from events.input import ButtonDownEvent
+from frontboards.common import FRONTBOARD_BUTTON_TYPES
 from requests import get
 from system.eventbus import eventbus
 from system.launcher.app import (
@@ -529,17 +530,17 @@ class CodeInstall:
     def _handle_buttondown(self, event: ButtonDownEvent):
         kbd_button = event.button.find_parent_in_group("Keyboard")
 
-        if BUTTON_TYPES["UP"] in event.button:
+        if FRONTBOARD_BUTTON_TYPES["A"] in event.button:
             self.id += "0"
-        elif BUTTON_TYPES["RIGHT"] in event.button:
+        elif FRONTBOARD_BUTTON_TYPES["B"] in event.button:
             self.id += "1"
-        elif BUTTON_TYPES["CONFIRM"] in event.button:
+        elif FRONTBOARD_BUTTON_TYPES["C"] in event.button:
             self.id += "2"
-        elif BUTTON_TYPES["DOWN"] in event.button:
+        elif FRONTBOARD_BUTTON_TYPES["D"] in event.button:
             self.id += "3"
-        elif BUTTON_TYPES["LEFT"] in event.button:
+        elif FRONTBOARD_BUTTON_TYPES["E"] in event.button:
             self.id += "4"
-        elif BUTTON_TYPES["CANCEL"] in event.button:
+        elif FRONTBOARD_BUTTON_TYPES["F"] in event.button:
             self.id += "5"
         elif kbd_button is not None and kbd_button.name in "012345":
             self.id += kbd_button.name

--- a/modules/frontboards/common.py
+++ b/modules/frontboards/common.py
@@ -1,0 +1,11 @@
+from events.input import Button
+
+
+FRONTBOARD_BUTTON_TYPES = {
+    "A": Button("A", "Frontboard"),
+    "B": Button("B", "Frontboard"),
+    "C": Button("C", "Frontboard"),
+    "D": Button("D", "Frontboard"),
+    "E": Button("E", "Frontboard"),
+    "F": Button("F", "Frontboard"),
+}

--- a/modules/frontboards/twentyfour.py
+++ b/modules/frontboards/twentyfour.py
@@ -8,6 +8,7 @@ from tildagon import ePin
 from . import FrontBoard
 from system.hexpansion.events import HexpansionInsertionEvent, HexpansionRemovalEvent
 import time
+from frontboards.common import FRONTBOARD_BUTTON_TYPES
 
 try:
     from _sim import _sim
@@ -18,12 +19,24 @@ except ImportError:
 
 
 BUTTONS = {
-    "A": Button("A", "TwentyTwentyFour", BUTTON_TYPES["UP"]),
-    "B": Button("B", "TwentyTwentyFour", BUTTON_TYPES["RIGHT"]),
-    "C": Button("C", "TwentyTwentyFour", BUTTON_TYPES["CONFIRM"]),
-    "D": Button("D", "TwentyTwentyFour", BUTTON_TYPES["DOWN"]),
-    "E": Button("E", "TwentyTwentyFour", BUTTON_TYPES["LEFT"]),
-    "F": Button("F", "TwentyTwentyFour", BUTTON_TYPES["CANCEL"]),
+    "A": Button(
+        "A", "TwentyTwentyFour", [BUTTON_TYPES["UP"], FRONTBOARD_BUTTON_TYPES["A"]]
+    ),
+    "B": Button(
+        "B", "TwentyTwentyFour", [BUTTON_TYPES["RIGHT"], FRONTBOARD_BUTTON_TYPES["B"]]
+    ),
+    "C": Button(
+        "C", "TwentyTwentyFour", [BUTTON_TYPES["CONFIRM"], FRONTBOARD_BUTTON_TYPES["C"]]
+    ),
+    "D": Button(
+        "D", "TwentyTwentyFour", [BUTTON_TYPES["DOWN"], FRONTBOARD_BUTTON_TYPES["D"]]
+    ),
+    "E": Button(
+        "E", "TwentyTwentyFour", [BUTTON_TYPES["LEFT"], FRONTBOARD_BUTTON_TYPES["E"]]
+    ),
+    "F": Button(
+        "F", "TwentyTwentyFour", [BUTTON_TYPES["CANCEL"], FRONTBOARD_BUTTON_TYPES["F"]]
+    ),
 }
 
 

--- a/modules/frontboards/twentysix.py
+++ b/modules/frontboards/twentysix.py
@@ -65,7 +65,7 @@ JOYSTICK = {
     "FIRE": Button(
         "JOYFIRE",
         "TwentyTwentySix",
-        [BUTTON_TYPES["CONFIRM"], JOYSTICK_BUTTON_TYPES["A"]],
+        [BUTTON_TYPES["CONFIRM"], JOYSTICK_BUTTON_TYPES["SELECT"]],
     ),
 }
 

--- a/modules/frontboards/twentysix.py
+++ b/modules/frontboards/twentysix.py
@@ -2,6 +2,7 @@ import asyncio
 
 import display
 from events.input import Button, BUTTON_TYPES, ButtonDownEvent, ButtonUpEvent
+from events.joystick import JOYSTICK_BUTTON_TYPES
 import machine
 from system.eventbus import eventbus
 from tildagon import ePin
@@ -11,6 +12,7 @@ import time
 import frontboard2026
 from frontboards.utils import detect_frontboard
 from frontboards.cy8cmbrx import cy8cmbr3116_init
+from frontboards.common import FRONTBOARD_BUTTON_TYPES
 
 try:
     from _sim import _sim
@@ -21,20 +23,50 @@ except ImportError:
 
 
 BUTTONS = {
-    "A": Button("A", "TwentyTwentySix", BUTTON_TYPES["UP"]),
-    "B": Button("B", "TwentyTwentySix", BUTTON_TYPES["RIGHT"]),
-    "C": Button("C", "TwentyTwentySix", BUTTON_TYPES["CONFIRM"]),
-    "D": Button("D", "TwentyTwentySix", BUTTON_TYPES["DOWN"]),
-    "E": Button("E", "TwentyTwentySix", BUTTON_TYPES["LEFT"]),
-    "F": Button("F", "TwentyTwentySix", BUTTON_TYPES["CANCEL"]),
+    "A": Button(
+        "A", "TwentyTwentySix", [BUTTON_TYPES["UP"], FRONTBOARD_BUTTON_TYPES["A"]]
+    ),
+    "B": Button(
+        "B", "TwentyTwentySix", [BUTTON_TYPES["RIGHT"], FRONTBOARD_BUTTON_TYPES["B"]]
+    ),
+    "C": Button(
+        "C", "TwentyTwentySix", [BUTTON_TYPES["CONFIRM"], FRONTBOARD_BUTTON_TYPES["C"]]
+    ),
+    "D": Button(
+        "D", "TwentyTwentySix", [BUTTON_TYPES["DOWN"], FRONTBOARD_BUTTON_TYPES["D"]]
+    ),
+    "E": Button(
+        "E", "TwentyTwentySix", [BUTTON_TYPES["LEFT"], FRONTBOARD_BUTTON_TYPES["E"]]
+    ),
+    "F": Button(
+        "F", "TwentyTwentySix", [BUTTON_TYPES["CANCEL"], FRONTBOARD_BUTTON_TYPES["F"]]
+    ),
 }
 
 JOYSTICK = {
-    "UP": Button("JOYUP", "TwentyTwentySix", BUTTON_TYPES["UP"]),
-    "DOWN": Button("JOYDOWN", "TwentyTwentySix", BUTTON_TYPES["DOWN"]),
-    "LEFT": Button("JOYLEFT", "TwentyTwentySix", BUTTON_TYPES["LEFT"]),
-    "RIGHT": Button("JOYRIGHT", "TwentyTwentySix", BUTTON_TYPES["RIGHT"]),
-    "FIRE": Button("JOYFIRE", "TwentyTwentySix", BUTTON_TYPES["CONFIRM"]),
+    "UP": Button(
+        "JOYUP", "TwentyTwentySix", [BUTTON_TYPES["UP"], JOYSTICK_BUTTON_TYPES["UP"]]
+    ),
+    "DOWN": Button(
+        "JOYDOWN",
+        "TwentyTwentySix",
+        [BUTTON_TYPES["DOWN"], JOYSTICK_BUTTON_TYPES["DOWN"]],
+    ),
+    "LEFT": Button(
+        "JOYLEFT",
+        "TwentyTwentySix",
+        [BUTTON_TYPES["LEFT"], JOYSTICK_BUTTON_TYPES["LEFT"]],
+    ),
+    "RIGHT": Button(
+        "JOYRIGHT",
+        "TwentyTwentySix",
+        [BUTTON_TYPES["RIGHT"], JOYSTICK_BUTTON_TYPES["RIGHT"]],
+    ),
+    "FIRE": Button(
+        "JOYFIRE",
+        "TwentyTwentySix",
+        [BUTTON_TYPES["CONFIRM"], JOYSTICK_BUTTON_TYPES["A"]],
+    ),
 }
 
 


### PR DESCRIPTION
This changes the inheritence of buttons to allow them to have multiple inheritence paths, then updates the buttons on the frontboards to point to new common classes to be used across multiple boards. This should make detecting specifically the corner/joystick buttons easier. Also amends the firmware in a couple of places to use this distinction.
