### PR TITLE
I2c scan selective

### DIFF
--- a/modules/firmware_apps/hexpansionfw.py
+++ b/modules/firmware_apps/hexpansionfw.py
@@ -118,6 +118,15 @@ class HexpansionDetail:
             print("Resetting frontboard")
             print(f"Old header: {old_header}")
             i2c.writeto(87, bytes([0, 0, 0, 0, 0, 0, 0, 0]))
+            while True:
+                try:
+                    # Send an empty write to check if the device responds
+                    i2c.writeto(87, b"")
+                    break  # Chip responded with an ACK! It is ready for the next command.
+                except OSError:
+                    pass
+                finally:
+                    await asyncio.sleep_ms(1)
             frontboards.utils.detected_frontboard = None
             frontboard = frontboards.utils.detect_frontboard()
             print(f"Found frontboard {frontboard:04x}")

--- a/modules/frontboards/cy8cmbrx.py
+++ b/modules/frontboards/cy8cmbrx.py
@@ -158,7 +158,7 @@ cy8cmbr3116_config = [
 
 def cy8cmbr3116_init():
     top = I2C(0)
-    top.scan()
+    top.scan(0x37)
     device_crc = top.readfrom_mem(0x37, 0x7E, 2)
     # could look for a calibration file and alter the config to apply it
     config_crc = cy8cmbr_crc(cy8cmbr3116_config)

--- a/modules/frontboards/cy8cmbrx.py
+++ b/modules/frontboards/cy8cmbrx.py
@@ -158,7 +158,14 @@ cy8cmbr3116_config = [
 
 def cy8cmbr3116_init():
     top = I2C(0)
-    top.scan(0x37)
+    scan_count = 0
+    while True:
+        scan = top.scan(0x37)
+        if 0x37 in scan:
+            break
+        scan_count += 1
+        if scan_count > 100:
+            raise Exception("cy8cmbr3116 not detected")
     device_crc = top.readfrom_mem(0x37, 0x7E, 2)
     # could look for a calibration file and alter the config to apply it
     config_crc = cy8cmbr_crc(cy8cmbr3116_config)

--- a/modules/frontboards/utils.py
+++ b/modules/frontboards/utils.py
@@ -45,7 +45,7 @@ def detect_frontboard():
 
             if header is None:
                 print("detecting frontboard with i2c")
-                devices = i2c.scan()
+                devices = i2c.scan(range(0x57, 0x59))
                 if 0x58 in devices and 0x57 in devices:
                     header = HexpansionHeader(
                         manifest_version="2026",

--- a/modules/lib/eeprom_i2c.py
+++ b/modules/lib/eeprom_i2c.py
@@ -49,7 +49,9 @@ class EEPROM(EepromDevice):
 
     # Check for a valid hardware configuration
     def scan(self, verbose, chip_size, addr, max_chips_count):
-        devices = self._i2c.scan()  # All devices on I2C bus
+        devices = self._i2c.scan(
+            range(addr, addr + max_chips_count)
+        )  # All potential EEPROM devices on I2C bus
         eeproms = [
             d for d in devices if addr <= d < addr + max_chips_count
         ]  # EEPROM chips

--- a/modules/system/hexpansion/util.py
+++ b/modules/system/hexpansion/util.py
@@ -10,7 +10,7 @@ handle_insertion_lock = asyncio.Lock()
 
 
 def detect_eeprom_addr(i2c):
-    devices = i2c.scan()
+    devices = i2c.scan(range(0x50, 0x58))
     if 0x57 in devices and 0x50 not in devices:
         return (0x57, 2)
     if (
@@ -44,7 +44,7 @@ def read_hexpansion_header(
 
     @return: A HexpansionHeader object if successful, otherwise None.
     """
-    devices = i2c.scan()
+    devices = i2c.scan(eeprom_addr)
     if eeprom_addr not in devices:
         print(f"No device found at {hex(eeprom_addr)}")
         return None

--- a/patches/micropython-i2c-scan.diff
+++ b/patches/micropython-i2c-scan.diff
@@ -1,0 +1,88 @@
+diff --git a/docs/library/machine.I2C.rst b/docs/library/machine.I2C.rst
+index 635d58734..faab70045 100644
+--- a/docs/library/machine.I2C.rst
++++ b/docs/library/machine.I2C.rst
+@@ -103,11 +103,16 @@ General Methods
+ 
+    Availability: WiPy.
+ 
+-.. method:: I2C.scan()
++.. method:: I2C.scan(addresses=None, /)
+ 
+-   Scan all I2C addresses between 0x08 and 0x77 inclusive and return a list of
+-   those that respond.  A device responds if it pulls the SDA line low after
+-   its address (including a write bit) is sent on the bus.
++   Scan the I2C bus and return a list of the addresses that respond.  A device
++   responds if it pulls the SDA line low after its address (including a write
++   bit) is sent on the bus.
++
++   By default all addresses between 0x08 and 0x77 inclusive are scanned.  If
++   *addresses* is given it may be a single 7-bit address, or an iterable of
++   7-bit addresses (for example a `range` or list), and only those addresses are
++   probed, which is faster when only a subset is of interest.
+ 
+ Primitive I2C operations
+ ------------------------
+diff --git a/extmod/machine_i2c.c b/extmod/machine_i2c.c
+index bddf77529..0ec905423 100644
+--- a/extmod/machine_i2c.c
++++ b/extmod/machine_i2c.c
+@@ -319,23 +319,46 @@ static mp_obj_t machine_i2c_init(size_t n_args, const mp_obj_t *args, mp_map_t *
+ }
+ MP_DEFINE_CONST_FUN_OBJ_KW(machine_i2c_init_obj, 1, machine_i2c_init);
+ 
+-static mp_obj_t machine_i2c_scan(mp_obj_t self_in) {
+-    mp_obj_base_t *self = MP_OBJ_TO_PTR(self_in);
++static mp_obj_t machine_i2c_scan(size_t n_args, const mp_obj_t *args) {
++    mp_obj_base_t *self = MP_OBJ_TO_PTR(args[0]);
+     mp_obj_t list = mp_obj_new_list(0, NULL);
+-    // 7-bit addresses 0b0000xxx and 0b1111xxx are reserved
+-    for (int addr = 0x08; addr < 0x78; ++addr) {
+-        int ret = mp_machine_i2c_writeto(self, addr, NULL, 0, true);
+-        if (ret == 0) {
+-            mp_obj_list_append(list, MP_OBJ_NEW_SMALL_INT(addr));
++    if (n_args == 1) {
++        // 7-bit addresses 0b0000xxx and 0b1111xxx are reserved
++        for (int addr = 0x08; addr < 0x78; ++addr) {
++            int ret = mp_machine_i2c_writeto(self, addr, NULL, 0, true);
++            if (ret == 0) {
++                mp_obj_list_append(list, MP_OBJ_NEW_SMALL_INT(addr));
++            }
++            // This scan loop may run for some time, so process any pending events/exceptions,
++            // or allow the port to run any necessary background tasks.  But do it as fast as
++            // possible, in particular we are not waiting on any events.
++            mp_event_handle_nowait();
++        }
++    } else {
++        // Restrict the scan to a single integer address, or the addresses
++        // produced by the supplied iterable (e.g. a range or list).
++        if (mp_obj_is_int(args[1])) {
++            int ret = mp_machine_i2c_writeto(self, mp_obj_get_int(args[1]), NULL, 0, true);
++            if (ret == 0) {
++                mp_obj_list_append(list, args[1]);
++            }
++            mp_event_handle_nowait();
++        } else {
++            mp_obj_iter_buf_t iter_buf;
++            mp_obj_t iterable = mp_getiter(args[1], &iter_buf);
++            mp_obj_t item;
++            while ((item = mp_iternext(iterable)) != MP_OBJ_STOP_ITERATION) {
++                int ret = mp_machine_i2c_writeto(self, mp_obj_get_int(item), NULL, 0, true);
++                if (ret == 0) {
++                    mp_obj_list_append(list, item);
++                }
++                mp_event_handle_nowait();
++            }
+         }
+-        // This scan loop may run for some time, so process any pending events/exceptions,
+-        // or allow the port to run any necessary background tasks.  But do it as fast as
+-        // possible, in particular we are not waiting on any events.
+-        mp_event_handle_nowait();
+     }
+     return list;
+ }
+-MP_DEFINE_CONST_FUN_OBJ_1(machine_i2c_scan_obj, machine_i2c_scan);
++MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_i2c_scan_obj, 1, 2, machine_i2c_scan);
+ 
+ static mp_obj_t machine_i2c_start(mp_obj_t self_in) {
+     mp_obj_base_t *self = (mp_obj_base_t *)MP_OBJ_TO_PTR(self_in);

--- a/scripts/fb2026 config.py
+++ b/scripts/fb2026 config.py
@@ -105,7 +105,7 @@ CY8CMBRX_SCRATCHPAD0 = 0x00
 CY8CMBRX_SCRATCHPAD1 = 0x00
 
 # follow section 6 of https://www.infineon.com/assets/row/public/documents/30/42/infineon-an90071-cy8cmbr3xxx-capsenser-design-guide-applicationnotes-en.pdf
-# to configure this. 
+# to configure this.
 cy8cmbr3116_config = [
 CY8CMBRX_CS0_ENABLE | CY8CMBRX_CS1_ENABLE | CY8CMBRX_CS2_ENABLE | CY8CMBRX_CS3_ENABLE | CY8CMBRX_CS4_ENABLE | CY8CMBRX_CS5_ENABLE | CY8CMBRX_CS6_ENABLE | CY8CMBRX_CS7_ENABLE, #0x00 SENSOR_EN LSB
 CY8CMBRX_CS8_ENABLE | CY8CMBRX_CS9_ENABLE | CY8CMBRX_CS10_ENABLE | CY8CMBRX_CS11_ENABLE | CY8CMBRX_CS12_ENABLE | CY8CMBRX_CS13_ENABLE | CY8CMBRX_CS14_ENABLE, #0x01 SENSOR_EN MSB
@@ -239,7 +239,7 @@ CY8CMBRX_ATH_EN | CY8CMBRX_GUARD_EN, #0x4F DEVICE_CFG2
 
 def cy8cmbr3116_init():
     top = I2C(0)
-    top.scan()
+    top.scan(0x37)  # is this needed at all, we don't use the result - perhaps it wakes up the device?
     device_crc = top.readfrom_mem(0x37, 0x7E, 2)
     # could look for a calibration file and alter the config to apply it
     config_crc = cy8cmbr_crc(cy8cmbr3116_config)

--- a/scripts/firstTime.sh
+++ b/scripts/firstTime.sh
@@ -6,6 +6,7 @@ git reset --hard
 git apply ../patches/micropython.diff
 git apply ../patches/micropython_wasm.diff
 git apply ../patches/micropython-i2s-pdm.diff
+git apply ../patches/micropython-i2c-scan.diff
 popd
 pushd micropython/lib/micropython-lib
 git reset --hard

--- a/sim/fakes/machine.py
+++ b/sim/fakes/machine.py
@@ -34,7 +34,7 @@ class I2C:
     def __init__(self, *args, **kwargs):
         pass
 
-    def scan(self):
+    def scan(self, *args, **kwargs):
         return []
 
     def writeto(self, *args, **kwargs):


### PR DESCRIPTION
# Description

i2c.scan always scans all valid I2C device addresses which typically takes up to a second.  In all cases where this method is used within the badge code we are only interested in a few actual addresses.  This change introduces the ability to pass an argument to the scan method which specifies a single, list or range (i.e. any python iterable type) to filter which addresses are scanned. fully backwards compatible for any other use cases.

Updates to the badge code which uses i2c.scan() to only request scan of the addresses of interest. Scan uses a special probe I2C transaction which has no risk of side effects. (NB other techniques, like performing a read or write to a device address are risky as some devices can have their state altered by such transactions).

**There is a 2-3 second improvement in startup time of the badge.**

Had to introduce a change to reset_frontboard_handler() ("Autodetect" from the hexpansion app) to ensure that the write which blanks the frontboard header has completed before trying to read the header back as part of checking for a known frontboard - previously the i2c.scan() in detect_frontboard() took so long that it was almost guaranteed that the write would have finished.  