### PR TITLE
Update menu items in AppStoreApp to conditionally show uninstall option

### DIFF
--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -253,14 +253,13 @@ class AppStoreApp(app.App):
             elif value == REFRESH:
                 self.get_index()
 
+        menu_items = [AVAILABLE, CODE_INSTALL, UPDATE]
+        if len(list_all_apps()) > 0:
+            menu_items.append(INSTALLED) # Only show uninstall option if there are installed apps (else a zero-length menu crashes)
+
         self.menu = Menu(
             self,
-            menu_items=[
-                AVAILABLE,
-                CODE_INSTALL,
-                UPDATE,
-                INSTALLED,
-            ],
+            menu_items=menu_items,
             select_handler=on_select,
             back_handler=on_cancel,
         )

--- a/modules/firmware_apps/app_store.py
+++ b/modules/firmware_apps/app_store.py
@@ -255,7 +255,9 @@ class AppStoreApp(app.App):
 
         menu_items = [AVAILABLE, CODE_INSTALL, UPDATE]
         if len(list_all_apps()) > 0:
-            menu_items.append(INSTALLED) # Only show uninstall option if there are installed apps (else a zero-length menu crashes)
+            menu_items.append(
+                INSTALLED
+            )  # Only show uninstall option if there are installed apps (else a zero-length menu crashes)
 
         self.menu = Menu(
             self,


### PR DESCRIPTION
In the App store, if there are no apps installed, selecting "Uninstall" crashes the app as it attempts to show a zero-length Menu. This commit only shows the "Uninstall" option in the App store if `len(list_all_apps()) > 0`.