### PR TITLE
Setting to disable boop animation

### DIFF
--- a/modules/firmware_apps/settings_app.py
+++ b/modules/firmware_apps/settings_app.py
@@ -239,6 +239,28 @@ class SettingsApp(app.App):
                     )
                     self.layout.items.append(entry)
 
+                if id == "enable_boot_animation":
+
+                    async def _button_event_mirror_toggle(event):
+                        if BUTTON_TYPES["CONFIRM"] in event.button:
+                            enable_boot_animation = settings.get(
+                                "enable_boot_animation"
+                            )
+
+                            # default will evaluate to False here
+                            enable_boot_animation = not enable_boot_animation
+
+                            settings.set("enable_boot_animation", enable_boot_animation)
+                            await self.update_values()
+                            await render_update()
+                            return True
+                        return False
+
+                    entry = layout.ButtonDisplay(
+                        "Toggle", button_handler=_button_event_mirror_toggle
+                    )
+                    self.layout.items.append(entry)
+
                 if id == "backleds_emotes":
 
                     async def _button_event_backleds_emotes_toggle(event):
@@ -344,6 +366,7 @@ class SettingsApp(app.App):
             ("pattern_mirror_hexpansions", "Mirror pattern", on_off_formatter, None),
             ("backleds_emotes", "Flash emotes on backleds", on_off_formatter, None),
             ("background", "Background", tuple_formatter, None),
+            ("enable_boot_animation", "Enable Boot Animation", on_off_formatter, None),
             ("version", "Software version", version_formatter, self.dev_mode),
             ("update_channel", "Update channel", string_formatter, None),
             ("wifi_tx_power", "WiFi TX power", string_formatter, None),

--- a/modules/main.py
+++ b/modules/main.py
@@ -11,7 +11,7 @@ from system.espnow import espnow_service
 from system.launcher.app import Launcher
 from system.power.handler import PowerEventHandler
 from system.power.app import PowerManager
-from system.boopscreen.app import BoopSpinner
+from settings import get
 
 from frontboards.utils import detect_frontboard
 import frontboard2026
@@ -37,7 +37,10 @@ else:
 scheduler.start_app(HexpansionManagerApp())
 
 # Start the spinning-tilde boop animation
-scheduler.start_app(BoopSpinner(), always_on_top=True)
+if get("enable_boot_animation", default=True):
+    from system.boopscreen.app import BoopSpinner
+
+    scheduler.start_app(BoopSpinner(), always_on_top=True)
 
 # Start led pattern displayer app
 scheduler.start_app(PatternDisplay())


### PR DESCRIPTION
It boots a little faster when it's disabled, which makes frequent resetting of the device during development faster. I've added an entry inside SettingsApp to toggle this.