### PR TITLE
Expose more Ctx methods to micropython

### DIFF
--- a/drivers/gc9a01/mp_uctx.c
+++ b/drivers/gc9a01/mp_uctx.c
@@ -582,6 +582,21 @@ static mp_obj_t mp_ctx_load_font_ctx(mp_obj_t self_in, mp_obj_t name_in, mp_obj_
 }
 MP_DEFINE_CONST_FUN_OBJ_3(mp_ctx_load_font_ctx_obj, mp_ctx_load_font_ctx);
 
+static mp_obj_t mp_ctx_textureclock(mp_obj_t self_in) {
+    mp_ctx_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    int clock = ctx_textureclock(self->ctx);
+    return mp_obj_new_int(clock);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(mp_ctx_textureclock_obj, mp_ctx_textureclock);
+
+static mp_obj_t mp_ctx_set_textureclock(mp_obj_t self_in, mp_obj_t clock_obj) {
+    mp_ctx_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    int clock = mp_obj_get_int(clock_obj);
+    ctx_set_textureclock(self->ctx, clock);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(mp_ctx_set_textureclock_obj, mp_ctx_set_textureclock);
+
 #if CTX_TINYVG
 static mp_obj_t mp_ctx_tinyvg_get_size(mp_obj_t self_in, mp_obj_t buffer_in) {
     mp_buffer_info_t buffer_info;
@@ -923,6 +938,8 @@ static const mp_rom_map_elem_t mp_ctx_locals_dict_table[] = {
     MP_CTX_METHOD(add_stop),
     MP_CTX_METHOD(line_dash),
     MP_CTX_METHOD(texture),
+    MP_CTX_METHOD(textureclock),
+    MP_CTX_METHOD(set_textureclock),
     MP_CTX_METHOD(image),
     MP_CTX_METHOD(start_frame),
     MP_CTX_METHOD(end_frame),

--- a/drivers/gc9a01/mp_uctx.c
+++ b/drivers/gc9a01/mp_uctx.c
@@ -260,6 +260,7 @@ MP_CTX_COMMON_FUN_0(start_group);
 MP_CTX_COMMON_FUN_0(end_group);
 #endif
 MP_CTX_COMMON_FUN_0(clip);
+MP_CTX_COMMON_FUN_0(identity);
 MP_CTX_COMMON_FUN_1F(rotate);
 MP_CTX_COMMON_FUN_2F(scale);
 MP_CTX_COMMON_FUN_2F(translate);
@@ -903,6 +904,7 @@ static const mp_rom_map_elem_t mp_ctx_locals_dict_table[] = {
     MP_CTX_METHOD(clip),
     MP_CTX_METHOD(text),
     MP_CTX_METHOD(text_width),
+    MP_CTX_METHOD(identity),
     MP_CTX_METHOD(rotate),
     MP_CTX_METHOD(scale),
     MP_CTX_METHOD(translate),


### PR DESCRIPTION
These changes expose the following methods:

* ctx.identity()
* ctx.textureclock()
* ctx.set_textureclock()

These methods are used by the display driver, and I need them for my Screen Hexpansion display driver. 