### PR TITLE
Disable drawlist mode

### DIFF
--- a/drivers/gc9a01/display.c
+++ b/drivers/gc9a01/display.c
@@ -6,7 +6,7 @@
 
 #define TILDAGON_CTX_SHOW_FPS        0 // shows fps counter at top of display
 
-#define TILDAGON_CTX_DRAWLIST_MODE   1 // accumulates draw commands in drawlists
+#define TILDAGON_CTX_DRAWLIST_MODE   0 // accumulates draw commands in drawlists
    // and render changed sub-regions of display, the opposite is
    // DIRECT mode
    //


### PR DESCRIPTION
We are seeing some bugs related to image rendering, such as #390. From bisecting, I believe that drawlist mode may be the reason. This PR disables it, while leaving the code to implement it in place.
