### PR TITLE
keyboard enter done in TextDialog

### DIFF
--- a/modules/app_components/dialog.py
+++ b/modules/app_components/dialog.py
@@ -308,6 +308,9 @@ class TextDialog:
             elif kbd_button.name in SYMBOL_ALPHABET:
                 key = -2
                 final = kbd_button.name
+            elif KEYBOARD_BUTTONS["ENTER"] in event.button:
+                key = -2
+                final = SPECIAL_KEY_DONE
 
         # The following are generics not caught by either frontboard corner buttons
         # or keyboard events. They are, therefore, secondary confirm/cancel/etc buttons


### PR DESCRIPTION
There was no way to send a Done using the keyboard for a TextDialog input, you had to press the C button on the frontboard still. Escape works for Back/F

This uses the Enter key as a Done.