### PR TITLE
move buttons to be polled

### DIFF
--- a/modules/frontboards/twentyfour.py
+++ b/modules/frontboards/twentyfour.py
@@ -143,7 +143,9 @@ class TwentyTwentyFour(FrontBoard):
 
                     for key in TwentyTwentyFour.button_states.keys():
                         if TwentyTwentyFour.button_states[key][0]:
-                            if TwentyTwentyFour.button_states[key][1] > (50 // tick_ms):
+                            if TwentyTwentyFour.button_states[key][1] > (
+                                200 // tick_ms
+                            ):
                                 await eventbus.emit_async(
                                     ButtonDownEvent(button=BUTTONS[key])
                                 )

--- a/modules/frontboards/twentyfour.py
+++ b/modules/frontboards/twentyfour.py
@@ -40,30 +40,6 @@ BUTTONS = {
 }
 
 
-def buttondown(epin):
-    booped = not machine.Pin(0, mode=machine.Pin.IN).value()
-    hexindex = 1
-    for key in TwentyTwentyFour.pin_assignment.keys():
-        if TwentyTwentyFour.pin_assignment[key] is epin:
-            if booped:
-                now = time.ticks_ms()
-                if TwentyTwentyFour.hexpansion_states[hexindex] is None:
-                    TwentyTwentyFour.hexpansion_states[hexindex] = now
-                    eventbus.emit(HexpansionInsertionEvent(port=hexindex))
-                hexindex += 1
-            else:
-                eventbus.emit(ButtonDownEvent(button=BUTTONS[key]))
-                TwentyTwentyFour.button_states[key][0] = True
-
-
-def buttonup(epin):
-    for key in TwentyTwentyFour.pin_assignment.keys():
-        if TwentyTwentyFour.pin_assignment[key] is epin:
-            eventbus.emit(ButtonUpEvent(button=BUTTONS[key]))
-            TwentyTwentyFour.button_states[key][0] = False
-            TwentyTwentyFour.button_states[key][1] = 0
-
-
 def scale_color(c):
     return (c[0] / 256.0, c[1] / 256.0, c[2] / 256.0)
 
@@ -120,14 +96,8 @@ class TwentyTwentyFour(FrontBoard):
         for key in TwentyTwentyFour.pin_assignment:
             gpio = self.BUTTON_PINS[BUTTONS[key]]
             TwentyTwentyFour.pin_assignment[key] = ePin(gpio)
-            if not sim:
-                TwentyTwentyFour.pin_assignment[key].irq(
-                    handler=buttondown, trigger=ePin.IRQ_FALLING
-                )
-                TwentyTwentyFour.pin_assignment[key].irq(
-                    handler=buttonup, trigger=ePin.IRQ_RISING
-                )
 
+        tick_ms = 10
         while True:
             booped = not machine.Pin(0, mode=machine.Pin.IN).value()
             if booped:
@@ -136,6 +106,11 @@ class TwentyTwentyFour(FrontBoard):
                     map(lambda i: self.BUTTON_PINS[BUTTONS[i]], "ABCDEF")
                 ):
                     state = TwentyTwentyFour.hexpansion_states[i + 1]
+                    button_down = not ePin(gpio).value()
+                    # print(i, now, state)
+                    if button_down and state is None:
+                        TwentyTwentyFour.hexpansion_states[i + 1] = now
+                        await eventbus.emit_async(HexpansionInsertionEvent(port=i + 1))
                     if state and time.ticks_diff(now, state) > 4000:
                         TwentyTwentyFour.hexpansion_states[i + 1] = None
                         await eventbus.emit_async(HexpansionRemovalEvent(port=i + 1))
@@ -153,12 +128,26 @@ class TwentyTwentyFour(FrontBoard):
                             )
                         TwentyTwentyFour.button_states[key][0] = button_down
                 else:
+                    for key in TwentyTwentyFour.pin_assignment.keys():
+                        button_down = not TwentyTwentyFour.pin_assignment[key].value()
+                        if button_down and not TwentyTwentyFour.button_states[key][0]:
+                            await eventbus.emit_async(
+                                ButtonDownEvent(button=BUTTONS[key])
+                            )
+                        if not button_down and TwentyTwentyFour.button_states[key][0]:
+                            await eventbus.emit_async(
+                                ButtonUpEvent(button=BUTTONS[key])
+                            )
+                            TwentyTwentyFour.button_states[key][1] = 0
+                        TwentyTwentyFour.button_states[key][0] = button_down
+
                     for key in TwentyTwentyFour.button_states.keys():
                         if TwentyTwentyFour.button_states[key][0]:
-                            if TwentyTwentyFour.button_states[key][1] > 4:
+                            if TwentyTwentyFour.button_states[key][1] > (50 // tick_ms):
                                 await eventbus.emit_async(
                                     ButtonDownEvent(button=BUTTONS[key])
                                 )
+                                TwentyTwentyFour.button_states[key][1] = 0
                             else:
                                 TwentyTwentyFour.button_states[key][1] += 1
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(tick_ms // 1000)

--- a/modules/frontboards/twentysix.py
+++ b/modules/frontboards/twentysix.py
@@ -91,32 +91,6 @@ TOUCH = {
 }
 
 
-def buttondown(epin):
-    booped = not machine.Pin(0, mode=machine.Pin.IN).value()
-    hexindex = 1
-    for key in TwentyTwentySix.pin_assignment.keys():
-        if TwentyTwentySix.pin_assignment[key] is epin:
-            if booped:
-                now = time.ticks_ms()
-                if TwentyTwentySix.hexpansion_states[hexindex] is None:
-                    TwentyTwentySix.hexpansion_states[hexindex] = now
-                    eventbus.emit(HexpansionInsertionEvent(port=hexindex))
-                hexindex += 1
-            else:
-                eventbus.emit(ButtonDownEvent(button=BUTTONS[key]))
-                TwentyTwentySix.button_states[key][0] = True
-                print(f"{key} down")
-
-
-def buttonup(epin):
-    for key in TwentyTwentySix.pin_assignment.keys():
-        if TwentyTwentySix.pin_assignment[key] is epin:
-            eventbus.emit(ButtonUpEvent(button=BUTTONS[key]))
-            TwentyTwentySix.button_states[key][0] = False
-            TwentyTwentySix.button_states[key][1] = 0
-            print(f"{key} up")
-
-
 def joy_down(epin):
     for key in TwentyTwentySix.joy_assignment.keys():
         if TwentyTwentySix.joy_assignment[key] is epin:
@@ -283,13 +257,6 @@ class TwentyTwentySix(FrontBoard):
         for key in TwentyTwentySix.pin_assignment:
             gpio = self.BUTTON_PINS[BUTTONS[key]]
             TwentyTwentySix.pin_assignment[key] = ePin(gpio)
-            if not sim:
-                TwentyTwentySix.pin_assignment[key].irq(
-                    handler=buttondown, trigger=ePin.IRQ_FALLING
-                )
-                TwentyTwentySix.pin_assignment[key].irq(
-                    handler=buttonup, trigger=ePin.IRQ_RISING
-                )
         for key in TwentyTwentySix.PROX_INPUTS:
             if not sim:
                 frontboard2026.set_cb(
@@ -315,19 +282,25 @@ class TwentyTwentySix(FrontBoard):
                     frontboard2026.IRQ_FALLING,
                 )
 
+        self.run_count = 0
+        tick_ms = 10
         while True:
-            frontboard2026.run()
+            if self.run_count == 0:
+                frontboard2026.run()
+                self.run_count = 150 // tick_ms
+            self.run_count = self.run_count - 1
             booped = not machine.Pin(0, mode=machine.Pin.IN).value()
             if booped:
                 now = time.ticks_ms()
                 for i, gpio in enumerate(
-                    map(
-                        lambda i: self.BUTTON_PINS[BUTTONS[i]],
-                        ["A", "B", "C", "D", "E", "CANCEL"],
-                    )
+                    map(lambda i: self.BUTTON_PINS[BUTTONS[i]], "ABCDEF")
                 ):
                     state = TwentyTwentySix.hexpansion_states[i + 1]
-                    if state and time.ticks_diff(now, state) > 4000:
+                    button_down = not ePin(gpio).value()
+                    if button_down and state is None:
+                        TwentyTwentySix.hexpansion_states[i + 1] = now
+                        await eventbus.emit_async(HexpansionInsertionEvent(port=i + 1))
+                    elif state and time.ticks_diff(now, state) > 4000:
                         TwentyTwentySix.hexpansion_states[i + 1] = None
                         await eventbus.emit_async(HexpansionRemovalEvent(port=i + 1))
             else:
@@ -344,21 +317,38 @@ class TwentyTwentySix(FrontBoard):
                             )
                         TwentyTwentySix.button_states[key][0] = button_down
                 else:
+                    for key in TwentyTwentySix.pin_assignment.keys():
+                        button_down = not TwentyTwentySix.pin_assignment[key].value()
+                        if button_down and not TwentyTwentySix.button_states[key][0]:
+                            await eventbus.emit_async(
+                                ButtonDownEvent(button=BUTTONS[key])
+                            )
+                        if not button_down and TwentyTwentySix.button_states[key][0]:
+                            await eventbus.emit_async(
+                                ButtonUpEvent(button=BUTTONS[key])
+                            )
+                            TwentyTwentySix.button_states[key][1] = 0
+                        TwentyTwentySix.button_states[key][0] = button_down
+
                     for key in TwentyTwentySix.button_states.keys():
                         if TwentyTwentySix.button_states[key][0]:
-                            if TwentyTwentySix.button_states[key][1] > 4:
+                            if TwentyTwentySix.button_states[key][1] > (50 // tick_ms):
                                 await eventbus.emit_async(
                                     ButtonDownEvent(button=BUTTONS[key])
                                 )
+                                TwentyTwentySix.button_states[key][1] = 0
                             else:
                                 TwentyTwentySix.button_states[key][1] += 1
                     for key in TwentyTwentySix.joystick_states.keys():
                         if TwentyTwentySix.joystick_states[key][0]:
-                            if TwentyTwentySix.joystick_states[key][1] > 4:
+                            if TwentyTwentySix.joystick_states[key][1] > (
+                                50 // tick_ms
+                            ):
                                 await eventbus.emit_async(
                                     ButtonDownEvent(button=JOYSTICK[key])
                                 )
+                                TwentyTwentySix.joystick_states[key][1] = 0
                             else:
                                 TwentyTwentySix.joystick_states[key][1] += 1
 
-            await asyncio.sleep(0.15)
+            await asyncio.sleep(tick_ms / 1000)

--- a/modules/frontboards/twentysix.py
+++ b/modules/frontboards/twentysix.py
@@ -282,16 +282,15 @@ class TwentyTwentySix(FrontBoard):
                     frontboard2026.IRQ_FALLING,
                 )
 
-        self.run_count = 0
-        tick_ms = 10
+        self.run_time = 0
         while True:
-            if self.run_count == 0:
+            now = time.ticks_ms()
+            if time.ticks_diff(now, self.run_time) > 150:
                 frontboard2026.run()
-                self.run_count = 150 // tick_ms
-            self.run_count = self.run_count - 1
+                self.run_time = now
+
             booped = not machine.Pin(0, mode=machine.Pin.IN).value()
             if booped:
-                now = time.ticks_ms()
                 for i, gpio in enumerate(
                     map(lambda i: self.BUTTON_PINS[BUTTONS[i]], "ABCDEF")
                 ):
@@ -323,32 +322,40 @@ class TwentyTwentySix(FrontBoard):
                             await eventbus.emit_async(
                                 ButtonDownEvent(button=BUTTONS[key])
                             )
+                            TwentyTwentySix.button_states[key][1] = now
+                        elif button_down:
+                            if (
+                                time.ticks_diff(
+                                    now, TwentyTwentySix.button_states[key][1]
+                                )
+                                > 200
+                            ):
+                                await eventbus.emit_async(
+                                    ButtonDownEvent(button=BUTTONS[key])
+                                )
+                                TwentyTwentySix.button_states[key][1] = now
                         if not button_down and TwentyTwentySix.button_states[key][0]:
                             await eventbus.emit_async(
                                 ButtonUpEvent(button=BUTTONS[key])
                             )
-                            TwentyTwentySix.button_states[key][1] = 0
                         TwentyTwentySix.button_states[key][0] = button_down
 
-                    for key in TwentyTwentySix.button_states.keys():
-                        if TwentyTwentySix.button_states[key][0]:
-                            if TwentyTwentySix.button_states[key][1] > (50 // tick_ms):
-                                await eventbus.emit_async(
-                                    ButtonDownEvent(button=BUTTONS[key])
-                                )
-                                TwentyTwentySix.button_states[key][1] = 0
-                            else:
-                                TwentyTwentySix.button_states[key][1] += 1
                     for key in TwentyTwentySix.joystick_states.keys():
-                        if TwentyTwentySix.joystick_states[key][0]:
-                            if TwentyTwentySix.joystick_states[key][1] > (
-                                50 // tick_ms
+                        if (
+                            TwentyTwentySix.joystick_states[key][0]
+                            and not TwentyTwentySix.joystick_states[key][1]
+                        ):
+                            TwentyTwentySix.joystick_states[key][1] = now
+                        elif TwentyTwentySix.joystick_states[key][0]:
+                            if (
+                                time.ticks_diff(
+                                    now, TwentyTwentySix.joystick_states[key][1]
+                                )
+                                > 200
                             ):
                                 await eventbus.emit_async(
                                     ButtonDownEvent(button=JOYSTICK[key])
                                 )
-                                TwentyTwentySix.joystick_states[key][1] = 0
-                            else:
-                                TwentyTwentySix.joystick_states[key][1] += 1
+                                TwentyTwentySix.joystick_states[key][1] = now
 
-            await asyncio.sleep(tick_ms / 1000)
+            await asyncio.sleep(0.01)


### PR DESCRIPTION
# Description

reports on badge channel of buttons locking up on the 2024 frontboard. I tested the spaceagon buttons and I could make those lock up quite easily. This reverts the 2024 buttons to polled and moves the 2026 buttons to be polled.  