### PR TITLE
Add minimal autoexec.bat support

### DIFF
--- a/modules/system/launcher/app.py
+++ b/modules/system/launcher/app.py
@@ -15,6 +15,7 @@ from system.scheduler.events import (
 )
 from system.notification.events import ShowNotificationEvent
 from app_components.background import Background as bg
+from app_components.tokens import symbols
 
 APP_DIR = "/apps"
 
@@ -192,3 +193,37 @@ class Launcher(App):
     def update(self, delta):
         bg.update(delta)
         self.menu.update(delta)
+
+    async def background_task(self):
+        # oneshot at startup, not a loop like most apps backgroud_tasks
+
+        try:
+            with open("/autoexec.bat", "r") as f:
+                lines = f.readlines()
+                if len(lines) == 0:
+                    raise RuntimeError("autoexec.bat must name an app to launch")
+                app_subname = lines[0].strip()
+                found = False
+                for app in self.menu_items:
+                    if app["name"].find(app_subname) != -1:
+                        self.launch(app)
+                        found = True
+                        break
+                if not found:
+                    raise RuntimeError(f"No app named '{app_subname}'")
+
+        except Exception as e:
+            # don't log file-not-found as an error because that's the default
+            # for all badges.
+            if isinstance(e, OSError) and e.errno == 2:
+                pass
+            else:
+                # log exceptions but don't propagate - an autoexec failure
+                # shouldn't crash the launcher. Most badges will emit this message
+                # at startup.
+                print(f"autoexec.bat not processed fully: {type(e)} {e}")
+                eventbus.emit(
+                    ShowNotificationEvent(
+                        message=f"autoexec {symbols['bat_open']} failed. {e}"
+                    )
+                )


### PR DESCRIPTION
This is implemented in the launcher rather than calling directly in the scheduler so that the launcher is aware of launched apps, for re-entry off the launcher menu later.

This code matches against the name of the app, because that seems more user friendly than the class name.

This code matches a substring of the app name, so that you can launch "Duck Facts" when the app is actually called "Duck Facts [[EMF UNICODE VIOLATION DUCK :duck: ]]". The first matching app is launched, in whatever order the launcher built its menu.

A couple of possible use cases from IRC:

* less patching of core for the wasm emulator port to autoinstall apps: with this patch you can make an emulator-startup app, and have that run on startup

* running spyware on your kids badges automatically at startup

In IRC we talked about running multiple apps and running arbitrary Python. This does not directly support that.

For arbitrary Python, implement your own app (that's what apps are for!) and start that app using this mechanism.

For starting multiple apps, there isn't an exposed interface to launch apps (e.g. over eventbus) that can then be re-entered from the launcher. Fixing up that was more than I wanted to bite off in this PR. See PR #321 for related work for hexpansion apps.