### PR TITLE
Add CustomEvent and make eventbus more flexible

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Unit tests
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: Run unit tests
+        run: python -m unittest discover -t . -s tests -v

--- a/modules/events/custom.py
+++ b/modules/events/custom.py
@@ -1,0 +1,21 @@
+from . import Event
+
+class CustomEvent(Event):
+    __slots__ = ("type", "data", "requires_focus")
+
+    def __init__(self, type: str, data: dict, requires_focus: bool = False):
+        self.type = type
+        self.data = data
+        self.requires_focus = requires_focus
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def __setitem__(self, key, value):
+        self.data[key] = value
+
+    def __contains__(self, key):
+        return key in self.data
+
+    def __repr__(self):
+        return f"<{__class__.__name__}({self.type}): {self.data}>"

--- a/modules/events/custom.py
+++ b/modules/events/custom.py
@@ -1,5 +1,6 @@
 from . import Event
 
+
 class CustomEvent(Event):
     __slots__ = ("type", "data", "requires_focus")
 

--- a/modules/system/eventbus.py
+++ b/modules/system/eventbus.py
@@ -8,6 +8,22 @@ from system.notification.events import ShowNotificationEvent
 import sys
 
 
+def _type_name(event_type):
+    # event_type may be a class (built-in events) or a str (custom event types)
+    return getattr(event_type, "__name__", event_type)
+
+
+def _matches(event, event_type):
+    # A str event_type matches by the event's "type": either a .type attribute
+    # (e.g. CustomEvent) or a "type" key on a dict. Anything else is matched by
+    # isinstance as normal.
+    if isinstance(event_type, str):
+        if isinstance(event, dict):
+            return event.get("type") == event_type
+        return getattr(event, "type", None) == event_type
+    return isinstance(event, event_type)
+
+
 class _EventBus:
     def __init__(self):
         self.event_queue = AsyncQueue()
@@ -16,7 +32,7 @@ class _EventBus:
 
     def on(self, event_type, event_handler, app):
         print(
-            f"Registered event handler for {event_type.__name__}: {app.__class__.__name__} - {event_handler.__name__}"
+            f"Registered event handler for {_type_name(event_type)}: {app.__class__.__name__} - {event_handler.__name__}"
         )
         if app not in self.handlers:
             self.handlers[app] = {}
@@ -26,7 +42,7 @@ class _EventBus:
 
     def on_async(self, event_type, event_handler, app):
         print(
-            f"Registered async event handler for {event_type.__name__}: {app.__class__.__name__} - {event_handler.__name__}"
+            f"Registered async event handler for {_type_name(event_type)}: {app.__class__.__name__} - {event_handler.__name__}"
         )
         if app not in self.async_handlers:
             self.async_handlers[app] = {}
@@ -45,14 +61,14 @@ class _EventBus:
             if event_type in self.handlers[app]:
                 if event_handler in self.handlers[app][event_type]:
                     print(
-                        f"Removed event handler for {event_type.__name__}: {app.__class__.__name__} - {event_handler.__name__}"
+                        f"Removed event handler for {_type_name(event_type)}: {app.__class__.__name__} - {event_handler.__name__}"
                     )
                     self.handlers[app][event_type].remove(event_handler)
         if app in self.async_handlers:
             if event_type in self.async_handlers[app]:
                 if event_handler in self.async_handlers[app][event_type]:
                     print(
-                        f"Removed event handler for {event_type.__name__}: {app.__class__.__name__} - {event_handler.__name__}"
+                        f"Removed event handler for {_type_name(event_type)}: {app.__class__.__name__} - {event_handler.__name__}"
                     )
                     self.async_handlers[app][event_type].remove(event_handler)
 
@@ -69,7 +85,10 @@ class _EventBus:
     async def run(self):
         while True:
             event = await self.event_queue.get()
-            requires_focus = hasattr(event, "requires_focus") and event.requires_focus
+            if isinstance(event, dict):
+                requires_focus = event.get("requires_focus", False)
+            else:
+                requires_focus = getattr(event, "requires_focus", False)
 
             # For both synchronous and asynchronous handlers, loop over the apps
             # that have registered handlers, then if the app is eligible to receive
@@ -85,7 +104,7 @@ class _EventBus:
                     try:
                         if getattr(app, "_focused", False) or not requires_focus:
                             for event_type in tuple(self.handlers[app]):
-                                if isinstance(event, event_type):
+                                if _matches(event, event_type):
                                     for handler in tuple(
                                         self.handlers[app][event_type]
                                     ):
@@ -104,7 +123,7 @@ class _EventBus:
                 for app in tuple(self.async_handlers.keys()):
                     if getattr(app, "_focused", False) or not requires_focus:
                         for event_type in tuple(self.async_handlers[app]):
-                            if isinstance(event, event_type):
+                            if _matches(event, event_type):
                                 for handler in tuple(
                                     self.async_handlers[app][event_type]
                                 ):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,28 @@
+"""Test suite bootstrap.
+
+These tests run under CPython, but the modules under test are written for
+MicroPython. Importing this package wires up the two things needed for that:
+
+  * puts ``modules/`` on ``sys.path`` so the flat imports used by the firmware
+    (``from async_queue import Queue`` etc.) resolve; and
+  * shims the MicroPython-only ``time.ticks_us`` / ``time.ticks_diff`` used by
+    ``perf_timer`` so it imports and runs under CPython.
+
+Run from the project root with:  python -m unittest discover -t . -s tests
+"""
+
+import os
+import sys
+import time
+
+_MODULES = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "modules"
+)
+
+if _MODULES not in sys.path:
+    sys.path.insert(0, _MODULES)
+
+if not hasattr(time, "ticks_us"):
+    time.ticks_us = lambda: int(time.monotonic() * 1_000_000)
+if not hasattr(time, "ticks_diff"):
+    time.ticks_diff = lambda a, b: a - b

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,12 +1,16 @@
 """Test suite bootstrap.
 
 These tests run under CPython, but the modules under test are written for
-MicroPython. Importing this package wires up the two things needed for that:
+MicroPython. Importing this package wires up the things needed for that:
 
   * puts ``modules/`` on ``sys.path`` so the flat imports used by the firmware
-    (``from async_queue import Queue`` etc.) resolve; and
+    (``from async_queue import Queue`` etc.) resolve.
   * shims the MicroPython-only ``time.ticks_us`` / ``time.ticks_diff`` used by
     ``perf_timer`` so it imports and runs under CPython.
+  * stubs the native ``display`` module
+  * imports ``system.scheduler`` before anything imports.
+    On the badge boot happens to import scheduler first, here we do it explicitly
+    to prevent import issues.
 
 Run from the project root with:  python -m unittest discover -t . -s tests
 """
@@ -14,6 +18,7 @@ Run from the project root with:  python -m unittest discover -t . -s tests
 import os
 import sys
 import time
+import types
 
 _MODULES = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "modules"
@@ -26,3 +31,7 @@ if not hasattr(time, "ticks_us"):
     time.ticks_us = lambda: int(time.monotonic() * 1_000_000)
 if not hasattr(time, "ticks_diff"):
     time.ticks_diff = lambda a, b: a - b
+
+sys.modules.setdefault("display", types.ModuleType("display"))
+
+import system.scheduler  # noqa: E402,F401

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,8 @@ MicroPython. Importing this package wires up the things needed for that:
   * puts ``modules/`` on ``sys.path`` so the flat imports used by the firmware
     (``from async_queue import Queue`` etc.) resolve.
   * shims the MicroPython-only ``time.ticks_us`` / ``time.ticks_diff`` used by
-    ``perf_timer`` so it imports and runs under CPython.
+    ``perf_timer`` and ``sys.print_exception`` used by the eventbus error
+    handling so they import and run under CPython.
   * stubs the native ``display`` module
   * imports ``system.scheduler`` before anything imports.
     On the badge boot happens to import scheduler first, here we do it explicitly
@@ -31,6 +32,14 @@ if not hasattr(time, "ticks_us"):
     time.ticks_us = lambda: int(time.monotonic() * 1_000_000)
 if not hasattr(time, "ticks_diff"):
     time.ticks_diff = lambda a, b: a - b
+
+if not hasattr(sys, "print_exception"):
+    import traceback
+
+    def _print_exception(exc, file=sys.stderr):
+        traceback.print_exception(type(exc), exc, exc.__traceback__, file=file)
+
+    sys.print_exception = _print_exception
 
 sys.modules.setdefault("display", types.ModuleType("display"))
 

--- a/tests/test_custom_event.py
+++ b/tests/test_custom_event.py
@@ -1,0 +1,38 @@
+import unittest
+
+from events.custom import CustomEvent
+
+
+class CustomEventTest(unittest.TestCase):
+    def test_getitem_reads_from_data(self):
+        event = CustomEvent("test", {"foo": 1})
+        self.assertEqual(event["foo"], 1)
+
+    def test_getitem_missing_key_raises(self):
+        event = CustomEvent("test", {})
+        with self.assertRaises(KeyError):
+            event["nope"]
+
+    def test_setitem_writes_to_data(self):
+        event = CustomEvent("test", {})
+        event["foo"] = 42
+        self.assertEqual(event.data["foo"], 42)
+        self.assertEqual(event["foo"], 42)
+
+    def test_contains(self):
+        event = CustomEvent("test", {"foo": 1})
+        self.assertIn("foo", event)
+        self.assertNotIn("bar", event)
+
+    def test_requires_focus_defaults_false(self):
+        self.assertFalse(CustomEvent("test", {}).requires_focus)
+        self.assertTrue(CustomEvent("test", {}, requires_focus=True).requires_focus)
+
+    def test_repr_includes_type_and_data(self):
+        text = repr(CustomEvent("test", {"foo": 1}))
+        self.assertIn("test", text)
+        self.assertIn("foo", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_eventbus.py
+++ b/tests/test_eventbus.py
@@ -1,7 +1,10 @@
 import asyncio
 import unittest
 
+import system.eventbus as eventbus_module
 from system.eventbus import _EventBus, _matches, _type_name
+from system.scheduler.events import RequestStopAppEvent
+from system.notification.events import ShowNotificationEvent
 from events import Event
 from events.custom import CustomEvent
 
@@ -163,3 +166,60 @@ class EventBusFocusTest(unittest.IsolatedAsyncioTestCase):
         self.bus.on("test", self.handler, App(focused=False))
         await drive(self.bus, [CustomEvent("test", {}, requires_focus=True)])
         self.assertEqual(self.received, [])
+
+
+class EventBusExceptionHandlingTest(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.bus = _EventBus()
+        self._real_singleton = eventbus_module.eventbus
+        eventbus_module.eventbus = self.bus
+        self.app = App()
+        self.observer = App()
+        self.stops = []
+        self.notifications = []
+        self.bus.on(RequestStopAppEvent, self.stops.append, self.observer)
+        self.bus.on(ShowNotificationEvent, self.notifications.append, self.observer)
+
+    def tearDown(self):
+        eventbus_module.eventbus = self._real_singleton
+
+    @staticmethod
+    def _boom(event):
+        raise RuntimeError("boom")
+
+    def _assert_app_stopped(self):
+        self.assertEqual([e.app for e in self.stops], [self.app])
+        self.assertEqual(len(self.notifications), 1)
+        self.assertIn("App has crashed", self.notifications[0].message)
+
+    async def test_sync_handler_exception_stops_app_and_notifies(self):
+        self.bus.on("crash", self._boom, self.app)
+        await drive(self.bus, [CustomEvent("crash", {})])
+        self._assert_app_stopped()
+
+    async def test_async_handler_exception_stops_app_and_notifies(self):
+        async def boom(event):
+            raise RuntimeError("boom")
+
+        self.bus.on_async("crash", boom, self.app)
+        await drive(self.bus, [CustomEvent("crash", {})])
+        self._assert_app_stopped()
+
+    async def test_exception_does_not_block_other_apps(self):
+        # A crashing handler on one app must not stop a healthy handler on
+        # another app from receiving the same event.
+        received = []
+        self.bus.on("crash", self._boom, self.app)
+        self.bus.on("crash", received.append, App())
+        await drive(self.bus, [CustomEvent("crash", {})])
+        self.assertEqual(len(received), 1)
+        self._assert_app_stopped()
+
+    async def test_run_loop_survives_exception(self):
+        # After a handler raises, later events must still be processed.
+        received = []
+        self.bus.on("crash", self._boom, self.app)
+        self.bus.on("ok", received.append, App())
+        await drive(self.bus, [CustomEvent("crash", {}), CustomEvent("ok", {})])
+        self.assertEqual(len(received), 1)

--- a/tests/test_eventbus.py
+++ b/tests/test_eventbus.py
@@ -1,0 +1,176 @@
+import asyncio
+import unittest
+
+from system.eventbus import _EventBus, _matches, _type_name
+from events import Event
+from events.custom import CustomEvent
+
+
+class DummyEvent(Event):
+    pass
+
+
+class OtherEvent(Event):
+    pass
+
+
+class App:
+    """Minimal stand-in for an app."""
+
+    def __init__(self, focused=True):
+        self._focused = focused
+
+
+async def drive(bus, events):
+    """Run the bus long enough to process ``events``, then stop it."""
+    task = asyncio.create_task(bus.run())
+    for event in events:
+        bus.emit(event)
+    # Yield repeatedly so run() can drain the queue and schedule handlers.
+    for _ in range(20):
+        await asyncio.sleep(0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+class MatchesTest(unittest.TestCase):
+    def test_class_matches_by_isinstance(self):
+        self.assertTrue(_matches(DummyEvent(), DummyEvent))
+        self.assertFalse(_matches(OtherEvent(), DummyEvent))
+
+    def test_string_matches_custom_event_type(self):
+        self.assertTrue(_matches(CustomEvent("test", {}), "test"))
+        self.assertFalse(_matches(CustomEvent("other", {}), "test"))
+
+    def test_string_matches_dict_type_field(self):
+        self.assertTrue(_matches({"type": "test"}, "test"))
+        self.assertFalse(_matches({"type": "other"}, "test"))
+        self.assertFalse(_matches({}, "test"))
+
+    def test_string_does_not_match_plain_object(self):
+        self.assertFalse(_matches(DummyEvent(), "test"))
+
+
+class TypeNameTest(unittest.TestCase):
+    def test_class_uses_dunder_name(self):
+        self.assertEqual(_type_name(DummyEvent), "DummyEvent")
+
+    def test_string_is_returned_as_is(self):
+        self.assertEqual(_type_name("test"), "test")
+
+
+class EventBusDispatchTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bus = _EventBus()
+        self.received = []
+        self.app = App()
+
+    def handler(self, event):
+        self.received.append(event)
+
+    async def test_class_registration_still_works(self):
+        self.bus.on(DummyEvent, self.handler, self.app)
+        event = DummyEvent()
+        await drive(self.bus, [event, OtherEvent()])
+        self.assertEqual(self.received, [event])
+
+    async def test_custom_event_by_string_type(self):
+        self.bus.on("test", self.handler, self.app)
+        event = CustomEvent("test", {"foo": 1})
+        await drive(self.bus, [event, CustomEvent("other", {})])
+        self.assertEqual(self.received, [event])
+
+    async def test_dict_event_by_string_type(self):
+        self.bus.on("test", self.handler, self.app)
+        event = {"type": "test", "foo": 1}
+        await drive(self.bus, [event, {"type": "other"}])
+        self.assertEqual(self.received, [event])
+
+    async def test_dict_class_receives_all_dict_events(self):
+        # Registering on the ``dict`` class (rather than a string type) should
+        # match every dict event regardless of its "type" field.
+        self.bus.on(dict, self.handler, self.app)
+        events = [{"type": "test"}, {"type": "other"}, {"no_type": 1}]
+        await drive(self.bus, events + [CustomEvent("test", {})])
+        self.assertEqual(self.received, events)
+
+    async def test_typeless_dict_ignored_by_string_subscriber(self):
+        # A dict without a "type" key has no type to match, so a string
+        # subscription never receives it (dict.get("type") is None).
+        self.bus.on("test", self.handler, self.app)
+        await drive(self.bus, [{"no_type": 1}, {"type": None}])
+        self.assertEqual(self.received, [])
+
+    async def test_typeless_dict_still_reaches_dict_class_subscriber(self):
+        # Subscribing on the dict class ignores "type" entirely, so a typeless
+        # dict is still delivered.
+        self.bus.on(dict, self.handler, self.app)
+        event = {"no_type": 1}
+        await drive(self.bus, [event])
+        self.assertEqual(self.received, [event])
+
+    async def test_async_handler(self):
+        async def async_handler(event):
+            self.received.append(event)
+
+        self.bus.on_async("test", async_handler, self.app)
+        event = CustomEvent("test", {})
+        await drive(self.bus, [event])
+        self.assertEqual(self.received, [event])
+
+    async def test_remove_stops_delivery(self):
+        self.bus.on("test", self.handler, self.app)
+        self.bus.remove("test", self.handler, self.app)
+        await drive(self.bus, [CustomEvent("test", {})])
+        self.assertEqual(self.received, [])
+
+    async def test_deregister_removes_app(self):
+        self.bus.on("test", self.handler, self.app)
+        self.bus.deregister(self.app)
+        await drive(self.bus, [CustomEvent("test", {})])
+        self.assertEqual(self.received, [])
+
+
+class EventBusFocusTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bus = _EventBus()
+        self.received = []
+
+    def handler(self, event):
+        self.received.append(event)
+
+    async def test_focus_required_dict_skips_unfocused_app(self):
+        self.bus.on("test", self.handler, App(focused=False))
+        await drive(self.bus, [{"type": "test", "requires_focus": True}])
+        self.assertEqual(self.received, [])
+
+    async def test_focus_required_dict_reaches_focused_app(self):
+        self.bus.on("test", self.handler, App(focused=True))
+        event = {"type": "test", "requires_focus": True}
+        await drive(self.bus, [event])
+        self.assertEqual(self.received, [event])
+
+    async def test_no_focus_required_reaches_unfocused_app(self):
+        self.bus.on("test", self.handler, App(focused=False))
+        event = {"type": "test"}
+        await drive(self.bus, [event])
+        self.assertEqual(self.received, [event])
+
+    async def test_custom_event_requires_focus_attribute(self):
+        self.bus.on("test", self.handler, App(focused=False))
+        await drive(self.bus, [CustomEvent("test", {}, requires_focus=True)])
+        self.assertEqual(self.received, [])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+    eventbus.on("blabla", doshit())
+
+    {"type": "blabla", "otherhting": "whatever"}
+
+    CustomEvent(type="blabla", data={"alskdjflaskdjfalskdfj": "alsdkfj"})

--- a/tests/test_eventbus.py
+++ b/tests/test_eventbus.py
@@ -163,14 +163,3 @@ class EventBusFocusTest(unittest.IsolatedAsyncioTestCase):
         self.bus.on("test", self.handler, App(focused=False))
         await drive(self.bus, [CustomEvent("test", {}, requires_focus=True)])
         self.assertEqual(self.received, [])
-
-
-if __name__ == "__main__":
-    unittest.main()
-
-
-    eventbus.on("blabla", doshit())
-
-    {"type": "blabla", "otherhting": "whatever"}
-
-    CustomEvent(type="blabla", data={"alskdjflaskdjfalskdfj": "alsdkfj"})


### PR DESCRIPTION
# Description

After the discussion about ad-hoc events and capabilities today, it seemed good to allow subscribing to events with only a string instead of a class definition. 

People were already using dicts and subscribing to dict events, which puts the burden of filtering for the events they are interested in on their app. This should be the responsibility of the eventbus, so this PR modifies it to make it more flexible and allow subscribing based on strings:

```python
eventbus.on("somethinghappened", dothething, app)
```

will call `dothething` for `CustomEvent`s with `type = somethinghappened`:

```python
eventbus.emit(CustomEvent(type="somethinghappened", data={"whatever": "youwanttoputhere"})
```

or `dict`s with an entry `yourdict["type"] = "somethinghappened"`:

```python
eventbus.emit({"type": "somethinghappened", "otherthing": "hi")
```

You can also still subscribe to classes (even `dict` to just get all dict events) like before

This seems like a good way to sidestep the issues with needing to share event classes / PRing them into the firmware etc.

Let me know what you think! 