### PR TITLE
Improve hexpansion bulk provisioning

### DIFF
--- a/modules/app_components/dialog.py
+++ b/modules/app_components/dialog.py
@@ -8,6 +8,7 @@ from events.keyboard import KEYBOARD_BUTTONS
 from system.eventbus import eventbus
 
 from .tokens import button_labels, label_font_size, set_color
+from .utils import wrap_text
 
 SPECIAL_KEY_META = "..."
 SPECIAL_KEY_DONE = "Done"
@@ -117,6 +118,7 @@ class ProgressDialog:
 
         # Tightly loop, waiting for a result, then return it
         while self.result is None:
+            await render_update()
             await asyncio.sleep(0.05)
         self.app.overlays.pop()
         await render_update()
@@ -131,10 +133,12 @@ class ProgressDialog:
         set_color(ctx, "label")
 
         if isinstance(self.message, list):
-            for idx, line in enumerate(self.message):
-                ctx.move_to(0, idx * text_height).text(line)
+            message = self.message
         else:
-            ctx.move_to(0, 0).text(self.message)
+            message = wrap_text(ctx, self.message, ctx.font_size)
+
+        for idx, line in enumerate(message):
+            ctx.move_to(0, idx * text_height).text(line)
 
     def draw(self, ctx):
         ctx.save()

--- a/modules/firmware_apps/hexpansionfw.py
+++ b/modules/firmware_apps/hexpansionfw.py
@@ -24,14 +24,15 @@ from system.hexpansion.util import (
     detect_eeprom_addr,
     get_hexpansion_block_devices,
     read_hexpansion_header,
+    handle_insertion_lock,
 )
 from system.notification.events import ShowNotificationEvent
 
 DEFAULT_REPO = (
     "https://github.com/emfcamp/hexpansion-firmwares/releases/download/latest/"
 )
-_FIRMWARE_URL = "{base}/firmware_0x{vid:04X}_0x{pid:04X}.tar.gz"
-_HEADER_URL = "{base}/firmware_0x{vid:04X}_0x{pid:04X}.json"
+_FIRMWARE_URL = "{base}/firmware_0x{vid:04x}_0x{pid:04x}.tar.gz"
+_HEADER_URL = "{base}/firmware_0x{vid:04x}_0x{pid:04x}.json"
 _TMP_PATH = "/firmware_dl.tar.gz"
 
 
@@ -242,6 +243,8 @@ class HexpansionDetail:
         i2c = I2C(port)
         await progress()
         addr, addr_len = detect_eeprom_addr(i2c)
+        if addr is None:
+            raise ValueError("No EEPROM detected")
         write_header(
             port,
             self.header,
@@ -276,7 +279,15 @@ class HexpansionDetail:
                 continue
             with open(f"{mountpoint}/{name}", "wb") as f:
                 f.write(archive_file.read())
+                f.flush()
                 await progress()
+        await progress()
+
+        header = read_hexpansion_header(i2c, addr, addr_len=addr_len)
+        if header != self.header:
+            print(header)
+            print(self.header)
+            raise ValueError("Header data mismatch")
 
     async def _factory_reset_wrapper(self):
         try:
@@ -325,17 +336,24 @@ class HexpansionDetail:
         return True
 
     async def _bulk_provision(self):
+        self.dialog = ProgressDialog("Downloading firmware", self.app)
+        progress = self.dialog.make_progress_handler(self.render_update)
+
         url = _FIRMWARE_URL.format(
             base=settings.get("hexpansion_firmware_repo", DEFAULT_REPO),
             vid=self.header.vid,
             pid=self.header.pid,
         )
         print(f"Downloading {url}")
-        response = await async_helpers.unblock(requests.get, self.render_update, url)
+        response = await async_helpers.unblock(requests.get, progress, url)
         with open(_TMP_PATH, "wb") as f:
             f.write(response.content)
+            f.flush()
 
-        eventbus.emit(ShowNotificationEvent(message="Bulk mode enabled"))
+        await handle_insertion_lock.acquire()
+
+        self.dialog.message = f"Ready\n{self.header.unique_id}"
+        await progress()
         eventbus.on_async(HexpansionInsertionEvent, self.bulk_insert, self.app)
 
     def _cleanup(self):
@@ -343,15 +361,27 @@ class HexpansionDetail:
 
     async def bulk_insert(self, event):
         self.header.unique_id += 1
-        print(f"Provisioning port {event.port} with unique_id {self.header.unique_id}")
+        self.dialog.message = f"Provisioning {self.header.unique_id}"
+        progress = self.dialog.make_progress_handler(self.render_update)
+
+        await progress()
+        print(f"Provisioning {event.port}\n{self.header.unique_id}")
+
         try:
-            await self._provision_port(event.port, self.render_update)
+            await self._provision_port(event.port, progress)
         except Exception:
-            eventbus.emit(ShowNotificationEvent(message="Failed to provision"))
+            self.header.unique_id -= 1
+            self.dialog.message = f"Provisioning {self.header.unique_id} failed"
         else:
-            eventbus.emit(
-                ShowNotificationEvent(message=f"Provisioned {self.header.unique_id}")
-            )
+            self.dialog.message = f"Ready\n{self.header.unique_id}"
+
+        handle_insertion_lock.release()
+        await progress()
+        await asyncio.sleep(0.1)
+        await progress()
+        await handle_insertion_lock.acquire()
+        await progress()
+
         self._layout = layout.LinearLayout(items=self._build_items())
 
     async def button_event(self, event):

--- a/modules/system/hexpansion/app.py
+++ b/modules/system/hexpansion/app.py
@@ -12,6 +12,7 @@ from system.hexpansion.util import (
     read_hexpansion_header,
     get_hexpansion_block_devices,
     detect_eeprom_addr,
+    handle_insertion_lock,
 )
 
 from app_components.dialog import YesNoDialog
@@ -132,7 +133,7 @@ class HexpansionManagerApp(app.App):
             _package = __import__(f"{mount}.app")
             package = _package.app
             print(f"Found app package: {package}")
-        except (ImportError, SyntaxError) as e:
+        except (ImportError, SyntaxError, ValueError) as e:
             print(e)
             print("App module not found")
             self._cleanup_import_path(old_cwd, old_sys_path)
@@ -219,6 +220,12 @@ class HexpansionManagerApp(app.App):
         if addr is None:
             print("Scan found no eeproms")
             return
+
+        # acquire and release the insertion lock - we don't care about
+        # keeping locked, but someone (provisioning) may want us to wait
+        # at this step
+        await handle_insertion_lock.acquire()
+        handle_insertion_lock.release()
 
         # Do we have a header?
         try:

--- a/modules/system/hexpansion/header.py
+++ b/modules/system/hexpansion/header.py
@@ -48,6 +48,12 @@ class HexpansionHeader:
             checksum ^= byte
         return checksum
 
+    def __eq__(self, other):
+        try:
+            return self.to_bytes() == other.to_bytes()
+        except Exception:
+            return False
+
     def to_bytes(self, include_checksum=True):
         b = struct.pack(
             self._header_format,

--- a/modules/system/hexpansion/util.py
+++ b/modules/system/hexpansion/util.py
@@ -1,9 +1,12 @@
+import asyncio
 from eeprom_i2c import EEPROM
 
 from eeprom_partition import EEPROMPartition
 from system.hexpansion.header import HexpansionHeader
 
 import typing
+
+handle_insertion_lock = asyncio.Lock()
 
 
 def detect_eeprom_addr(i2c):


### PR DESCRIPTION
This makes the bulk provisioning system easier to understand and more foolproof.

It adds on-screen state, and blocks hexpansion insertion logic during provisioning to prevent extranous messages about invalid headers.


Demo: https://www.youtube.com/watch?v=tUfV64_XQLg