### PR TITLE
add missing chars  in text dialog

### DIFF
--- a/modules/app_components/dialog.py
+++ b/modules/app_components/dialog.py
@@ -22,7 +22,7 @@ SPECIAL_KEY_SPACE = "Space"
 
 LOWERCASE_ALPHABET = list("abcdefghijklmnopqrstuvwxyz")
 UPPERCASE_ALPHABET = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890")
-SYMBOL_ALPHABET = list("-=!\"£$%^&*()_+[];'#,./{}:@~<>?") + [SPECIAL_KEY_SPACE]
+SYMBOL_ALPHABET = list("""!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~£""") + [SPECIAL_KEY_SPACE]
 HEX_ALPHABET = list("0123456789ABCDEF")
 NUM_ALPHABET = list("0123456789.")
 


### PR DESCRIPTION
# Description

The TextDialog was missing 3 characters 
```
\ ` |
```
While \ was in the original list it was escaping the " in the string

Moving to triple quotes and adding these characters in resolves this, I used the same string as the keyboard driver but also added £ as thats not present on the keyboard.

Built and tested on my badge