### PR TITLE
Give flow3r_bsp_gc9a01_cmd_sync internal linkage

### DIFF
--- a/components/flow3r_bsp/flow3r_bsp_gc9a01.c
+++ b/components/flow3r_bsp/flow3r_bsp_gc9a01.c
@@ -201,7 +201,7 @@ static IRAM_ATTR void flow3r_bsp_gc9a01_pre_transfer_callback(
  * mode for higher speed. The overhead of interrupt transactions is more than
  * just waiting for the transaction to complete.
  */
-esp_err_t flow3r_bsp_gc9a01_cmd_sync(flow3r_bsp_gc9a01_t *gc9a01, uint8_t cmd) {
+static esp_err_t flow3r_bsp_gc9a01_cmd_sync(flow3r_bsp_gc9a01_t *gc9a01, uint8_t cmd) {
     spi_transaction_t t;
     memset(&t, 0, sizeof(t));
 


### PR DESCRIPTION
Internal functions should have internal linkage, adding the missing static keyword prevents this function from being visible outside the translation unit, and makes it consistent with the flow3r_bsp_gc9a01_data_sync function

