### PR TITLE
Provide a "terminate this app" API

### DIFF
--- a/modules/app.py
+++ b/modules/app.py
@@ -4,6 +4,9 @@ import time
 from system.eventbus import eventbus
 from system.scheduler.events import RequestForegroundPopEvent
 
+from system.scheduler.events import RequestStopAppEvent
+from system.patterndisplay.events import PatternEnable
+
 
 class App:
     def __init__(self):
@@ -51,3 +54,12 @@ class App:
 
     def minimise(self):
         eventbus.emit(RequestForegroundPopEvent(self))
+
+    def terminate(self, restore_pattern=True):
+        """Terminate the app with extreme prejudice."""
+        if restore_pattern:
+            print("Restoring pattern")
+            eventbus.emit(PatternEnable())
+
+        print(f"Terminating app {self.__class__.__qualname__}")
+        eventbus.emit(RequestStopAppEvent(self))

--- a/modules/app.py
+++ b/modules/app.py
@@ -55,7 +55,7 @@ class App:
     def minimise(self):
         eventbus.emit(RequestForegroundPopEvent(self))
 
-    def terminate(self, restore_pattern=True):
+    def terminate(self, restore_pattern=False):
         """Terminate the app with extreme prejudice."""
         if restore_pattern:
             print("Restoring pattern")


### PR DESCRIPTION
# Description

Actually remove the app from the scheduler rather than `minimise` it. I've been using this in some of my apps and it feels like it might be more generally useful.
 
Also, and this might just be me, but it's easy to forget to restore the LED pattern and return them in whatever state your app left them.

