### PR TITLE
New approach to launch an app in the sim

### DIFF
--- a/sim/README.md
+++ b/sim/README.md
@@ -37,6 +37,23 @@ cd sim
 pipenv run python run.py
 ```
 
+You can launch an app at startup by its name in the menu:
+
+```
+pipenv run python run.py --menu "Example app"
+```
+
+or by its module path
+
+```
+pipenv run python run.py example.ExampleApp
+```
+
+Testing local apps
+---
+
+You can copy or symlink an app intp the `sim/apps/` directory. See `sim/apps/example` for an example.
+
 Known Issues
 ---
 

--- a/sim/run.py
+++ b/sim/run.py
@@ -169,6 +169,17 @@ def replace_launcher(module_name: str, class_name: str):
     import system.launcher.app
     system.launcher.app.Launcher = app_class
 
+def replace_launcher_wrap(menu_item: str):
+    "Wrap the launcher a subclass that selects a given item on initialisation"
+    import system.scheduler # import first to prevent circular import
+    import system.launcher.app
+    class WrappedLauncher(system.launcher.app.Launcher):
+        init_menu_item = menu_item
+        def __init__(self):
+            super().__init__()
+            self.select_handler(self.init_menu_item, 0)
+
+    system.launcher.app.Launcher = WrappedLauncher
 
 def sim_main():
     parser = argparse.ArgumentParser()
@@ -183,6 +194,11 @@ def sim_main():
         nargs="?",
         help="App to start instead of the main launcher. "
         + "This is in the format 'module.class', for example 'example.ExampleApp'.",
+    )
+    parser.add_argument(
+        "--menu",
+        help="At startup select this menu item. "
+        + "For example to start an app: --menu 'ExampleApp'.",
     )
     args = parser.parse_args()
 
@@ -201,6 +217,9 @@ def sim_main():
         except Exception as ex:
             print(f"Error: {ex}")
             sys.exit(1)
+
+    if args.menu is not None:
+        replace_launcher_wrap(args.menu)
 
     import main
 


### PR DESCRIPTION
Launch by wrapping the Launcher with a subclass that selects a given item on startup.

Closes #402

# Description

The sim needs to do magical things to the import system in order to emulate running on the badge in micro python. The `override_app` options does more magic to launch an app by a its module path. This is all quite fragile and can break when import orders change elsewhere in the badge software (e.g. #278).

I think the approach of wrapping the Launcher class and calling `select_handler()` is more robust. If the sim can get as far as launching, then it should be able to launch any app that it had found.

I have not removed the old method, as maybe there are cases that it is useful. This change only touches `sim/run.py` and only does anything when the `--menu` option is used.

I have also added a bit of documentation.