### PR TITLE
Update simple_tildagon library with display support

### DIFF
--- a/modules/lib/simple_tildagon.py
+++ b/modules/lib/simple_tildagon.py
@@ -152,7 +152,17 @@ class BadgeDisplay:
         clear_background(ctx)
         hw_display.end_frame(ctx)
 
-    def draw_text(self, text, delay=0, x=0, y=0, font_size=30, color=(255, 255, 255), clear_before=True, align_center=True):
+    def draw_text(
+        self,
+        text,
+        delay=0,
+        x=0,
+        y=0,
+        font_size=30,
+        color=(255, 255, 255),
+        clear_before=True,
+        align_center=True,
+    ):
         # Draw text in the middle of the screen
 
         # Needed as first text write always fails (draws only first letter) for an unknown reason
@@ -160,7 +170,15 @@ class BadgeDisplay:
             ctx = hw_display.get_ctx()
             if clear_before:
                 clear_background(ctx)
-            Image.text(ctx, text, x=x, y=y, font_size=font_size, color=color, align_center=align_center)
+            Image.text(
+                ctx,
+                text,
+                x=x,
+                y=y,
+                font_size=font_size,
+                color=color,
+                align_center=align_center,
+            )
             hw_display.end_frame(ctx)
         if delay:
             time.sleep(delay)
@@ -184,7 +202,7 @@ class Image:
         eye_y = -size * 0.15
         ctx.rgb(*eye_color).arc(-eye_x, eye_y, eye_r, 0, 2 * math.pi, False).fill()
         ctx.rgb(*eye_color).arc(eye_x, eye_y, eye_r, 0, 2 * math.pi, False).fill()
-    
+
     @staticmethod
     def _arrow(ctx, size=140):
         # Draw the shaft
@@ -204,7 +222,9 @@ class Image:
         ctx.fill()
 
     @staticmethod
-    def text(ctx, text, x=0, y=0, font_size=30, color=(255, 255, 255), align_center=True):
+    def text(
+        ctx, text, x=0, y=0, font_size=30, color=(255, 255, 255), align_center=True
+    ):
         ctx.save()
         ctx.font = ctx.get_font_name(0)  # Select a real embedded font
         ctx.font_size = font_size
@@ -221,14 +241,38 @@ class Image:
         ctx.restore()
 
     @staticmethod
-    def HAPPY(ctx, x=0, y=0, size=160, face_color=(1, 1, 0), eye_color=(0, 0, 0), mouth_color=(0, 0, 0)):
-        Image._face_base(ctx, x=x, y=y, size=size, face_color=face_color, eye_color=eye_color)
-        ctx.rgb(*mouth_color).arc(0, size * 0.08, size * 0.35, 0.2 * math.pi, 0.8 * math.pi, False).fill()
+    def HAPPY(
+        ctx,
+        x=0,
+        y=0,
+        size=160,
+        face_color=(1, 1, 0),
+        eye_color=(0, 0, 0),
+        mouth_color=(0, 0, 0),
+    ):
+        Image._face_base(
+            ctx, x=x, y=y, size=size, face_color=face_color, eye_color=eye_color
+        )
+        ctx.rgb(*mouth_color).arc(
+            0, size * 0.08, size * 0.35, 0.2 * math.pi, 0.8 * math.pi, False
+        ).fill()
 
     @staticmethod
-    def SAD(ctx, x=0, y=0, size=160, face_color=(1, 1, 0), eye_color=(0, 0, 0), mouth_color=(0, 0, 0)):
-        Image._face_base(ctx, x=x, y=y, size=size, face_color=face_color, eye_color=eye_color)
-        ctx.rgb(*mouth_color).arc(0, size * 0.25, size * 0.35, 1.2 * math.pi, 1.8 * math.pi, False).fill()
+    def SAD(
+        ctx,
+        x=0,
+        y=0,
+        size=160,
+        face_color=(1, 1, 0),
+        eye_color=(0, 0, 0),
+        mouth_color=(0, 0, 0),
+    ):
+        Image._face_base(
+            ctx, x=x, y=y, size=size, face_color=face_color, eye_color=eye_color
+        )
+        ctx.rgb(*mouth_color).arc(
+            0, size * 0.25, size * 0.35, 1.2 * math.pi, 1.8 * math.pi, False
+        ).fill()
 
     @staticmethod
     def HEART(ctx):
@@ -269,7 +313,6 @@ class Image:
         Image._arrow(ctx, size)
         ctx.restore()
 
-
     @staticmethod
     def ARROW_S(ctx, size=140):
         ctx.save()
@@ -277,14 +320,12 @@ class Image:
         Image._arrow(ctx, size)
         ctx.restore()
 
-
     @staticmethod
     def ARROW_E(ctx, size=140):
         ctx.save()
         ctx.rotate(math.pi / 2)
         Image._arrow(ctx, size)
         ctx.restore()
-
 
     @staticmethod
     def ARROW_W(ctx, size=140):
@@ -337,4 +378,3 @@ class Image:
 
 # Export a simple display instance
 display = BadgeDisplay()
-

--- a/modules/lib/simple_tildagon.py
+++ b/modules/lib/simple_tildagon.py
@@ -1,4 +1,6 @@
-# A easy to use module for the basic components of the tildagon badge
+# An easy to use module for the basic components of the tildagon badge
+
+__version__ = "0.2.0"
 
 from tildagonos import tildagonos
 from egpio import ePin
@@ -126,7 +128,7 @@ class BadgeDisplay:
     """Simple display API wrapper with `show`, `clear`, `draw_text`"""
 
     def show(self, what, delay=0.5):
-        # Accept strings, keywords 'happy'/'sad', callables that draw(ctx), or lists for simple animations
+        # Accept strings, Image objects, callables that draw(ctx), or lists for simple animations
         if hasattr(what, "__iter__") and not isinstance(what, str):
             for frame in what:
                 self.show(frame, delay=delay)
@@ -134,19 +136,7 @@ class BadgeDisplay:
 
         ctx = hw_display.get_ctx()
         clear_background(ctx)
-        # Accept string keys
-        if isinstance(what, str):
-            key = what.lower()
-        else:
-            key = None
-
-        if key:
-            handler = IMAGE_HANDLERS.get(key)
-            if handler:
-                handler(ctx)
-            else:
-                Image.text(ctx, what if isinstance(what, str) else key)
-        elif callable(what):
+        if callable(what):
             # custom draw function that accepts ctx
             what(ctx)
         else:
@@ -162,18 +152,16 @@ class BadgeDisplay:
         clear_background(ctx)
         hw_display.end_frame(ctx)
 
-    def draw_text(self, text, delay=0, clear_before=True, initial=True):
+    def draw_text(self, text, delay=0, x=0, y=0, font_size=30, color=(255, 255, 255), clear_before=True, align_center=True):
         # Draw text in the middle of the screen
-        
+
         # Needed as first text write always fails (draws only first letter) for an unknown reason
-        if initial:
-            self.draw_text("-", delay=delay, clear_before=clear_before, initial=False)
-        ctx = hw_display.get_ctx()
-        if clear_before:
-            clear_background(ctx)
-            #time.sleep(0.05)
-            Image.text(ctx, text)
-        hw_display.end_frame(ctx)
+        for i in range(2):
+            ctx = hw_display.get_ctx()
+            if clear_before:
+                clear_background(ctx)
+            Image.text(ctx, text, x=x, y=y, font_size=font_size, color=color, align_center=align_center)
+            hw_display.end_frame(ctx)
         if delay:
             time.sleep(delay)
 
@@ -216,14 +204,19 @@ class Image:
         ctx.fill()
 
     @staticmethod
-    def text(ctx, text, x=0, y=0, font_size=24, color=(1, 1, 1), align_center=True):
+    def text(ctx, text, x=0, y=0, font_size=30, color=(255, 255, 255), align_center=True):
         ctx.save()
         ctx.font = ctx.get_font_name(0)  # Select a real embedded font
         ctx.font_size = font_size
         if align_center:
             ctx.text_align = ctx.CENTER
             ctx.text_baseline = ctx.MIDDLE
-        ctx.rgb(*color)
+        # Accept either 0-1 floats or 0-255 ints for text color.
+        if all(0 <= c <= 1 for c in color):
+            rgb = color
+        else:
+            rgb = tuple(max(0, min(255, c)) / 255 for c in color)
+        ctx.rgb(*rgb)
         ctx.move_to(x, y).text(text)
         ctx.restore()
 
@@ -342,11 +335,6 @@ class Image:
         ctx.restore()
 
 
-# auto-generate IMAGE_HANDLERS from uppercase Image methods
-IMAGE_HANDLERS = {}
-for _attr in dir(Image):
-    if _attr.isupper():
-        IMAGE_HANDLERS[_attr.lower()] = getattr(Image, _attr)
-
 # Export a simple display instance
 display = BadgeDisplay()
+

--- a/modules/lib/simple_tildagon.py
+++ b/modules/lib/simple_tildagon.py
@@ -5,6 +5,8 @@ from egpio import ePin
 import imu as tilda_imu
 import math
 import time
+import display as hw_display
+from app_components import clear_background
 
 
 class led:
@@ -118,3 +120,233 @@ class imu:
         raw_data = tilda_imu.acc_read()
         acc_object = imu.ImuData(raw_data[0], raw_data[1], raw_data[2])
         return acc_object
+
+
+class BadgeDisplay:
+    """Simple display API wrapper with `show`, `clear`, `draw_text`"""
+
+    def show(self, what, delay=0.5):
+        # Accept strings, keywords 'happy'/'sad', callables that draw(ctx), or lists for simple animations
+        if hasattr(what, "__iter__") and not isinstance(what, str):
+            for frame in what:
+                self.show(frame, delay=delay)
+            return
+
+        ctx = hw_display.get_ctx()
+        clear_background(ctx)
+        # Accept string keys
+        if isinstance(what, str):
+            key = what.lower()
+        else:
+            key = None
+
+        if key:
+            handler = IMAGE_HANDLERS.get(key)
+            if handler:
+                handler(ctx)
+            else:
+                Image.text(ctx, what if isinstance(what, str) else key)
+        elif callable(what):
+            # custom draw function that accepts ctx
+            what(ctx)
+        else:
+            # fallback to text representation
+            Image.text(ctx, str(what))
+
+        hw_display.end_frame(ctx)
+        if delay:
+            time.sleep(delay)
+
+    def clear(self):
+        ctx = hw_display.get_ctx()
+        clear_background(ctx)
+        hw_display.end_frame(ctx)
+
+    def draw_text(self, text, delay=0, clear_before=True, initial=True):
+        # Draw text in the middle of the screen
+        
+        # Needed as first text write always fails (draws only first letter) for an unknown reason
+        if initial:
+            self.draw_text("-", delay=delay, clear_before=clear_before, initial=False)
+        ctx = hw_display.get_ctx()
+        if clear_before:
+            clear_background(ctx)
+            #time.sleep(0.05)
+            Image.text(ctx, text)
+        hw_display.end_frame(ctx)
+        if delay:
+            time.sleep(delay)
+
+
+class Image:
+    """Image namespace with drawing methods and constants.
+
+    Use like `Image.HAPPY` (constant) or pass `Image.HAPPY` as a callable to `display.show()`.
+    """
+
+    @staticmethod
+    def _face_base(ctx, x=0, y=0, size=120, face_color=(1, 1, 0), eye_color=(0, 0, 0)):
+        ctx.save()
+        ctx.translate(x, y)
+        r = size / 2
+        ctx.rgb(*face_color).arc(0, 0, r, 0, 2 * math.pi, False).fill()
+
+        eye_r = size * 0.06
+        eye_x = size * 0.25
+        eye_y = -size * 0.15
+        ctx.rgb(*eye_color).arc(-eye_x, eye_y, eye_r, 0, 2 * math.pi, False).fill()
+        ctx.rgb(*eye_color).arc(eye_x, eye_y, eye_r, 0, 2 * math.pi, False).fill()
+    
+    @staticmethod
+    def _arrow(ctx, size=140):
+        # Draw the shaft
+        ctx.rgb(1, 1, 1)
+        ctx.line_width = size * 0.12
+        ctx.begin_path()
+        ctx.move_to(0, size * 0.45)
+        ctx.line_to(0, -size * 0.12)
+        ctx.stroke()
+
+        # Draw a smaller arrowhead
+        ctx.begin_path()
+        ctx.move_to(0, -size * 0.5)
+        ctx.line_to(size * 0.22, -size * 0.1)
+        ctx.line_to(-size * 0.22, -size * 0.1)
+        ctx.close_path()
+        ctx.fill()
+
+    @staticmethod
+    def text(ctx, text, x=0, y=0, font_size=24, color=(1, 1, 1), align_center=True):
+        ctx.save()
+        ctx.font = ctx.get_font_name(0)  # Select a real embedded font
+        ctx.font_size = font_size
+        if align_center:
+            ctx.text_align = ctx.CENTER
+            ctx.text_baseline = ctx.MIDDLE
+        ctx.rgb(*color)
+        ctx.move_to(x, y).text(text)
+        ctx.restore()
+
+    @staticmethod
+    def HAPPY(ctx, x=0, y=0, size=160, face_color=(1, 1, 0), eye_color=(0, 0, 0), mouth_color=(0, 0, 0)):
+        Image._face_base(ctx, x=x, y=y, size=size, face_color=face_color, eye_color=eye_color)
+        ctx.rgb(*mouth_color).arc(0, size * 0.08, size * 0.35, 0.2 * math.pi, 0.8 * math.pi, False).fill()
+
+    @staticmethod
+    def SAD(ctx, x=0, y=0, size=160, face_color=(1, 1, 0), eye_color=(0, 0, 0), mouth_color=(0, 0, 0)):
+        Image._face_base(ctx, x=x, y=y, size=size, face_color=face_color, eye_color=eye_color)
+        ctx.rgb(*mouth_color).arc(0, size * 0.25, size * 0.35, 1.2 * math.pi, 1.8 * math.pi, False).fill()
+
+    @staticmethod
+    def HEART(ctx):
+        Image.text(ctx, "♥", x=0, y=0, font_size=180)
+
+    @staticmethod
+    def HEART_SMALL(ctx):
+        Image.text(ctx, "♥", x=0, y=0, font_size=120)
+
+    @staticmethod
+    def YES(ctx):
+        ctx.save()
+        ctx.rgb(0, 1, 0)
+        ctx.line_width = 18
+        ctx.begin_path()
+        ctx.move_to(-70, 0)
+        ctx.line_to(-10, 40)
+        ctx.line_to(70, -40)
+        ctx.stroke()
+        ctx.restore()
+
+    @staticmethod
+    def NO(ctx):
+        ctx.save()
+        ctx.rgb(1, 0, 0)
+        ctx.line_width = 18
+        ctx.begin_path()
+        ctx.move_to(-60, -60)
+        ctx.line_to(60, 60)
+        ctx.move_to(-60, 60)
+        ctx.line_to(60, -60)
+        ctx.stroke()
+        ctx.restore()
+
+    @staticmethod
+    def ARROW_N(ctx, size=140):
+        ctx.save()
+        Image._arrow(ctx, size)
+        ctx.restore()
+
+
+    @staticmethod
+    def ARROW_S(ctx, size=140):
+        ctx.save()
+        ctx.rotate(math.pi)
+        Image._arrow(ctx, size)
+        ctx.restore()
+
+
+    @staticmethod
+    def ARROW_E(ctx, size=140):
+        ctx.save()
+        ctx.rotate(math.pi / 2)
+        Image._arrow(ctx, size)
+        ctx.restore()
+
+
+    @staticmethod
+    def ARROW_W(ctx, size=140):
+        ctx.save()
+        ctx.rotate(-math.pi / 2)
+        Image._arrow(ctx, size)
+        ctx.restore()
+
+    @staticmethod
+    def CONFUSED(ctx):
+        Image._face_base(ctx, x=0, y=0, size=160)
+        ctx.rgb(0, 0, 0)
+        ctx.arc(-40, -20, 8, 0, 2 * math.pi, False).fill()
+        ctx.arc(40, -20, 8, 0, 2 * math.pi, False).fill()
+        ctx.line_width = 6
+        ctx.begin_path()
+        ctx.move_to(-30, 30)
+        ctx.rel_line_to(15, -12)
+        ctx.rel_line_to(15, 12)
+        ctx.rel_line_to(15, -12)
+        ctx.stroke()
+        ctx.restore()
+
+    @staticmethod
+    def SURPRISED(ctx):
+        Image._face_base(ctx, x=0, y=0, size=160)
+        ctx.rgb(0, 0, 0)
+        ctx.arc(-35, -20, 12, 0, 2 * math.pi, False).fill()
+        ctx.arc(35, -20, 12, 0, 2 * math.pi, False).fill()
+        ctx.arc(0, 30, 28, 0, 2 * math.pi, False).fill()
+        ctx.restore()
+
+    @staticmethod
+    def ANGRY(ctx):
+        Image._face_base(ctx, x=0, y=0, size=160)
+        ctx.rgb(0, 0, 0)
+        ctx.line_width = 12
+        ctx.begin_path()
+        ctx.move_to(-50, -50)
+        ctx.line_to(-10, -30)
+        ctx.stroke()
+        ctx.begin_path()
+        ctx.move_to(50, -50)
+        ctx.line_to(10, -30)
+        ctx.stroke()
+        ctx.rgb(0, 0, 0)
+        ctx.arc(0, 40, 56, 1.2 * math.pi, 1.8 * math.pi, False).fill()
+        ctx.restore()
+
+
+# auto-generate IMAGE_HANDLERS from uppercase Image methods
+IMAGE_HANDLERS = {}
+for _attr in dir(Image):
+    if _attr.isupper():
+        IMAGE_HANDLERS[_attr.lower()] = getattr(Image, _attr)
+
+# Export a simple display instance
+display = BadgeDisplay()


### PR DESCRIPTION
# Description

Add display functionality to the beginner friendly `simple_tildagon.py` library. 
Inspired by the BBC Micro:Bit Python library, adds a collection of symbols/icons (including faces), as well as the ability to easily draw text on the screen.

Showing a picture becomes as simple as 


``` python
import simple_tildagon as st
st.display.show(st.Image.HAPPY)
```

Or displaying text
``` python
import simple_tildagon as st
st.display.draw_text('Hello world')
```

<img width="2560" height="1920" alt="image" src="https://github.com/user-attachments/assets/57b7e53f-d4d0-473d-9406-0d6274378b40" />

<img width="2560" height="1920" alt="image" src="https://github.com/user-attachments/assets/e6961179-2514-4c8a-9294-f4f517b9e917" />

<img width="2560" height="1920" alt="image" src="https://github.com/user-attachments/assets/e96f29a0-ccad-424f-9e07-a968fb1494b5" />

<img width="2560" height="1920" alt="image" src="https://github.com/user-attachments/assets/03de6b7b-b26e-4dee-a8f0-933fa8bf31ab" />

