### PR TITLE
Test the simulator in builds

### DIFF
--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -1,0 +1,25 @@
+name: Test simulator boots
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  boot-sim:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install deps
+        run: pip install -r sim/requirements.txt
+      - name: Boot simulator
+        env:
+          SDL_VIDEODRIVER: dummy
+          SDL_AUDIODRIVER: dummy
+        working-directory: sim
+        run: python run.py --screenshot


### PR DESCRIPTION
Because we keep breaking either the main code, or the simulator.

This isn't testing the web emulator yet.