### PR TITLE
Remove duplicate screen dimension constants

### DIFF
--- a/components/flow3r_bsp/flow3r_bsp.h
+++ b/components/flow3r_bsp/flow3r_bsp.h
@@ -31,9 +31,5 @@ void flow3r_bsp_display_send_fb_osd(void *fb_data, int bits, int scale,
 // No-op if display hasn't been successfully initialized.
 void flow3r_bsp_display_set_backlight(uint8_t percent);
 
-// Currently same on all generations. Might change on future revisions.
-#define FLOW3R_BSP_DISPLAY_WIDTH 240
-#define FLOW3R_BSP_DISPLAY_HEIGHT 240
-
 // Badge hardware generation name, human-readable.
 extern const char *flow3r_bsp_hw_name;

--- a/drivers/gc9a01/display.c
+++ b/drivers/gc9a01/display.c
@@ -45,8 +45,8 @@ Ctx *tildagon_gfx_ctx(void)
 
 void tildagon_start_frame(Ctx *ctx)
 {
-  int32_t offset_x = FLOW3R_BSP_DISPLAY_WIDTH / 2;
-  int32_t offset_y = FLOW3R_BSP_DISPLAY_HEIGHT / 2;
+  int32_t offset_x = TILDAGON_DISPLAY_WIDTH / 2;
+  int32_t offset_y = TILDAGON_DISPLAY_HEIGHT / 2;
 
   ctx_save (ctx);
   ctx_identity (ctx);


### PR DESCRIPTION
These constants are defined in two places, which seems unnecessary.

I've been looking intensely at the display driver code recently for my Screen Hexpansion prototype, how opposed are you to me submitting patches to cleanup or extend this area?

