### PR TITLE
Sim: Add a fake for micropython.const()

### DIFF
--- a/sim/fakes/micropython.py
+++ b/sim/fakes/micropython.py
@@ -1,0 +1,2 @@
+def const(constant):
+    return constant


### PR DESCRIPTION
# Description

This is used to optimise constants in micropython, but is not present in cpython. Adding this fake allows apps that use this optimisation to run in the pygame simulator.
