### PR TITLE
TextDisplay: add method to set the text

### DIFF
--- a/modules/app_components/layout.py
+++ b/modules/app_components/layout.py
@@ -28,6 +28,10 @@ class TextDisplay(Layoutable):
             rgb = tokens.ui_colors["label"]
         self.rgb = rgb
 
+    def set_text(self, text):
+        self.text = text
+        self.lines = None
+
     def draw(self, ctx, focused=False):
         ctx.save()
         ctx.font_size = self.font_size


### PR DESCRIPTION
# Description

Currently it is hard to modify the text in a `TextDisplay`. If `self.lines` is not None then changes to `self.text` are ignored. A user either has to modify `text` and `lines`, or create a whole new `TextDisplay`.

This PR adds a `set_text()` method.

If a property would be preferred, I can modify the PR.